### PR TITLE
Update model 'StartTime' in SS_html

### DIFF
--- a/R/SS_html.R
+++ b/R/SS_html.R
@@ -246,7 +246,7 @@ SS_html <- function(replist=NULL,
         cat('<p><b>SS version:</b>\n',
             replist$SS_version,'</p>\n\n',
             '<p><b>Starting time of model:</b>\n',
-            substring(replist$Run_time,12),'</p>\n\n',
+            substring(replist$StartTime,12),'</p>\n\n',
             sep="", file=htmlfile, append=TRUE)
         if(!is.null(filenotes)){
           for(i in 1:length(filenotes)){


### PR DESCRIPTION
In relation to issue #49, @taylori made change to name of model `Run_time`, to `RunTime`, and replaced old `Run_time` with `StartTime`. `SS_html.R` still referred to `Run_time` so returned NULL and left the HTML 'Home' page empty. This simple fix updates the reference for 'Starting time of model:' to the new `replist$StartTime`.

Suggest also that issue #49 can now be closed. :)