### PR TITLE
Add a second plot of model data that shows the relative precision within a data type

### DIFF
--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -36,6 +36,8 @@
 #' @param verbose report progress to R GUI?
 #' @param datasize Add second data plot whose circles are proportional
 #' to either catch or relative uncertainty? Produced as data_plot2.png.
+#' @param maxsize The size of the largest bubble in the datasize
+#' plot. Default is 1/2.
 #' @author Ian Taylor, Chantel Wetzel
 #' @export
 #' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}},
@@ -50,6 +52,7 @@ SSplotData <- function(replist,
                        margins=c(5.1,2.1,2.1,8.1),
                        cex=2,lwd=12,
                        datasize=TRUE,
+                       maxsize=0.5,
                        verbose=TRUE)
 {
   pngfun <- function(file,caption=NA){
@@ -241,7 +244,7 @@ SSplotData <- function(replist,
               ## contained in size, NA's don't work for symbols so remove them
               x <- x[!is.na(y)]
               y <- y[!is.na(y)]
-              symbols(x=x, y=y, circles=size.cex*0.5,
+              symbols(x=x, y=y, circles=size.cex*maxsize,
                       bg=fleetcol[fleets==ifleet], add=TRUE, inches=FALSE)
           }
           axistable[itick,] <- c(ifleet,yval)

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -238,7 +238,9 @@ SSplotData <- function(replist,
               lines(x, y, lwd=lwd, col=fleetcol[fleets==ifleet])
           } else {
               ## make circle sizes propotional to the uncertainty,
-              ## contained in size
+              ## contained in size, NA's don't work for symbols so remove them
+              x <- x[!is.na(y)]
+              y <- y[!is.na(y)]
               symbols(x=x, y=y, circles=size.cex*0.5,
                       bg=fleetcol[fleets==ifleet], add=TRUE, inches=FALSE)
           }

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -35,7 +35,10 @@
 #' @param lwd Line width for lines showing ranges of years of data
 #' @param verbose report progress to R GUI?
 #' @param datasize Add second data plot whose circles are proportional
-#' to either catch or relative uncertainty? Produced as data_plot2.png.
+#' to either catch or relative uncertainty? Produced as
+#' data_plot2.png. Circle sizes are relative within a data category (e.g.,
+#' catches, indices) and are proportional to: absolute catch for catches,
+#' 1/SE of indices, and \code{N} for compositions.
 #' @param maxsize The size of the largest bubble in the datasize
 #' plot. Default is 1/2.
 #' @author Ian Taylor, Chantel Wetzel

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -1,10 +1,10 @@
 #' Timeline of presence/absence of data by type, year, and fleet.
-#' 
+#'
 #' Plot shows graphical display of what data is being used in the model.  Some
 #' data types may not yet be included. Note, this is based on output from the
 #' model, not the input data file.
-#' 
-#' 
+#'
+#'
 #' @param replist list created by \code{\link{SS_output}}
 #' @param plot plot to active plot device?
 #' @param print print to PNG files?
@@ -34,6 +34,8 @@
 #' @param cex Character expansion for points showing isolated years of data
 #' @param lwd Line width for lines showing ranges of years of data
 #' @param verbose report progress to R GUI?
+#' @param datasize Add second data plot whose circles are proportional
+#' to either catch or relative uncertainty? Produced as data_plot2.png.
 #' @author Ian Taylor, Chantel Wetzel
 #' @export
 #' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}},
@@ -47,6 +49,7 @@ SSplotData <- function(replist,
                        pwidth=6.5,pheight=5.0,punits="in",res=300,ptsize=10,cex.main=1,
                        margins=c(5.1,2.1,2.1,8.1),
                        cex=2,lwd=12,
+                       datasize=TRUE,
                        verbose=TRUE)
 {
   pngfun <- function(file,caption=NA){
@@ -65,7 +68,7 @@ SSplotData <- function(replist,
   nfishfleets   <- replist$nfishfleets
   if(fleetnames[1]=="default") fleetnames  <- replist$FleetNames
   if(plotdir=="default") plotdir <- replist$inputs$dir
-  
+
   # catch
   catch <- SSplotCatch(replist,plot=F,print=F,verbose=FALSE)
   catch <- catch$totobscatchmat
@@ -74,7 +77,7 @@ SSplotData <- function(replist,
 
   # index
   cpue          <- replist$cpue
-  
+
   # composition data
   lendbase      <- replist$lendbase
   sizedbase     <- replist$sizedbase
@@ -95,69 +98,83 @@ SSplotData <- function(replist,
   discard       <- replist$discard
 
   typetable <- matrix(c(
-      "catch",         "Catch",                                         #1  
-      "cpue",          "Abundance indices",                             #2 
-      "lendbase",      "Length compositions",                           #3 
-      "sizedbase",     "Size compositions",                             #4 
-      "agedbase",      "Age compositions",                              #5 
-      "condbase",      "Conditional age-at-length compositions",        #6 
-      "ghostagedbase", "Ghost age compositions",                        #7 
-      "ghostcondbase", "Ghost conditional age-at-length compositions",  #8 
-      "ghostlendbase", "Ghost length compositions",                     #9 
-      "ladbase",       "Mean length-at-age",                            #10 
+      "catch",         "Catch",                                         #1
+      "cpue",          "Abundance indices",                             #2
+      "lendbase",      "Length compositions",                           #3
+      "sizedbase",     "Size compositions",                             #4
+      "agedbase",      "Age compositions",                              #5
+      "condbase",      "Conditional age-at-length compositions",        #6
+      "ghostagedbase", "Ghost age compositions",                        #7
+      "ghostcondbase", "Ghost conditional age-at-length compositions",  #8
+      "ghostlendbase", "Ghost length compositions",                     #9
+      "ladbase",       "Mean length-at-age",                            #10
       "wadbase",       "Mean weight-at-age",                            #11
       "mnwgt",         "Mean body weight",                              #12
       "discard",       "Discards",                                      #13
-      "tagdbase1",     "Tagging data",                                  #14 
+      "tagdbase1",     "Tagging data",                                  #14
       "tagdbase2",     "Tagging data"),ncol=2,byrow=TRUE)               #15
   if(!ghost) typetable <- typetable[-grep("ghost",typetable[,1]),]
   typenames <- typetable[,1]
   typelabels <- typetable[,2]
-  
+
   # loop over types to make a database of years with comp data
   ntypes <- 0
-  # replace typetable object with empty table
+ # replace typetable object with empty table
   typetable <- NULL
-  # now loop over typenames looking for presence of this data type
+  ## now loop over typenames looking for presence of this data type
+  ### --- 11/2015 Cole added a "size" column to this data so that relative
+  ### uncertainties can be used for cex values in a new plot below.
   for(itype in 1:length(typenames)){
-    dat <- get(typenames[itype])
-    typename <- typenames[itype]
-    if(!is.null(dat) && !is.na(dat) && nrow(dat)>0){
-      ntypes <- ntypes+1
-      for(ifleet in 1:nfleets){
-        allyrs <- NULL
-        # identify years from different data types
-        if(typename=="catch" & ifleet<=nfishfleets){
-          allyrs <- dat$Yr[dat[,ifleet]>0]
-        }
-        if(typename %in% c("cpue")){
-          allyrs <- dat$Yr[dat$Use>0 & dat$FleetNum==ifleet]
-        }
-        if(typename %in% c("mnwgt","discard")){
-          allyrs <- dat$Yr[dat$FleetNum==ifleet]
-        }
-        if(length(grep("dbase",typename))>0){
-          allyrs <- dat$Yr[dat$Fleet==ifleet]
-        }
-        # expand table of years with data
-        if(!is.null(allyrs) & length(allyrs)>0){
-          yrs <- sort(unique(floor(allyrs)))
-          typetable <- rbind(typetable,
-                             data.frame(yr=yrs,fleet=ifleet,
-                                        itype=ntypes,typename=typename,
-                                        stringsAsFactors=FALSE))
-        }
+      dat <- get(typenames[itype])
+      typename <- typenames[itype]
+      if(!is.null(dat) && !is.na(dat) && nrow(dat)>0){
+          ntypes <- ntypes+1
+          for(ifleet in 1:nfleets){
+              allyrs <- NULL
+              size <- NULL
+              # identify years from different data types
+              if(typename=="catch" & ifleet<=nfishfleets){
+                  allyrs <- dat$Yr[dat[,ifleet]>0]
+                  size <- dat[dat[,ifleet]>0, fleetnames[ifleet]]
+              }
+              if(typename %in% c("cpue")){
+                  allyrs <- dat$Yr[dat$Use>0 & dat$FleetNum==ifleet]
+                  size <- 1/dat$SE[dat$Use>0 & dat$FleetNum==ifleet]
+              }
+              if(typename %in% c("mnwgt","discard")){
+                  allyrs <- dat$Yr[dat$FleetNum==ifleet]
+                  size <- rep(1, len=length(allyears))
+              }
+              if(length(grep("dbase",typename))>0){
+                  allyrs <- dat$Yr[dat$Fleet==ifleet]
+                  size <- dat$N[dat$Fleet==ifleet]
+              }
+              # expand table of years with data
+              if(!is.null(allyrs) & length(allyrs)>0){
+                  ## subset to unique values and be careful about keeping the
+                  ## order of size
+                  unique.index <- which(!duplicated(allyrs))
+                  yrs <- floor(allyrs[unique.index])
+                  size.sorted <- size[unique.index][order(yrs)]
+                  yrs.sorted <- yrs[order(yrs)]
+                  typetable <- rbind(typetable,
+                                     data.frame(yr=yrs.sorted,fleet=ifleet,
+                                                itype=ntypes,typename=typename,
+                                                size=size.sorted,
+                                                stringsAsFactors=FALSE))
+              }
+          }
       }
-    }
   }
   # typetable is full data frame of all fleets and data types
   # typetable2 has been subset according to requested choices
-  
+
   # subset by fleets and data types if requested
   if(fleets[1]=="all") fleets <- 1:nfleets
   if(datatypes[1]=="all") datatypes <- typenames
   typetable2 <- typetable[typetable$fleet %in% fleets &
-                          typetable$typename %in% datatypes,]
+                              typetable$typename %in% datatypes,]
+
   # define dimensions of plot
   ntypes <- max(typetable2$itype)
   fleets <- sort(unique(typetable2$fleet))
@@ -174,24 +191,33 @@ SSplotData <- function(replist,
   }
 
   # function containing plotting commands
-  plotdata <- function(){
+  plotdata <- function(datasize){
     par(mar=margins) # multi-panel plot
     xlim <- c(-1,1)+range(typetable2$yr,na.rm=TRUE)
     yval <- 0
     # count number of unique combinations of fleet and data type
     ymax <- sum(as.data.frame(table(typetable2$fleet,typetable2$itype))$Freq>0)
+    main.temp <- if(datasize) {
+        "Data by type and year, circle size relative within data type"
+    } else {
+        "Data by type and year"
+    }
     plot(0,xlim=xlim,ylim=c(0,ymax+2*ntypes+.5),axes=FALSE,xaxs='i',yaxs='i',
-         type="n",xlab="Year",ylab="",main="Data by type and year",cex.main=cex.main)
+         type="n",xlab="Year",ylab="",main=main.temp, cex.main=cex.main)
     xticks <- 5*round(xlim[1]:xlim[2]/5)
     abline(v=xticks,col='grey',lty=3)
     axistable <- data.frame(fleet=rep(NA,ymax),yval=NA)
     itick <- 1
     for(itype in rev(unique(typetable2$itype))){
+        ## Calculate relative size for each data type separately
+        typetable2$size[typetable2$itype==itype] <-
+            typetable2$size[typetable2$itype==itype]/max(typetable2$size[typetable2$itype==itype])
       typename <- unique(typetable2$typename[typetable2$itype==itype])
       #fleets <- sort(unique(typetable2$fleet[typetable2$itype==itype]))
       for(ifleet in rev(fleets)){
         yrs <- typetable2$yr[typetable2$fleet==ifleet & typetable2$itype==itype]
         if(length(yrs)>0){
+          size.cex <- typetable2$size[typetable2$fleet==ifleet & typetable2$itype==itype]
           yval <- yval+1
           x <- min(yrs):max(yrs)
           n <- length(x)
@@ -202,18 +228,24 @@ SSplotData <- function(replist,
           if(n==1) solo <- 1
           if(n==2 & yrs[2]!=yrs[1]+1) solo <- rep(TRUE,2)
           if(n>=3){
-            for(i in 2:(n-1)) if(is.na(y[i-1]) & is.na(y[i+1])) solo[i] <- TRUE
-            if(is.na(y[2])) solo[1] <- TRUE
-            if(is.na(y[n-1])) solo[n] <- TRUE
+              for(i in 2:(n-1)) if(is.na(y[i-1]) & is.na(y[i+1])) solo[i] <- TRUE
+              if(is.na(y[2])) solo[1] <- TRUE
+              if(is.na(y[n-1])) solo[n] <- TRUE
           }
-          # add points and lines
-          points(x[solo], y[solo], pch=16, cex=cex,col=fleetcol[fleets==ifleet])
-          lines(x, y, lwd=lwd, col=fleetcol[fleets==ifleet])
+          if(!datasize){
+              ## The original plot is to add points and lines
+              points(x[solo], y[solo], pch=16, cex=1, col=fleetcol[fleets==ifleet])
+              lines(x, y, lwd=lwd, col=fleetcol[fleets==ifleet])
+          } else {
+              ## make circle sizes propotional to the uncertainty,
+              ## contained in size
+              symbols(x=x, y=y, circles=size.cex*0.5,
+                      bg=fleetcol[fleets==ifleet], add=TRUE, inches=FALSE)
+          }
           axistable[itick,] <- c(ifleet,yval)
           itick <- itick+1
         }
       }
-      
       yval <- yval+2
       if(itype!=1) abline(h=yval+.3,col='grey',lty=3)
       text(mean(xlim),yval-.3,typelabels[typenames==typename],font=2)
@@ -223,18 +255,29 @@ SSplotData <- function(replist,
     box()
     axis(1,at=xticks)
   }
-
-  if(plot) plotdata()
+  ## Always make the original one
+  if(plot) plotdata(datasize=FALSE)
   if(print) {
     file <- file.path(plotdir,"data_plot.png")
     caption <- "Data presence by year for each fleet"
     plotinfo <- pngfun(file=file, caption=caption)
-    plotdata()
+    plotdata(datasize=FALSE)
     dev.off()
+  }
+  ## Make second data plot if desired
+  if(datasize){
+      if(plot) plotdata(datasize=TRUE)
+      if(print) {
+          file <- file.path(plotdir,"data_plot2.png")
+          caption <- "Data presence by year for each fleet"
+          plotinfo <- pngfun(file=file, caption=caption)
+          plotdata(datasize)
+          dev.off()
+      }
   }
 
   returnlist <- list(typetable2=typetable2)
-  
+
   if(!is.null(plotinfo)){
     plotinfo$category <- "Data"
     returnlist$plotinfo <- plotinfo

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -36,7 +36,7 @@
 #' @param verbose report progress to R GUI?
 #' @param datasize Add second data plot whose circles are proportional
 #' to either catch or relative uncertainty? Produced as
-#' data_plot2.png. Circle sizes are relative within a data category (e.g.,
+#' data_plot2.png. Circle areas are relative within a data category (e.g.,
 #' catches, indices) and are proportional to: absolute catch for catches,
 #' 1/SE of indices, and \code{N} for compositions.
 #' @param maxsize The size of the largest bubble in the datasize
@@ -204,7 +204,7 @@ SSplotData <- function(replist,
     # count number of unique combinations of fleet and data type
     ymax <- sum(as.data.frame(table(typetable2$fleet,typetable2$itype))$Freq>0)
     main.temp <- if(datasize) {
-        "Data by type and year, circle size relative within data type"
+        "Data by type and year, circle area is relative to precision within data type"
     } else {
         "Data by type and year"
     }
@@ -247,7 +247,7 @@ SSplotData <- function(replist,
               ## contained in size, NA's don't work for symbols so remove them
               x <- x[!is.na(y)]
               y <- y[!is.na(y)]
-              symbols(x=x, y=y, circles=size.cex*maxsize,
+              symbols(x=x, y=y, circles=sqrt(size.cex)*maxsize,
                       bg=fleetcol[fleets==ifleet], add=TRUE, inches=FALSE)
           }
           axistable[itick,] <- c(ifleet,yval)
@@ -277,7 +277,10 @@ SSplotData <- function(replist,
       if(plot) plotdata(datasize=TRUE)
       if(print) {
           file <- file.path(plotdir,"data_plot2.png")
-          caption <- "Data presence by year for each fleet"
+          caption <- paste(
+              "Data presence by year for each fleet, where circle area is relative <br> ",
+              "within a data type, and proportional to precision for indices and compositions, <br> ",
+              "and absolute catch for catches")
           plotinfo <- pngfun(file=file, caption=caption)
           plotdata(datasize)
           dev.off()

--- a/man/SSplotData.Rd
+++ b/man/SSplotData.Rd
@@ -8,7 +8,8 @@ SSplotData(replist, plot = TRUE, print = FALSE, plotdir = "default",
   fleetcol = "default", datatypes = "all", fleets = "all",
   fleetnames = "default", ghost = FALSE, pwidth = 6.5, pheight = 5,
   punits = "in", res = 300, ptsize = 10, cex.main = 1,
-  margins = c(5.1, 2.1, 2.1, 8.1), cex = 2, lwd = 12, verbose = TRUE)
+  margins = c(5.1, 2.1, 2.1, 8.1), cex = 2, lwd = 12, datasize = TRUE,
+  maxsize = 0.5, verbose = TRUE)
 }
 \arguments{
 \item{replist}{list created by \code{\link{SS_output}}}
@@ -56,6 +57,15 @@ be increased if fleet names run off right-hand margin}
 \item{cex}{Character expansion for points showing isolated years of data}
 
 \item{lwd}{Line width for lines showing ranges of years of data}
+
+\item{datasize}{Add second data plot whose circles are proportional
+to either catch or relative uncertainty? Produced as
+data_plot2.png. Circle sizes are relative within a data category (e.g.,
+catches, indices) and are proportional to: absolute catch for catches,
+1/SE of indices, and \code{N} for compositions.}
+
+\item{maxsize}{The size of the largest bubble in the datasize
+plot. Default is 1/2.}
 
 \item{verbose}{report progress to R GUI?}
 }

--- a/man/SSplotData.Rd
+++ b/man/SSplotData.Rd
@@ -60,7 +60,7 @@ be increased if fleet names run off right-hand margin}
 
 \item{datasize}{Add second data plot whose circles are proportional
 to either catch or relative uncertainty? Produced as
-data_plot2.png. Circle sizes are relative within a data category (e.g.,
+data_plot2.png. Circle areas are relative within a data category (e.g.,
 catches, indices) and are proportional to: absolute catch for catches,
 1/SE of indices, and \code{N} for compositions.}
 


### PR DESCRIPTION
I think this is ready to be implemented in master based on discussion in this commit: https://github.com/r4ss/r4ss/commit/2de27d95f2809392fdbb31794454832482cfe6a7#commitcomment-14227098

I've updated the branch to have circles be proportional to area instead of diameter and included a more informative HTML caption. Attached is a screen shot of the new plot in a browser.

@taylori If there's a set of models you use to test new functionality I could run this code by those. I've only tested this on two very similar models. 

![capture](https://cloud.githubusercontent.com/assets/4804974/11006810/bfea563c-847a-11e5-8103-9f4284277615.PNG)
