### PR TITLE
Use hidewarn for 3.24f tag output warning

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -522,7 +522,8 @@ SS_output <-
 
       # make correction to tag output associated with 3.24f (fixed in later versions)
       if(substr(SS_version,1,9)=="SS-V3.24f"){
-        cat('Correcting for bug in tag data output associated with SSv3.24f\n')
+        if(!hidewarn)
+          cat('Correcting for bug in tag data output associated with SSv3.24f\n')
         tag1rows <- compdbase$Pick_gender=="TAG1"
         if(any(tag1rows)){
           tag1 <- compdbase[tag1rows,]


### PR DESCRIPTION
This particular message could be hidden if hidewarn=TRUE. Probably some others too, but this one is hitting me right now.