### PR TITLE
Exclude PType column from MG_parms in SS_writectl output

### DIFF
--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -115,6 +115,7 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
     }
     if(!is.null(dataframe)){
       if(header){
+        dataframe$PType <- NULL
         names(dataframe)[1] <- paste("#_",names(dataframe)[1],sep="")
         writeLines(paste(names(dataframe),collapse="\t"),con=zz)
       }
@@ -213,10 +214,7 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
     "env/block/dev_adjust_method (1=standard; 2=logistic transform keeps in base parm bounds; 3=standard w/ no bound check)")
   writeComment(c("#","#_growth_parms"))
   #writeComment("#_LO HI INIT PRIOR PR_type SD PHASE env-var use_dev dev_minyr dev_maxyr dev_stddev Block Block_Fxn")
-  PType <- ctllist$MG_parms$PType
-  ctllist$MG_parms$PType <- NULL
   printdf("MG_parms")
-  ctllist$MG_parms$PType <- PType
 
   writeComment("#")
   writeComment("#_Cond 0  #custom_MG-env_setup (0/1)")

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -213,7 +213,10 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
     "env/block/dev_adjust_method (1=standard; 2=logistic transform keeps in base parm bounds; 3=standard w/ no bound check)")
   writeComment(c("#","#_growth_parms"))
   #writeComment("#_LO HI INIT PRIOR PR_type SD PHASE env-var use_dev dev_minyr dev_maxyr dev_stddev Block Block_Fxn")
+  PType <- ctllist$MG_parms$PType
+  ctllist$MG_parms$PType <- NULL
   printdf("MG_parms")
+  ctllist$MG_parms$PType <- PType
 
   writeComment("#")
   writeComment("#_Cond 0  #custom_MG-env_setup (0/1)")


### PR DESCRIPTION
The column is added to `MG_parms` during `SS_readctl` process, and should not
be written to control files. Otherwise the roundtrip of read-write
is impossible.

https://github.com/r4ss/r4ss/blob/871255ec83022df6594225a308c37c15d6da0c6d/R/SS_readctl_3.24.R#L481-L482