### PR TITLE
Fix duplication check in SS_readctl

### DIFF
--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -998,14 +998,12 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
     ctllist<-add_df(ctllist,name="lambdas",nrow=ctllist$N_lambdas,ncol=5,
                       col.names=c("like_comp","fleet/survey","phase","value","sizefreq_method"))
     # find and delete duplicates
-    chk<-paste0(ctllist$lambdas$like_comp,ctllist$lambdas$`fleet/survey`
-                ,ctllist$lambdas$phase,ctllist$lambdas$sizefreq_method,sep=" ")
-    chk1<-duplicated(chk)
+    chk1<-duplicated(ctllist$lambdas)
     if(any(chk1)) # there are duplicates
     {
       ctllist$lambdas<-ctllist$lambdas[!chk1,]
       ctllist$N_lambdas<-nrow(ctllist$lambdas)
-      ctllist$warnings<-paste0(ctllist$warnings,"Duplicate_lambdas",sep=",")
+      ctllist$warnings<-paste(ctllist$warnings,"Duplicate_lambdas",sep=",")
     }
 
     for(i in 1:ctllist$N_lambdas){

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1073,14 +1073,12 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
   
   if(ctllist$N_lambdas>0){
     # find and delete duplicates
-    chk<-paste0(ctllist$lambdas$like_comp,ctllist$lambdas$`fleet/survey`
-                ,ctllist$lambdas$phase,ctllist$lambdas$sizefreq_method,sep=" ")
-    chk1<-duplicated(chk)
+    chk1<-duplicated(ctllist$lambdas)
     if(any(chk1)) # there are duplicates
     {
       ctllist$lambdas<-ctllist$lambdas[!chk1,]
       ctllist$N_lambdas<-nrow(ctllist$lambdas)
-      ctllist$warnings<-paste0(ctllist$warnings,"Duplicate_lambdas",sep=",")
+      ctllist$warnings<-paste(ctllist$warnings,"Duplicate_lambdas",sep=",")
     }
 
     for(i in 1:ctllist$N_lambdas){


### PR DESCRIPTION
`paste0()` with `sep=` argument works in an unexpected way. E.g., `paste0('a', 'b', 'c', sep=',')` ends in `'abc '`, not `'a b c'`. Duplication in lambda table has been checked with the strings concatenated by paste0, and it can result in false positive. E.g., rows (1,20,1,1,0) and (12,0,1,1,0) get marked duplicated.