### PR TITLE
fix: allow for matrix of Flimitfractions in forecast

### DIFF
--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -96,6 +96,15 @@ SS_readforecast <-  function(file='forecast.ss', Nfleets, Nareas, nseas,
     mylist$BforconstantF <- allnums[i]; i <- i+1
     mylist$BfornoF <- allnums[i]; i <- i+1
     mylist$Flimitfraction <- allnums[i]; i <- i+1
+    if (mylist$Flimitfraction < 0) {
+      ii <- i
+      while (allnums[ii] != -999) ii <- ii + 1
+      mylist$Flimitfraction_m <- data.frame(matrix(allnums[i:(ii + 1)], 
+        ncol = 2, byrow = TRUE))
+      colnames(mylist$Flimitfraction_m) <- c("Year", "Fraction")
+      i <- ii + 2
+      remove(ii)
+    }
     mylist$N_forecast_loops <- allnums[i]; i <- i+1
     mylist$First_forecast_loop_with_stochastic_recruitment <- allnums[i]; i <- i+1
     mylist$Forecast_loop_control_3 <- allnums[i]; i <- i+1

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -93,6 +93,9 @@ SS_writeforecast <-  function(mylist, dir=NULL, file="forecast.ss",
     wl("BforconstantF")
     wl("BfornoF")
     wl("Flimitfraction")
+    if (mylist$Flimitfraction < 0) {
+      printdf("Flimitfraction_m")
+    }
     wl("N_forecast_loops")
 
     wl("First_forecast_loop_with_stochastic_recruitment")


### PR DESCRIPTION
If mylist$Flimitfraction is negative, a matrix of years and limits
will follow Flimitfraction. I use -999 to find the end of the matrix.
Then, many i values are skipped over so that the matrix values are not
wrongly put into other named values.

The write forecast function then puts writes these numbers back to the
file if Flimitfraction is negative.

I don't predict that the changes will have any conflicts with other
versions of SS.