### PR TITLE
Edit readctl

### DIFF
--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -29,11 +29,16 @@
 #'  explicitly available in control file
 #' @param Nsurveys number of survey fleets in the model. This information is also not
 #'  explicitly available in control file
-#' @param DatFile read datfile list for additional information for version 3.30
-#' and above
 #' @param N_tag_groups number of tag release groups in the model.
 #' This information is also not explicitly available in control file.
 #' @param N_CPUE_obs numbere of CPUE observations.
+#' @param use_datlist LOGICAL if TRUE, use datlist to derive parameters which can not be
+#'  determined from control file
+#' @param datlist list or character. if list : produced from SS_writedat
+#'  or character : file name of dat file.
+#' @param ptype include a column in the output indicating parameter type?
+#'  (Can be useful, but causes problems for SS_writectl.) Only possible to use
+#'  for 3.24 control files.
 #' @author Ian G. Taylor, Yukio Takeuchi, Neil L Klaer
 #' @export
 #' @seealso \code{\link{SS_readctl_3.24}}, \code{\link{SS_readdat}},
@@ -48,9 +53,11 @@ SS_readctl <- function(file, ctlversion="3.24", verbose=TRUE,echoall=FALSE,
                        Npopbins=NA,
                        Nfleet=2,
                        Nsurveys=2,
-                       DatFile=NA,
                        N_tag_groups=NA,
-                       N_CPUE_obs=NA){
+                       N_CPUE_obs=NA,
+                       use_datlist=FALSE,
+                       datlist=NULL,
+                       ptype=TRUE){
 
   # wrapper function to call old or new version of SS_readctl
 
@@ -91,8 +98,10 @@ SS_readctl <- function(file, ctlversion="3.24", verbose=TRUE,echoall=FALSE,
                                Nfleet       = Nfleet,
                                Nsurveys     = Nsurveys,
                                N_tag_groups = N_tag_groups,
-                               N_CPUE_obs   = N_CPUE_obs)
-
+                               N_CPUE_obs   = N_CPUE_obs,
+                               use_datlist  = use_datlist,
+                               datlist      = datlist,
+                               ptype        = ptype)
   }
 
   # call function for SS version 3.30
@@ -109,10 +118,10 @@ SS_readctl <- function(file, ctlversion="3.24", verbose=TRUE,echoall=FALSE,
                                Npopbins     = Npopbins,
                                Nfleet       = Nfleet,
                                Nsurveys     = Nsurveys,
-                               DatFile      = DatFile,
                                N_tag_groups = N_tag_groups,
-                               N_CPUE_obs   = N_CPUE_obs)
-
+                               N_CPUE_obs   = N_CPUE_obs,
+                               use_datlist  = use_datlist,
+                               datlist      = datlist)
   }
 
   # return the result

--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -7,7 +7,7 @@
 #'
 #'
 #' @param file Filename either with full path or relative to working directory.
-#' @param ctlversion SS version number. Currently only "3.24" or "3.30" are supported,
+#' @param version SS version number. Currently only "3.24" or "3.30" are supported,
 #' either as character or numeric values (noting that numeric 3.30  = 3.3).
 #' @param verbose Should there be verbose output while running the file?
 #' Default=TRUE.
@@ -44,7 +44,7 @@
 #' @seealso \code{\link{SS_readctl_3.24}}, \code{\link{SS_readdat}},
 #' \code{\link{SS_readdat_3.24}}
 
-SS_readctl <- function(file, ctlversion="3.24", verbose=TRUE,echoall=FALSE,
+SS_readctl <- function(file, version=NULL, verbose=TRUE,echoall=FALSE,
                        ## Parameters that are not defined in control file
                        nseas=4,
                        N_areas=1,
@@ -61,12 +61,29 @@ SS_readctl <- function(file, ctlversion="3.24", verbose=TRUE,echoall=FALSE,
 
   # wrapper function to call old or new version of SS_readctl
 
-  # automatic testing of version number could be added here in the future
-  # see SS_readdat for example attempt
+  # automatic testing of version number
+  if(is.null(version)) {
+    # look for 3.24 or 3.30 at the top of the chosen file
+    version <- scan(file, what=character(), nlines=1)
+    version <- substring(version,3,6)
+    # if that fails, look for data.ss_new file in the same directory
+    if(version %in% c("3.24", "3.30")){
+      cat("assuming version", version, "based on first line of control file\n")
+    }else{
+      newfile <- file.path(dirname(file), "control.ss_new")
+      if(file.exists(newfile)){
+        version <- scan(newfile, what=character(), nlines=1)
+        version <- substring(version,3,6)
+        cat("assuming version", version, "based on first line of control.ss_new\n")
+      }else{
+        stop("input 'version' required due to missing value at top of", file)
+      }
+    }
+  }
 
-  nver=as.numeric(substring(ctlversion,1,4))
+  nver=as.numeric(substring(version,1,4))
 
-  if(verbose) cat("Char version is ", ctlversion, "\n")
+  if(verbose) cat("Char version is ", version, "\n")
   if(verbose) cat("Numeric version is ", nver, "\n")
 
   # call function for SS version 2.00
@@ -87,7 +104,7 @@ SS_readctl <- function(file, ctlversion="3.24", verbose=TRUE,echoall=FALSE,
   if((nver>=3.2)&&(nver<3.3)){
 
     ctllist <- SS_readctl_3.24(file         = file,
-                               ctlversion   = ctlversion,
+                               version   = version,
                                verbose      = verbose,
                                echoall      = echoall,
                                nseas        = nseas,
@@ -108,7 +125,7 @@ SS_readctl <- function(file, ctlversion="3.24", verbose=TRUE,echoall=FALSE,
   if(nver>=3.3){
 
     ctllist <- SS_readctl_3.30(file         = file,
-                               ctlversion   = ctlversion,
+                               version   = version,
                                verbose      = verbose,
                                echoall      = echoall,
                                nseas        = nseas,

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -11,7 +11,7 @@
 #'  Default=TRUE.
 #' @param echoall Debugging tool (not fully implemented) of echoing blocks of
 #'  data as it is being read.
-#' @param ctlversion SS version number. Currently only "3.24" or "3.30" are supported,
+#' @param version SS version number. Currently only "3.24" or "3.30" are supported,
 #' either as character or numeric values (noting that numeric 3.30  = 3.3).
 #' @param nseas number of seasons in the model. This information is not
 #'  explicitly available in control file
@@ -50,7 +50,7 @@
 #' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
 #' \code{\link{SS_writestarter}},
 #' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
-SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
+SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
 ## Parameters that are not defined in control file
     nseas=4,
     N_areas=1,
@@ -72,7 +72,7 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
   if(verbose) cat("running SS_readctl_3.24\n")
   dat <- readLines(file,warn=FALSE)
 
-  nver=as.numeric(substring(ctlversion,1,4))
+  nver=as.numeric(substring(version,1,4))
   # parse all the numeric values into a long vector (allnums)
   temp <- strsplit(dat[2]," ")[[1]][1]
   if(!is.na(temp) && temp=="Start_time:") dat <- dat[-(1:2)]

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -181,7 +181,7 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
     ctllist$fleetnames<-fleetnames
   }else{
     if(is.character(datlist))datlist<-SS_readdat(file=datlist)
-    if(is.null(datlist))stop("datlist from SS_readdat is needed is use_datlist is TRUE")
+    if(is.null(datlist))stop("datlist from SS_readdat is needed if use_datlist is TRUE")
     ctllist$nseas<-nseas<-datlist$nseas
     ctllist$N_areas<-N_areas<-datlist$N_areas
     ctllist$Nages<-Nages<-datlist$Nages
@@ -213,7 +213,7 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
   if(ctllist$N_GP>1)stop("this function not yet written for models with multiple growth patterns")
   ctllist<-add_elem(ctllist,"N_platoon")
   if(ctllist$N_platoon>1){
-    stop("currently sub morphs are not supported yet")
+    stop("sub morphs are not supported yet")
 #    ctllist<-add_elem(ctllist,"N_platoon")
     ctllist<-add_elem(ctllist,"submorphdist")
   }else{
@@ -245,7 +245,6 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
   ctllist$recr_dist_method<-1 # compatibility with v 3.30
 
   if(ctllist$N_areas>1){
-    #stop("Multi areas are not yet implemented")
     ctllist<-add_elem(ctllist,"N_moveDef") #_N_movement_definitions goes here if N_areas > 1
     if(ctllist$N_moveDef>0)
     {
@@ -276,8 +275,7 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
     ctllist<-add_vec(ctllist,name="M_ageBreakPoints",length=ctllist$N_natM) # age(real) at M breakpoints
     N_natMparms<-ctllist$N_natM
   }else if(ctllist$natM_type==2){
-#    stop("natM_type =2 is not yet implemented in this script")
-    N_natMparms<-1 ## 2016-12-8
+    N_natMparms<-1
     comments<-if(ctllist$N_GP==1){
       "#_reference age for Lorenzen M; read 1P per morph"
     }else{
@@ -1049,7 +1047,6 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.24",
 # 9=init_equ_catch; 10=recrdev; 11=parm_prior; 12=parm_dev; 13=CrashPen; 14=Morphcomp; 15=Tag-comp; 16=Tag-negbin
   ctllist<-add_elem(ctllist,"more_stddev_reporting")  # (0/1) read specs for more stddev reporting
   if(ctllist$more_stddev_reporting!=0){
-  #  stop("Currently additional reporting of derived quantities is not implemented in this R code")
     ctllist<-add_vec(ctllist,name="stddev_reporting_specs",length=9)
     ## Selex bin
     if(ctllist$stddev_reporting_specs[4]>0){

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -266,8 +266,7 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,version="3.30",
   # recruitment timing and distribution
   ctllist<-add_elem(ctllist,"recr_dist_method")
   if(ctllist$recr_dist_method == "1") {
-    # may want to remove this check and implement the approach
-    stop("recr_dist_method 1 should not be used in 3.30. Please use 2, 3, or 4")
+    warning("recr_dist_method 1 should not be used in SS version 3.30. Please use 2, 3, or 4. \n")
   }
   ctllist<-add_elem(ctllist,"recr_global_area")
   
@@ -275,8 +274,8 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,version="3.30",
   recr_dist_read<-ctllist$recr_dist_read
   ctllist<-add_elem(ctllist,"recr_dist_inx") # recruitment interaction requested
   if(ctllist$recr_dist_inx>0){
-    # may want to remove this check and implement the approach
-    stop("Recr_dist_inx should not be used in 3.30, so please set = 0 to read")
+    #give warning but don't stop for now
+    warning("Recr_dist_inx should not be used in SS version 3.30. Please set to 0. \n")
   }
   ctllist<-add_df(ctllist,"recr_dist_pattern",nrow=recr_dist_read,ncol=4,
       col.names=c("GP","seas","area","age"))

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -10,7 +10,7 @@
 #' Default=TRUE.
 #' @param echoall Debugging tool (not fully implemented) of echoing blocks of
 #' data as it is being read.
-#' @param ctlversion SS version number. Currently only "3.24" or "3.30" are supported,
+#' @param version SS version number. Currently only "3.24" or "3.30" are supported,
 #' either as character or numeric values (noting that numeric 3.30  = 3.3).
 #' @param nseas number of seasons in the model. This information is not
 #'  explicitly available in control file
@@ -44,7 +44,7 @@
 #' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
 #' \code{\link{SS_writestarter}},
 #' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
-SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
+SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,version="3.30",
 ## Parameters that are not defined in control file
     nseas=4,
     N_areas=1,
@@ -65,7 +65,7 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
   if(verbose) cat("running SS_readctl_3.30\n")
   dat <- readLines(file,warn=FALSE)
 
-  nver=as.numeric(substring(ctlversion,1,4))
+  nver=as.numeric(substring(version,1,4))
   # parse all the numeric values into a long vector (allnums)
   temp <- strsplit(dat[2]," ")[[1]][1]
   if(!is.na(temp) && temp=="Start_time:") dat <- dat[-(1:2)]

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1085,11 +1085,14 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
                                                         "mult_by_lencomp_N",
                                                         "mult_by_agecomp_N",
                                                         "mult_by_size-at-age_N")))
-  if(nrow(ctllist$Variance_adjustment_list)>0)
-  {
-    for(j in 1:nrow(ctllist$Variance_adjustment_list))ctllist$Variance_adjustments[ctllist$Variance_adjustment_list[j,]$Factor,
-                                                                                   ctllist$Variance_adjustment_list[j,]$Fleet]<-ctllist$Variance_adjustment_list[j,]$Value
+  if(!is.null(ctllist$Variance_adjustment_list)) { #check if is null first
+    if(nrow(ctllist$Variance_adjustment_list) > 0) {
+    for(j in 1:nrow(ctllist$Variance_adjustment_list)){
+      ctllist$Variance_adjustments[ctllist$Variance_adjustment_list[j,]$Factor,ctllist$Variance_adjustment_list[j,]$Fleet]<-
+        ctllist$Variance_adjustment_list[j,]$Value
+    }
     ctllist$DoVar_adjust<-1
+    }
   }
   
   ctllist<-add_elem(ctllist,"maxlambdaphase") #_maxlambdaphase

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -27,7 +27,6 @@
 #'  explicitly available in control file
 #' @param Nsurveys number of survey fleets in the model. This information is also not
 #'  explicitly available in control file
-#' @param DatFile read datfile list for additonal information
 #' @param Do_AgeKey Flag to indicate if 7 additional ageing error parameters to be read
 #'  set 1 (but in fact any non zero numeric in R) or TRUE to enable to read them 0 or FALSE (default)
 #'  to disable them. This information is not explicitly available in control file, too.
@@ -54,7 +53,6 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
     Npopbins=NA,
     Nfleet=2,
     Nsurveys=2,
-    DatFile=NA,
     Do_AgeKey=FALSE,
     N_tag_groups=NA,
     N_CPUE_obs=c(0,0,9,12), # This information is needed if Q_type of 3 or 4 is used
@@ -385,14 +383,14 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
   ctllist<-add_elem(ctllist,"parameter_offset_approach")    #_parameter_offset_approach
   
   ## catch multipler parameters
-  if(any(DatFile$fleetinfo$need_catch_mult==1))
+  if(any(datlist$fleetinfo$need_catch_mult==1))
   {
     # need to read a parameter line per value = 1
     stop("Catch multipliers not yet implemented in this script")
   }
   
   ## age error parameters
-  if(any(DatFile$ageerror[,1]<0))
+  if(any(datlist$ageerror[,1]<0))
   {
     # need to read 7 full (14) parameter lines
     stop("Age error parameters not yet implemented in this script")
@@ -699,13 +697,13 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
   }
    
   #_initial_F_parms - get them for fleet/seasons with non-zero initial equilbrium catch 
-  if(any(DatFile$init_equil>0))
+  if(any(datlist$init_equil>0))
   {  
     comments_initF<-list()
     k<-0
     for(j in 1:Nfleet)
     {
-      if(DatFile$init_equil[j]>0)
+      if(datlist$init_equil[j]>0)
       {
         comments_initF<-c(comments_initF,paste0("InitF_",j,"_",fleetnames[j]))
         k<-k+1

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -212,7 +212,7 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
     ctllist$fleetnames<-fleetnames
   }else{
     if(is.character(datlist))datlist<-SS_readdat(file=datlist)
-    if(is.null(datlist))stop("datlist from SS_readdat is needed is use_datlist is TRUE")
+    if(is.null(datlist))stop("datlist from SS_readdat is needed if use_datlist is TRUE")
     ctllist$nseas<-nseas<-datlist$nseas
     ctllist$N_areas<-N_areas<-datlist$N_areas
     ctllist$Nages<-Nages<-datlist$Nages
@@ -247,7 +247,7 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
   if(ctllist$N_GP>1)stop("this function not yet written for models with multiple growth patterns")
   ctllist<-add_elem(ctllist,"N_platoon")
   if(ctllist$N_platoon>1){
-    stop("currently sub morphs are not supported yet")
+    stop("sub morphs are not supported yet")
 #    ctllist<-add_elem(ctllist,"N_platoon")
     ctllist<-add_elem(ctllist,"submorphdist")
   }else{
@@ -276,7 +276,6 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
       col.names=c("GP","seas","area","age"))
 
   if(ctllist$N_areas>1){
-    #stop("Multi areas are not yet implemented")
     ctllist<-add_elem(ctllist,"N_moveDef") #_N_movement_definitions goes here if N_areas > 1
     if(ctllist$N_moveDef>0)
     {
@@ -305,8 +304,7 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
     ctllist<-add_vec(ctllist,name="M_ageBreakPoints",length=ctllist$N_natM) # age(real) at M breakpoints
     N_natMparms<-ctllist$N_natM
   }else if(ctllist$natM_type==2){
-#    stop("natM_type =2 is not yet implemented in this script")
-    N_natMparms<-1 ## 2016-12-8
+    N_natMparms<-1
     comments<-if(ctllist$N_GP==1){
       "#_reference age for Lorenzen M; read 1P per morph"
     }else{
@@ -385,7 +383,6 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
     ctllist<-add_elem(ctllist,"Herm_MalesInSSB")  #_Hermaphroditism_males_in_SSB
   }
   ctllist<-add_elem(ctllist,"parameter_offset_approach")    #_parameter_offset_approach
-  # ctllist<-add_elem(ctllist,"env_block_dev_adjust_method")   #_env/block/dev_adjust_method XX what to do with this?
   
   ## catch multipler parameters
   if(any(DatFile$fleetinfo$need_catch_mult==1))
@@ -1122,7 +1119,6 @@ SS_readctl_3.30 <- function(file,verbose=TRUE,echoall=FALSE,ctlversion="3.30",
 # 9=init_equ_catch; 10=recrdev; 11=parm_prior; 12=parm_dev; 13=CrashPen; 14=Morphcomp; 15=Tag-comp; 16=Tag-negbin
   ctllist<-add_elem(ctllist,"more_stddev_reporting")  # (0/1) read specs for more stddev reporting
   if(ctllist$more_stddev_reporting!=0){
-  #  stop("Currently additional reporting of derived quantities is not implemented in this R code")
     ctllist<-add_vec(ctllist,name="stddev_reporting_specs",length=9)
     ## Selex bin
     if(ctllist$stddev_reporting_specs[4]>0){

--- a/man/SS_readctl.Rd
+++ b/man/SS_readctl.Rd
@@ -7,7 +7,8 @@
 SS_readctl(file, ctlversion = "3.24", verbose = TRUE,
   echoall = FALSE, nseas = 4, N_areas = 1, Nages = 20,
   Ngenders = 1, Npopbins = NA, Nfleet = 2, Nsurveys = 2,
-  DatFile = NA, N_tag_groups = NA, N_CPUE_obs = NA)
+  N_tag_groups = NA, N_CPUE_obs = NA, use_datlist = FALSE,
+  datlist = NULL, ptype = TRUE)
 }
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.}
@@ -44,13 +45,20 @@ explicitly available in control file}
 \item{Nsurveys}{number of survey fleets in the model. This information is also not
 explicitly available in control file}
 
-\item{DatFile}{read datfile list for additional information for version 3.30
-and above}
-
 \item{N_tag_groups}{number of tag release groups in the model.
 This information is also not explicitly available in control file.}
 
 \item{N_CPUE_obs}{numbere of CPUE observations.}
+
+\item{use_datlist}{LOGICAL if TRUE, use datlist to derive parameters which can not be
+determined from control file}
+
+\item{datlist}{list or character. if list : produced from SS_writedat
+or character : file name of dat file.}
+
+\item{ptype}{include a column in the output indicating parameter type?
+(Can be useful, but causes problems for SS_writectl.) Only possible to use
+for 3.24 control files.}
 }
 \description{
 Read Stock Synthesis control file into list object in R. This function is a

--- a/man/SS_readctl_3.30.Rd
+++ b/man/SS_readctl_3.30.Rd
@@ -7,8 +7,8 @@
 SS_readctl_3.30(file, verbose = TRUE, echoall = FALSE,
   ctlversion = "3.30", nseas = 4, N_areas = 1, Nages = 20,
   Ngenders = 1, Npopbins = NA, Nfleet = 2, Nsurveys = 2,
-  DatFile = NA, Do_AgeKey = FALSE, N_tag_groups = NA,
-  N_CPUE_obs = c(0, 0, 9, 12), use_datlist = FALSE, datlist = NULL)
+  Do_AgeKey = FALSE, N_tag_groups = NA, N_CPUE_obs = c(0, 0, 9, 12),
+  use_datlist = FALSE, datlist = NULL)
 }
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.}
@@ -43,8 +43,6 @@ explicitly available in control file}
 
 \item{Nsurveys}{number of survey fleets in the model. This information is also not
 explicitly available in control file}
-
-\item{DatFile}{read datfile list for additonal information}
 
 \item{Do_AgeKey}{Flag to indicate if 7 additional ageing error parameters to be read
 set 1 (but in fact any non zero numeric in R) or TRUE to enable to read them 0 or FALSE (default)


### PR DESCRIPTION
This change fixes issues with reading the number of recruitment distribution params read in  MGparms, which varies by method. Also adds warnings when using recruitment distribution method 1 or recruitment method interactions, which should not be used in 3.30 but were possible to use  in early versions of SS 3.30. Finally, it cleans up some inconsistencies among the functions in terms of how variables are named.

It includes a fix to allow the control file to be read when no variance adjustment was used, but this was taken care of by @lee-qi in commit c9feed80892a7d94cab2e8ca0489c38ad69d7049 that is now incorporated in master and development branches.

Note that I created this branch off an older version of development (last commit fae607a1c3c63a78b20714dce9e492b5b60e7f5f), which is why it can't be automatically merged. If it makes more sense to, I can cancel this pull request, rebase the latest r4ss development branch onto edit_readctl, and then extend a new request. 