### PR TITLE
Fix: Add bycatch only fleet to SS_read/write_3.30 funs

### DIFF
--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -196,14 +196,30 @@ SS_readdat_3.30 <-
   d$surveytiming <- as.numeric(d$fleetinfo$surveytiming)
   d$units_of_catch <- as.numeric(d$fleetinfo$units)
   d$areas <- as.numeric(d$fleetinfo$area)
-
   ## ## For backwards compatability add the fleetinfo1 data frame
   ## d$fleetinfo1 <- as.data.frame(do.call("rbind", list(d$fleetinfo$surveytiming,
   ##                                                     d$fleetinfo$areas)))
   ## d$fleetinfo1 <- cbind(d$fleetinfo1, c("#_surveytiming", "#_areas"))
   ## rownames(d$fleetinfo1) <- c("surveytiming", "areas")
   ## colnames(d$fleetinfo1) <- c(d$fleetinfo$fleetname, "input")
-
+  
+  ##############################################################################
+  ### Bycatch Data (only added for fleets with type = 2)
+  if(any(d$fleetinfo$type == 2)) {
+    nbycatch <- length(d$fleetinfo$type[d$fleetinfo$type == 2])
+    d$bycatch_fleet_info <- get.df(dat, ind, nbycatch)
+  
+    colnames(d$bycatch_fleet_info) <- c("fleetindex",
+                                        "includeinMSY",
+                                        "Fmult",
+                                        "F_or_first_year",
+                                        "F_or_last_year",
+                                        "unused"
+                                        )
+  # add a fleetname column, as in fleet info.
+    d$bycatch_fleet_info <-cbind(d$bycatch_fleet_info, 
+                                 d$fleetinfo[d$fleetinfo$type == 2, "fleetname", drop = FALSE])
+  }
   ###############################################################################
   ## Catch data
   d$catch <- get.df(dat, ind)

--- a/R/SS_writedat_3.30.R
+++ b/R/SS_writedat_3.30.R
@@ -195,9 +195,15 @@ SS_writedat_3.30 <- function(datlist,
   # write table of info on each fleet
   writeComment("#_fleetinfo")
   print.df(d$fleetinfo, terminate=FALSE)
-
+  
+  # write table of info on bycatch only fleets, if exists.
+  if(!is.null(d$bycatch_fleet_info)){
+    writeComment("#Bycatch_fleet_input")
+    print.df(subset(d$bycatch_fleet_info, select = -fleetname), terminate = FALSE)
+  }
   # write table of catch
   #year season  fleet catch catch_se
+  writeComment("#_Catch data")
   catch.out <- d$catch
   #catch.out <- merge(stats::reshape(d$catch, direction = "long",
   #  idvar = c("year", "seas"),


### PR DESCRIPTION
Bycatch only fleet info previously was being grouped in incorrectly as catch data in the SS_read/write_3.30 functions.This now allows it to be read and written in the correct format.

Testing done on a model with several bycatch only fleets as well as a model without.

Please feel free to change column or variable names if desired. I tried to use terms from ```data .ss_new``` 3.30.13 default comments when feasible.