### PR TITLE
Fix changepars

### DIFF
--- a/R/SS_changepars.R
+++ b/R/SS_changepars.R
@@ -112,7 +112,10 @@ function(
   fullctlfile <- file.path(dir, ctlfile)
   ctl <- readLines(fullctlfile)
 
-  # check for valid input
+# check for valid input
+  inargs <- list("newvals" = newvals, "newlos" = newlos, "newhis" = newhis, 
+    "newprior" = newprior, "newprsd" = newprsd, "newprtype" = newprtype, 
+    "estimate" = estimate, "newphs" = newphs)
   if(is.null(linenums) & !is.null(strings) & class(strings)=="character")
   {
     # get table of parameter lines
@@ -121,16 +124,25 @@ function(
     # list of all parameter labels
     allnames <- ctltable$Label
     # empty list of "good" labels to be added to
-    goodnames <- NULL
+    goodnames <- list()
     # if strings are provided, look for matching subset of labels
     if(!is.null(strings)){
       # loop over vector of strings to add to goodnames vector
       for(i in 1:length(strings)){
         # fixed matching on string
-        goodnames <- c(goodnames, allnames[grep(strings[i], allnames, fixed=TRUE)])
+        goodnames[[i]] <- allnames[grep(strings[i], allnames, fixed=TRUE)]
       }
       # remove duplicates and print some feedback
-      goodnames <- unique(goodnames)
+      if (any(duplicated(unlist(goodnames))) & 
+        (repeat.vals & any(sapply(inargs, length) > 1))) {
+        stop("Entries in 'strings' did not map to unique parameters and\n",
+          "it is unclear how to order the par names to match the order\n",
+          "of other arguments provided to SS_changepars.\n",
+          "E.g., strings = c('CV', 'Mal') each return 'CV_young_Mal_GP_1'\n",
+          "and should be changed to strings = c('young_Fem', 'old_Fem', 'Mal')\n",
+          "to get all CV and all Male parameters.")
+      }
+      goodnames <- unique(unlist(goodnames))
       if(verbose){
         cat("parameter names in control file matching input vector 'strings' (n=",
             length(goodnames),"):\n",sep="")

--- a/R/SS_changepars.R
+++ b/R/SS_changepars.R
@@ -179,57 +179,22 @@ function(
   oldprior <- oldprsd <- oldprtype <- newphase <- rep(NA, nvals)
   # check all inputs
   # check values and make repeat if requested
-  if (!is.null(newvals) & length(newvals)!=nvals){
-    if (repeat.vals){
-      newvals <- rep(newvals, nvals)
-    }else{
-      stop("'newvals' and either 'linenums' or 'strings' should have",
-           "the same number of elements")
+  for (ii in names(inargs)) {
+    tmp <- get(ii)
+    if (is.null(tmp)) next
+    if (is.data.frame(tmp) & ii!="estimate") tmp <- as.numeric(tmp)
+    if (length(tmp)!=nvals & repeat.vals) {
+      if (length(tmp) > 1) stop("SS_changepars doesn't yet accommodate ",
+        "repeat.vals=TRUE and of length(.) > 1")
+      assign(ii, rep(tmp, nvals))
     }
-  }
-  # check bounds
-  # lower and upper bounds don't yet have option for repeat.vals=TRUE
-  if (!is.null(newlos) & length(newlos) != nvals) {
-    stop("'newlos' and either 'linenums' or 'strings' should have",
-         "the same number of elements")
-  }
-  if (!is.null(newhis) & length(newhis) != nvals) {
-    stop("'newhis' and either 'linenums' or 'strings' should have",
-         "the same number of elements")
-  }
-  if (is.data.frame(newlos)){
-    newlos <- as.numeric(newlos)
-  }
-  if (is.data.frame(newhis)){
-    newhis <- as.numeric(newhis)
-  }
-  if (is.data.frame(newprior)){
-    newprior <- as.numeric(newprior)
-  }
-  if (is.data.frame(newprsd)){
-    newprsd <- as.numeric(newprsd)
-  }
-  if (is.data.frame(newprtype)){
-    newprtype <- as.numeric(newprtype)
-  }
-  if (!is.null(estimate)){
-    if (!(length(estimate) %in% c(1,nvals))){
-      stop("'estimate' should have 1 element or same number as 'newvals'")
+    if (length(get(ii))!=nvals) {
+      stop(paste0("'", ii, "'"), " and either 'linenums' or 'strings'",
+        " should have the same number of elements,\n",
+        "instead of ", length(get(ii)), " and ", length(linenums), ".\n",
+        "Note: a string can map to multiple parameters, here are your pars,\n",
+        paste(goodnames, collapse = "\n"))
     }
-    if (length(estimate)==1){
-      estimate <- rep(estimate, nvals)
-    }
-  }
-  if (!is.null(newphs)){
-    if (!(length(newphs) %in% c(1, nvals))){
-      stop("'newphs' should have 1 element or same number as 'newvals'")
-    }
-    if (length(newphs)==1){
-      newphs <- rep(newphs, nvals)
-    }
-  }
-  if (is.data.frame(newvals)){
-    newvals <- as.numeric(newvals)
   }
 
   navar <- c(NA, "NA", "NAN", "Nan")

--- a/R/SS_changepars.R
+++ b/R/SS_changepars.R
@@ -156,7 +156,7 @@ function(
   ctlsubset <- ctl[linenums]
   if(verbose){
     cat("line numbers in control file (n=",length(linenums),"):\n",sep="")
-    print(linenums)
+    cat(paste(linenums, collapse = ", "))
   }
   # define objects to store changes
   newctlsubset <- NULL
@@ -234,7 +234,7 @@ function(
     vecstrings <- strsplit(splitline[1],split="[[:blank:]]+")[[1]]
     vec <- as.numeric(vecstrings[vecstrings!=""])
     if(max(is.na(vec))==1){
-      stop("There's a problem with a non-numeric value in line",linenums[i])
+      stop("There's a problem with a non-numeric value in line ",linenums[i])
     }
     # store information on old value and replace with new value (unless NULL)
     oldvals[i] <- vec[3]

--- a/R/SS_parlines.R
+++ b/R/SS_parlines.R
@@ -53,13 +53,16 @@ SS_parlines <- function(ctlfile="control.ss_new", dir=NULL,
 
   # read control file
   if(!is.null(dir)) ctlfile <- file.path(dir,'control.ss_new')
-  ncols = 150 # !!this should by more dynamic--if it's too small, the function dies
-  ctl <- read.table(file=ctlfile,col.names=1:ncols,fill=TRUE,
-                    quote="",colClasses="character",comment.char="", blank.lines.skip=FALSE)
-
+    raw <- readLines(ctlfile)
+    ctl <- matrix(NA, nrow = 50000, ncol = 100)
+  while (nrow(ctl) > length(raw)) {
+    ctl <- read.table(file=ctlfile,col.names=1:(ncol(ctl) + 50),fill=TRUE,
+                      quote="",colClasses="character",comment.char="", blank.lines.skip=FALSE)
+  }
+  rm(raw)
   nrows <- nrow(ctl)
   #print(nrows)
-  ctl_num <- matrix(NA,nrows,ncols) # copy of ctl converted to numerical values or NA
+  ctl_num <- matrix(NA,nrows,ncol(ctl)) # copy of ctl converted to numerical values or NA
   num_cnt <- rep(NA,nrows)          # count of number of numerical values in each row
   num_cnt7 <- rep(NA,nrows)         # count of number of numerical values in first 7 values of each row
   num_cnt14 <- rep(NA,nrows)        # count of number of numerical values in first 14 values of each row

--- a/R/SS_parlines.R
+++ b/R/SS_parlines.R
@@ -60,6 +60,7 @@ SS_parlines <- function(ctlfile="control.ss_new", dir=NULL,
                       quote="",colClasses="character",comment.char="", blank.lines.skip=FALSE)
   }
   rm(raw)
+  ctl <- ctl[!grepl("blocks_per_pattern", ctl[, 8]), ]
   nrows <- nrow(ctl)
   #print(nrows)
   ctl_num <- matrix(NA,nrows,ncol(ctl)) # copy of ctl converted to numerical values or NA

--- a/R/SS_parlines.R
+++ b/R/SS_parlines.R
@@ -87,7 +87,7 @@ SS_parlines <- function(ctlfile="control.ss_new", dir=NULL,
                     "Label", "Label2")
     names(parlines7 ) <- namesvec7
   }
-  if(version=="3.30"){
+  if(version=="3.30"|version>=3.3){
     namesvec7 <- c("LO", "HI", "INIT", "PRIOR", "PR_SD", "PR_type", "PHASE",
                    "Label", "Label2")
     namesvec14 <- c("LO", "HI", "INIT", "PRIOR", "PR_SD", "PR_type", "PHASE",

--- a/tests/testthat/test_profile.R
+++ b/tests/testthat/test_profile.R
@@ -1,0 +1,52 @@
+###############################################################################
+### automated tests of r4ss package
+###############################################################################
+
+context("Profiling and changing parameter values")
+
+example_path <- system.file("extdata", package="r4ss")
+
+###############################################################################
+# global variables
+###############################################################################
+ctlfile <- file.path(example_path, "simple_3.30.13", "simple_control.ss")
+ss3file <- file.path(dirname(ctlfile), "ss.exe")
+pars <- SS_parlines(ctlfile = ctlfile)
+
+###############################################################################
+# test r4ss functions used by SS_profile
+###############################################################################
+test_that("blocks_per_pattern not in read pars",
+  expect_true(!"blocks_per_pattern" %in% pars[, "Label"]))
+
+test_that("Error when repeat isn't true and string matches > 1 par", 
+  expect_error(SS_changepars(dir = dirname(ctlfile), ctlfile = basename(ctlfile),
+  newctlfile = "control_change.ss",
+  strings = "NatM", newvals = 2, verbose = FALSE)))
+test_that("Error when repeat is true and strings aren't unique", 
+  expect_error(SS_changepars(dir = dirname(ctlfile), ctlfile = basename(ctlfile),
+  newctlfile = "control_change.ss", repeat.vals = TRUE,
+  strings = c("CV", "Mal"), newvals = c(2, 3), verbose = FALSE)))
+test_that("Error when repeat is false and string matches > 1 par", 
+  expect_error(SS_changepars(dir = dirname(ctlfile), ctlfile = basename(ctlfile),
+  newctlfile = "control_change.ss", repeat.vals = FALSE,
+  strings = c("CV", "Mal"), newvals = c(2, 3), verbose = FALSE)))
+test_that("Should change the lower bound and INIT of 10 pars", {
+  outs <- SS_changepars(dir = dirname(ctlfile), ctlfile = basename(ctlfile),
+    newctlfile = "control_change.ss", repeat.vals = FALSE,
+    strings = c("CV", "Mal"), newvals = rep(0.025, 10), 
+    newlos = rep(0, 10), verbose = FALSE)
+  expect_equal(NROW(outs), 10)
+  expect_equal(outs[, "newvals"], rep(0.025, 10))
+  expect_equal(outs[, "newlos"], rep(0.0, 10))
+  })
+test_that("Error when repeat is true and vals have length > 1", 
+  expect_error(SS_changepars(dir = dirname(ctlfile), ctlfile = basename(ctlfile),
+  newctlfile = "control_change.ss", repeat.vals = TRUE,
+  strings = c("NatM", "CV"), newvals = 2:3, verbose = FALSE)))
+unlink(file.path(dirname(ctlfile), "control_change.ss"))
+
+# writeLines("dummy", con = ss3file)
+# SS_profile(dir = dirname(ctlfile),
+#   masterctlfile = basename(ctlfile), 
+#   newctlfile = "test_ctl.ss", string = "NatM")


### PR DESCRIPTION
Development in SS_parlines and SS_changepars. I think they are all okay, given they pass the new tests that I made, but (3) could be thought about more and better developed to work with (4).
(1) SS_parlines object ncols was not large enough for sablefish model, now it dynamically creates a large enough matrix.
(2) SS_parlines interpreted blocks_per_pattern as a parameter
(3) SS_changepars would reorder parameter names if unique() removed duplicated names causing the newvals to be out of order with the names. My changes here could potentially be further developed, but at least they remove the error that I found. Unfortunately, they still don't work if you want to use repeat.vals = TRUE and give it a vector of the same length as strings but have each individual string match multiple parameter names. Something to think about, but right now a stop message stops this.
(4) SS_changepars repeats all input vectors if length of the vector is one and repeat.vals = TRUE