### PR TITLE
enable read/write_forecast with fleet_relative_F == 2

### DIFF
--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -100,8 +100,9 @@ SS_readforecast <-  function(file='forecast.ss', Nfleets, Nareas, nseas,
     mylist$Ydecl <- allnums[i]; i <- i+1
     mylist$Yinit <- allnums[i]; i <- i+1
     mylist$fleet_relative_F <- allnums[i]; i <- i+1
-    if(mylist$fleet_relative_F==2){
-      stop("SS_readforecast doesn't yet support option 2 for 'fleet relative F'")
+    if(mylist$fleet_relative_F==2){ ## START 35
+      mylist$vals_fleet_relative_f <- allnums[i:(i+Nfleets-1)]; i <- i+Nfleets
+      # stop("SS_readforecast doesn't yet support option 2 for 'fleet relative F'")
     }
     mylist$basis_for_fcast_catch_tuning <- allnums[i]; i <- i+1
     if(version==3.24){

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -102,7 +102,7 @@ SS_writeforecast <-  function(mylist, dir=NULL, file="forecast.ss",
     wl("Ydecl")
     wl("Yinit")
     wl("fleet_relative_F")
-    if(mylist$fleet_relative_F==2) stop("SS_readforecast doesn't yet support option 2 for 'fleet relative F'")
+   # if(mylist$fleet_relative_F==2) stop("SS_readforecast doesn't yet support option 2 for 'fleet relative F'")
 
     wl("basis_for_fcast_catch_tuning")
     if(mylist$SSversion==3.24){


### PR DESCRIPTION
I wrote a line into SS_readforecast which can deal with fleet_relative_F == 2 (retaining the correct order of mylist) and disabled the attendant stop() in SS_writeforecast . Worked reliably on my china rockfish iterations.