### PR TITLE
Fix years plotted in rec deviations and ymax in recruitment time series

### DIFF
--- a/R/SSplotRecdevs.R
+++ b/R/SSplotRecdevs.R
@@ -103,7 +103,7 @@ SSplotRecdevs <-
 
       Yr <- c(recdevEarly$Yr,recdev$Yr,recdevFore$Yr)
       if(forecastplot){
-        goodyrs <- rep(TRUE,length(Yr))[Yr >= minyr & Yr <= maxyr]
+        goodyrs <- ifelse(Yr >= minyr & Yr <= maxyr, TRUE,FALSE)
       }else{
         # TRUE/FALSE of in range or not
         goodyrs <- Yr <= endyr+1 & Yr >= minyr & Yr <= maxyr 

--- a/R/SSplotRecdevs.R
+++ b/R/SSplotRecdevs.R
@@ -120,10 +120,10 @@ SSplotRecdevs <-
                     rep(col1,nrow(recdev)),
                     rep(col2,nrow(recdevFore)))[goodyrs]
         ## alldevs$Parm_StDev[is.na(alldevs$Parm_StDev)] <- 0
-        val <- alldevs$Value[goodyrs]
-        Yr <- alldevs$Yr[goodyrs]
+        val <- alldevs$Value
+        Yr <- alldevs$Yr
         if(uncertainty){
-          std <- alldevs$Parm_StDev[goodyrs]
+          std <- alldevs$Parm_StDev
           recdev_hi <- val + 1.96*std
           recdev_lo <- val - 1.96*std
           ylim <- range(recdev_hi, recdev_lo, na.rm=TRUE)

--- a/R/SSplotTimeseries.R
+++ b/R/SSplotTimeseries.R
@@ -369,6 +369,7 @@ SSplotTimeseries <-
               "   ",max(stdtable$Yr),"is last year with uncertainty in Report file, but",max(ts$YrSeas),"is last year of time series.\n",
               "    Consider changing starter file input for 'max yr for sdreport outputs' to -2\n")
         }
+    stdtable <- stdtable[stdtable$Yr >= minyr & stdtable$Yr <= maxyr,]
       }
     }
 


### PR DESCRIPTION
2 observed problems
(1) using minyr in SSplotRecdevs was leading to the wrong years being plotted b/c it was subsetting the time series twice with goodyrs
(2) the ylim of SSplotTimeSeries(subplot = 11, minyr = x) was very large when I used the minyr argument, which was occurring because stdtable was not being truncated for the same years as the time series

I am pretty sure that I fixed (1), but the fix to (2) might not be the best. SSplotTimeSeries is more complicated and so I may have introduced problems for other things. I can easily revert this last commit and repush if you think that (2) should be fixed a different way and you just want to merge in the fixes for (1).