### PR TITLE
add codecov to travis - first attempt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 
 r_packages:
   - devtools
+  - covr
 
 notifications:
   email:
@@ -16,3 +17,7 @@ notifications:
     on_failure: change
 
 warnings_are_errors: false
+
+after_success:
+  - Rscript -e 'library(covr); codecov()'
+  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # r4ss: R code for Stock Synthesis
 [![Build Status](https://travis-ci.org/r4ss/r4ss.png?branch=master)](https://travis-ci.org/r4ss/r4ss) (master)
 [![Build Status](https://travis-ci.org/r4ss/r4ss.svg?branch=development)](https://travis-ci.org/r4ss/r4ss) (development)
+[![codecov](https://codecov.io/gh/r4ss/r4ss/branch/development/graph/badge.svg)](https://codecov.io/gh/r4ss/r4ss) (development)
 
 Stock Synthesis is a fisheries stock assessment model written in ADMB by Rick Methot. The Stock Synthesis software and many other associated materials are available on the NOAA Virtual Laboratory at [https://vlab.ncep.noaa.gov/web/stock-synthesis/home](https://vlab.ncep.noaa.gov/web/stock-synthesis/home). The r4ss package is a collection of R functions for interacting with Stock Synthesis. It is based on the original work of Ian Stewart begun around 2005 and released as an open source R package in 2009. The package has a long list of authors and has benefited from a large community of users making suggestions and reporting issues.
 


### PR DESCRIPTION
We need to see if this works on travis first. Then, @iantaylor-NOAA, if you make an account at https://codecov.io/gh to use with your github account, we should be able to add the badge to the repo.