### PR TITLE
update SS-readdat_3.30.R to find 999 EOF marker

### DIFF
--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -45,7 +45,7 @@ SS_readdat_3.30 <-
   }
 
   ###############################################################################
-  sec.end.inds <- grep("^999$", dat)
+  sec.end.inds <- grep("\\b999\\b", dat)
   Nsections <- length(sec.end.inds)
   if(!Nsections){
     stop("Error - There was no EOF marker (999) in the data file.")


### PR DESCRIPTION
It was looking for 999 without anything following it, but some users may have a comment after the 999. Using \\b finds the whole word. Tested with this code:

`tmp <- c("999 # End of data file","999","999#","xx","9999","99","999\t")`
`grep("^999$",tmp)`
`grep("\\b999\\b",tmp)`