### PR TITLE
Wtatage

### DIFF
--- a/R/SS_readwtatage.R
+++ b/R/SS_readwtatage.R
@@ -19,16 +19,12 @@ SS_readwtatage <- function(file = "wtatage.ss", verbose=TRUE) {
     if(verbose) message("Skipping weight-at-age file. File missing or empty:",file,"\n")
     return(NULL)
   }
-  # read top few lines to figure out how many to skip
-  wtatagelines <- readLines(file,n=20)
-  accuage <- strsplit(wtatagelines, "\\s")
-  accuage <- accuage[!lapply(accuage, "[[", 1) %in% c("#", " ")][[1]]
-  accuage <- accuage[!grepl("\\s", accuage)][1]
 
   # read full file
-  wtatage <- read.table(file,header=FALSE,comment.char="",
-                        skip=grep("Yr Seas ", wtatagelines, ignore.case=TRUE),
-                        stringsAsFactors=FALSE)
+  wtatagelines <- read.table(file,header=FALSE,comment.char="#", blank.lines.skip=TRUE,
+                        stringsAsFactors=FALSE, strip.white=TRUE, fill=TRUE)
+  accuage <- wtatagelines[1,1]
+  wtatage <- wtatagelines[-1,]
   # problems with header so simply manually replacing column names
   wtatage_names <- c("Yr", "Seas", "Sex", "Bio_Pattern", "BirthSeas", "Fleet",
                      0:accuage)
@@ -38,6 +34,6 @@ SS_readwtatage <- function(file = "wtatage.ss", verbose=TRUE) {
   }
   names(wtatage) <- wtatage_names
   # Remove terminator line
-  wtatage <- wtatage[wtatage$Yr > 0, ]
+  wtatage <- wtatage[wtatage$Yr > -9998, ]
   return(wtatage)
 }

--- a/tests/testthat/test-wtatage.R
+++ b/tests/testthat/test-wtatage.R
@@ -1,0 +1,39 @@
+context("Read in weight-at-age data file.")
+
+file.temp <- tempfile(pattern = "wtatage", fileext = ".ss")
+
+test_that("Test weight-at-age is read in.", {
+  sink(file = file.temp)
+  cat("# This is a temp file\n")
+  cat(" # With a space before the comment\n")
+  cat(" 34#Nages\n")
+  cat(rep(19, times = 35+6), "\n")
+  cat(-9999, rep(0, times = 34+6), "\n")
+  sink()
+    temp <- SS_readwtatage(file = file.temp)
+    expect_equal(NCOL(temp), 41, tolerance = 0.01,
+      label = "Number of columns in read weight-at-age")
+    expect_equal(colnames(temp)[NCOL(temp)], "34",
+      label = "Last column name")
+})
+
+test_that("Test comment column is created and blank lines are okay", {
+  sink(file = file.temp)
+  cat("# This is a temp file\n")
+  cat(" # With a space before the comment\n")
+  cat(" 34#Nages\n")
+  cat(rep(19, times = 35+6), "#comment", "\n\n")
+  cat(rep(19, times = 35+6), "#comment", "\n\n")
+  cat(-9999, rep(0, times = 34+7), "\n")
+  sink()
+    temp <- SS_readwtatage(file = file.temp)
+    expect_equal(NCOL(temp), 42, tolerance = 0.01,
+      label = "Number of columns in read weight-at-age")
+    expect_equal(colnames(temp)[NCOL(temp)], "comment",
+      label = "Last column name")
+    expect_equal(NROW(temp), 2,
+      label = "Number of rows of data")
+})
+
+unlink(file.temp, recursive = TRUE)
+rm(file.temp)

--- a/tests/testthat/test_simple.R
+++ b/tests/testthat/test_simple.R
@@ -125,18 +125,18 @@ test_that("SSsummarize and SSplotComparisons both work", {
 test_that("SS_readdat and SS_writedat both work for 3.24", {
   # read data file
   simple3.24_dat <- SS_readdat(file = file.path(example_path,"simple_3.24/simple.dat"),
-                               version="3.24")
+                               version="3.24", verbose = FALSE)
   # write data file
   SS_writedat(datlist = simple3.24_dat,
               outfile = file.path(example_path, "simple_3.24/testdat_3.24.ss"),
               version = "3.24",
-              faster = FALSE)
+              faster = FALSE, verbose = FALSE)
 
   # write data file with faster option
   SS_writedat(datlist = simple3.24_dat,
               outfile = file.path(example_path, "simple_3.24/fastdat_3.24.ss"),
               version = "3.24",
-              faster = TRUE)
+              faster = TRUE, verbose = FALSE)
 })
 
 ###############################################################################
@@ -146,16 +146,16 @@ test_that("SS_readdat and SS_writedat both work for 3.24", {
 test_that("SS_readdat and SS_writedat both work for 3.30.01", {
   # read data file
   simple3.30.01_dat <- SS_readdat(file = file.path(example_path,"simple_3.30.01/simple.dat"),
-                               version="3.30")
+                               version="3.30", verbose = FALSE)
   # write data file
   SS_writedat(datlist = simple3.30.01_dat,
               outfile = file.path(example_path, "simple_3.30.01/testdat_3.30.01.ss"),
-              faster = FALSE)
+              faster = FALSE, verbose = FALSE)
 
   # write data file with faster option
   SS_writedat(datlist = simple3.30.01_dat,
               outfile = file.path(example_path, "simple_3.30.01/fastdat_3.30.01.ss"),
-              faster = TRUE)
+              faster = TRUE, verbose = FALSE)
 })
 
 ###############################################################################
@@ -165,16 +165,16 @@ test_that("SS_readdat and SS_writedat both work for 3.30.01", {
 test_that("SS_readdat and SS_writedat both work for 3.30.12", {
   # read data file
   simple3.30.12_dat <- SS_readdat(file = file.path(example_path,"simple_3.30.12/simple_data.ss"),
-                               version="3.30")
+                               version="3.30", verbose = FALSE)
   # write data file
   SS_writedat(datlist = simple3.30.12_dat,
               outfile = file.path(example_path, "simple_3.30.12/testdat_3.30.12.ss"),
-              faster = FALSE)
+              faster = FALSE, verbose = FALSE)
 
   # write data file with faster option
   SS_writedat(datlist = simple3.30.12_dat,
               outfile = file.path(example_path, "simple_3.30.12/fastdat_3.30.12.ss"),
-              faster = TRUE)
+              faster = TRUE, verbose = FALSE)
 })
 
 
@@ -185,16 +185,16 @@ test_that("SS_readdat and SS_writedat both work for 3.30.12", {
 test_that("SS_readdat and SS_writedat both work for 3.30.13", {
   # read data file
   simple3.30.13_dat <- SS_readdat(file = file.path(example_path,"simple_3.30.13/simple_data.ss"),
-                               version="3.30")
+                               version="3.30", verbose = FALSE)
   # write data file
   SS_writedat(datlist = simple3.30.13_dat,
               outfile = file.path(example_path, "simple_3.30.13/testdat_3.30.13.ss"),
-              faster = FALSE)
+              faster = FALSE, verbose = FALSE)
 
   # write data file with faster option
   SS_writedat(datlist = simple3.30.13_dat,
               outfile = file.path(example_path, "simple_3.30.13/fastdat_3.30.13.ss"),
-              faster = TRUE)
+              faster = TRUE, verbose = FALSE)
 })
 
 
@@ -206,9 +206,10 @@ test_that("SS_readforecast and SS_writeforecast both work for 3.30.13", {
   # read forecast file
   simple3.30.13_forecast <-
     SS_readforecast(file = file.path(example_path,"simple_3.30.13/forecast.ss"),
-                    version="3.30")
+                    version="3.30", verbose = FALSE)
   # write forecast file
   SS_writeforecast(mylist = simple3.30.13_forecast,
                    dir = file.path(example_path, "simple_3.30.13"),
-                   file = "testforecast_3.30.13.ss")
+                   file = "testforecast_3.30.13.ss",
+                   overwrite = TRUE)
 })


### PR DESCRIPTION
Reading in weight-at-age file for hake led to SS_readwtatage failing because there are blank lines.
  * implemented verbose = FALSE for the simple tests (didn't have anything to do with this branch but the tests were leading to lots of screen output)
  * overwrite forecast file in test to TRUE (again doesn't have to do with this branch)
  * allow for blank lines and simplify code in SS_readwtatage
  * do not remove all negative years (though I am not sure if this breaks later code, such as that in SS_output) -- can you please confirm that I didn't do something dumb here
  * created a test for reading in the weight-at-age file b/c there wasn't one, though I had to create my own dummy file because none of the simple examples store a weight-at-age file.