### PR TITLE
Reduce verbose

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -221,7 +221,7 @@ SS_output <-
     if(!is.na(parfile)){
       corfile <- sub(".par",".cor",parfile,fixed=TRUE)
       if(!file.exists(corfile)){
-        cat("Some stats skipped because the .cor file not found:",corfile,"\n")
+        warning("Some stats skipped because the .cor file not found:",corfile,"\n")
         corfile <- NA
       }
     }

--- a/R/SS_tune_comps.R
+++ b/R/SS_tune_comps.R
@@ -17,6 +17,7 @@
 #' @param option Which type of tuning: 'none', 'Francis', or 'MI'
 #' @param digits Number of digits to round numbers to
 #' @param write Write suggested tunings to a file 'suggested_tunings.ss'
+#' @template verbose
 #'
 #' @return Returns a table that can be copied into the control file.
 #' If \code{write=TRUE} then will write the values to a file
@@ -29,7 +30,7 @@
 #' @references Francis, R.I.C.C. (2011). Data weighting in statistical
 #' fisheries stock assessment models. Can. J. Fish. Aquat. Sci. 68: 1124-1138.
 SS_tune_comps <- function(replist, fleets='all', option="Francis",
-                          digits=6, write=TRUE){
+                          digits=6, write=TRUE, verbose = TRUE){
   # check inputs
   if(!option %in% c("none", "Francis", "MI")){
     stop("Input 'option' should be 'none', 'Francis', or 'MI'")
@@ -62,7 +63,7 @@ SS_tune_comps <- function(replist, fleets='all', option="Francis",
   # loop over fleets and modify the values for length data
   for(type in c("len","age")){
     for(fleet in fleets){
-      cat("calculating",type,"tunings for fleet",fleet,"\n")
+      if(verbose) message("calculating ",type," tunings for fleet ",fleet,"\n")
       if(type=="len"){
         # table of info from SS
         tunetable <- replist$Length_comp_Eff_N_tuning_check
@@ -88,12 +89,14 @@ SS_tune_comps <- function(replist, fleets='all', option="Francis",
         Francis_lo <- NULL
         Francis_hi <- NULL
         Francis_output <- SSMethod.TA1.8(fit=replist, type=type,
-                                         fleet=fleet, plotit=FALSE)
+                                         fleet=fleet, plotit=FALSE, 
+                                         printit = verbose)
         if(has_conditional){
           # run separate function for conditional data
           # (replaces marginal multiplier if present)
           Francis_output <- SSMethod.Cond.TA1.8(fit=replist,
-                                                fleet=fleet, plotit=FALSE)          
+                                                fleet=fleet, plotit=FALSE, 
+                                                printit = verbose)          
         }
         Francis_mult <- Francis_output[1]
         Francis_lo <- Francis_output[2]
@@ -188,7 +191,7 @@ SS_tune_comps <- function(replist, fleets='all', option="Francis",
   # return the results
   if(write){
     file <- file.path(replist$inputs$dir, "suggested_tuning.ss")
-    cat("writing to file", file, "\n")
+    if(verbose) message("writing to file", file, "\n")
     write.table(tuning_table,
                 file=file, quote=FALSE, row.names=FALSE)
     # append generalized size comp table with different columns

--- a/man/SS_tune_comps.Rd
+++ b/man/SS_tune_comps.Rd
@@ -9,7 +9,8 @@ SS_tune_comps(
   fleets = "all",
   option = "Francis",
   digits = 6,
-  write = TRUE
+  write = TRUE,
+  verbose = TRUE
 )
 }
 \arguments{
@@ -22,6 +23,9 @@ SS_tune_comps(
 \item{digits}{Number of digits to round numbers to}
 
 \item{write}{Write suggested tunings to a file 'suggested_tunings.ss'}
+
+\item{verbose}{A logical value specifying if output should be printed
+to the screen. The default is \code{verbose = TRUE}.}
 }
 \value{
 Returns a table that can be copied into the control file.

--- a/man/SSexecutivesummary.Rd
+++ b/man/SSexecutivesummary.Rd
@@ -4,12 +4,22 @@
 \alias{SSexecutivesummary}
 \title{A function to create a executive summary tables from an SS Report.sso file}
 \usage{
-SSexecutivesummary(replist, plotfolder = "default", ci_value = 0.95,
-  es_only = FALSE, tables = c("a", "b", "c", "d", "e", "f", "g", "h",
-  "i", "catch", "timeseries", "numbers"), divide_by_2 = FALSE,
-  endyr = NULL, adopted_ofl = NULL, adopted_abc = NULL,
-  adopted_acl = NULL, forecast_ofl = NULL, forecast_abc = NULL,
-  verbose = TRUE)
+SSexecutivesummary(
+  replist,
+  plotfolder = "default",
+  ci_value = 0.95,
+  es_only = FALSE,
+  tables = c("a", "b", "c", "d", "e", "f", "g", "h", "i", "catch", "timeseries",
+    "numbers"),
+  divide_by_2 = FALSE,
+  endyr = NULL,
+  adopted_ofl = NULL,
+  adopted_abc = NULL,
+  adopted_acl = NULL,
+  forecast_ofl = NULL,
+  forecast_abc = NULL,
+  verbose = TRUE
+)
 }
 \arguments{
 \item{replist}{Object name that holds output from the SS_output function.}


### PR DESCRIPTION
Small changes to reduce verbosity in `SS_output` and `SS_tune_comps`, if the user desires. The motivation for this was using some functions in ss3sim and wanting to have the ability to reduce output to the console. The biggest change is adding an argument `verbose` to `SS_tune_comps` which has a default value of TRUE, I also ran `devtools::document()` .