### PR TITLE
fix indices plot in SSplotComparisons

### DIFF
--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -1283,7 +1283,7 @@ SSplotComparisons <-
     for(iline in 1:nlines){
       imodel <- models[iline]
       subset1 <- indices$imodel==imodel & !is.na(indices$Like)
-      subset2 <- indices$imodel==imodel
+      subset2 <- indices$imodel==imodel & indices$Yr <= endyrvec[iline]
       if(length(unique(indices$Fleet[subset2])) > 1){
         if(!is.null(indexfleets[imodel])){
           ifleet <- indexfleets[imodel]
@@ -1359,7 +1359,12 @@ SSplotComparisons <-
     meanQ <- rep(NA,nlines)
 
     if(!add){
-      plot(0, type = "n", xlim = range(yr), yaxs = yaxs, 
+      if(!is.null(endyrvec)) {
+        xlim <- c(min(yr), max(endyrvec))
+      }else {
+        xlim <- range(yr)
+      }
+      plot(0, type = "n", xlim = xlim, yaxs = yaxs,
            ylim = ylim, xlab = "Year", ylab = ylab, axes = FALSE)
     }
     if(!log & yaxs != "i"){
@@ -1415,7 +1420,8 @@ SSplotComparisons <-
     }
 
     if(!add){
-      axis(1, at=yr)
+      xticks <- pretty(xlim)
+      axis(1, at=xticks, labels=format(xticks))
       if(tickEndYr){
         axis(1, at=max(endyrvec))
       }


### PR DESCRIPTION
Problem = indices are not subset for endyr like other matrices. The hake assessment uses a group plot of five different comparisons (e.g., biomass, depletion, index) for bridging models and the different terminal year for the panels was driving Chris crazy. 
* truncate indices by endyrvec
* change the limit of the xaxis given the newly truncated
values or keep range if there is no endyrvec
* make the axes values pretty b/c lots overlap when you have
four digit year values with las = whatever makes the x axis parallel

One issue that I did not deal with because I am not sure how to, is the padding on the x axis. Other plots remove this padding automatically, but it makes it awkward with the index value because without the padding you cannot see the points at the min and max years very well. This pull request has the bare minimum of fixing of subsetting because I am not sure that fundamentally we want to remove the padding, i.e., `xaxs = "i"`.