### PR TITLE
fix: Consolidate code into version specific read/write files

### DIFF
--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -25,10 +25,12 @@
 #' also not explicitly available in control file and this information is only
 #' required if length based
 #'  maturity vector is directly supplied (Maturity option of 6), and not yet tested
-#' @param Nfleet number of fisheries in the model. This information is also not
-#'  explicitly available in control file
+#' @param Nfleets number of fishery + Survey fleets in the model. This 
+#'  information is also not explicitly available in control file 3.30 syntax
+#' @param Nfleet number of fishery fleets in the model. This information is also not
+#'  explicitly available in control file 3.24 syntax
 #' @param Nsurveys number of survey fleets in the model. This information is also not
-#'  explicitly available in control file
+#'  explicitly available in control file 3.24 syntax
 #' @param N_tag_groups number of tag release groups in the model.
 #' This information is also not explicitly available in control file.
 #' @param N_CPUE_obs number of CPUE observations.
@@ -59,6 +61,7 @@ SS_readctl <- function(file, version=NULL, verbose=TRUE,echoall=FALSE,
                        Nages=20,
                        Ngenders=1,
                        Npopbins=NA,
+                       Nfleets=4,
                        Nfleet=2,
                        Nsurveys=2,
                        N_tag_groups=NA,
@@ -114,6 +117,16 @@ SS_readctl <- function(file, version=NULL, verbose=TRUE,echoall=FALSE,
   # call function for SS version 3.24
   if((nver>=3.2)&&(nver<3.3)){
 
+    if(Nfleets!=4){
+      if(Nfleets!=(Nfleet+Nsurveys)){
+        if(Nfleet==2 & Nsurveys==2){
+          stop("SS v3.24 uses Nfleet and Nsurveys but you have input a value for Nfleets instead")
+        }else{
+          stop("SS v3.30 uses Nfleet and Nsurveys but you have input a value for Nfleets as well that doesn't match with your Nfleet and Nsurveys inputs")
+        }
+      }
+    }
+    
     ctllist <- SS_readctl_3.24(file         = file,
                                version   = version,
                                verbose      = verbose,
@@ -135,6 +148,16 @@ SS_readctl <- function(file, version=NULL, verbose=TRUE,echoall=FALSE,
   # call function for SS version 3.30
   if(nver>=3.3){
 
+    if(Nfleet!=2 | Nsurveys!=2){
+      if(Nfleets!=(Nfleet+Nsurveys)){
+        if(Nfleets==4){
+          stop("SS v3.30 uses Nfleets but you have input values for Nfleet and Nsurveys")
+        }else{
+          stop("SS v3.30 uses Nfleets but you have input values for Nfleet and Nsurveys as well that don't match with your Nfleets input")
+        }
+      }
+    }
+    
     ctllist <- SS_readctl_3.30(file         = file,
                                version   = version,
                                verbose      = verbose,
@@ -144,8 +167,7 @@ SS_readctl <- function(file, version=NULL, verbose=TRUE,echoall=FALSE,
                                Nages        = Nages,
                                Ngenders     = Ngenders,
                                Npopbins     = Npopbins,
-                               Nfleet       = Nfleet,
-                               Nsurveys     = Nsurveys,
+                               Nfleets      = Nfleets,
                                N_tag_groups = N_tag_groups,
                                N_CPUE_obs   = N_CPUE_obs,
                                catch_mult_fleets = catch_mult_fleets,

--- a/R/SS_readdat.R
+++ b/R/SS_readdat.R
@@ -59,152 +59,23 @@ SS_readdat <- function(file, version=NULL, verbose=TRUE,echoall=FALSE,section=NU
   if(nver<3){
     datlist <- SS_readdat_2.00(file=file, verbose=verbose,
                                echoall=echoall, section=section)
-    # get fleet info
-    finfo<-rbind(datlist$fleetinfo,c(rep(1,datlist$Nfleet),rep(3,datlist$Nsurveys)))
-    finfo<-rbind(finfo,c(datlist$units_of_catch,rep(0,datlist$Nsurveys)))
-    rownames(finfo)[3]<-"type"
-    rownames(finfo)[4]<-"units"
-    finfo<-finfo[,1:(length(finfo)-1)]
-    finfo<-as.data.frame(t(finfo))
-    datlist$fleetinfo<-finfo
-    ##!!! need to add fixes to pop len bins? (see 3.24)
   }
 
   # call function for SS version 3.00 ----
   if((nver>=3)&&(nver<3.2)){
     datlist <- SS_readdat_3.00(file=file, verbose=verbose,
                                echoall=echoall, section=section)
-    # get fleet info
-    finfo<-rbind(datlist$fleetinfo1,c(rep(1,datlist$Nfleet),rep(3,datlist$Nsurveys)))
-    finfo<-rbind(finfo,c(datlist$units_of_catch,rep(0,datlist$Nsurveys)))
-    rownames(finfo)[3]<-"type"
-    rownames(finfo)[4]<-"units"
-    finfo<-finfo[,1:(length(finfo)-1)]
-    finfo<-as.data.frame(t(finfo))
-    datlist$fleetinfo<-finfo
-    ##!!! need to add fixes to pop len bins? (see 3.24)
   }
   
   # call function for SS version 3.24 ----
   if((nver>=3.2)&&(nver<3.3)){
     datlist <- SS_readdat_3.24(file=file, verbose=verbose,
                                echoall=echoall, section=section)
-    # get fleet info
-    finfo<-rbind(datlist$fleetinfo1,c(rep(1,datlist$Nfleet),rep(3,datlist$Nsurveys)))
-    finfo<-rbind(finfo,c(datlist$units_of_catch,rep(0,datlist$Nsurveys)))
-    rownames(finfo)[3]<-"type"
-    rownames(finfo)[4]<-"units"
-    finfo<-finfo[,1:(length(finfo)-1)]
-    finfo<-as.data.frame(t(finfo))
-    datlist$fleetinfo<-finfo
-    datlist$NCPUEObs<-array(data=0,dim=datlist$Nfleet+datlist$Nsurveys)
-    for(j in 1:nrow(datlist$CPUE))
-    {
-      if(datlist$CPUE[j,]$index>0)datlist$NCPUEObs[datlist$CPUE[j,]$index]<-datlist$NCPUEObs[datlist$CPUE[j,]$index]+1
-    }
-    # fix some things
-    if(!is.null(datlist$lbin_method))
-    {
-      if(datlist$lbin_method==1) # same as data bins
-      {
-        datlist$N_lbinspop<-datlist$N_lbins
-        datlist$lbin_vector_pop<-datlist$lbin_vector
-      }
-      if(datlist$lbin_method==2) # defined wid, min, max
-      {
-        if(!is.null(datlist$binwidth)&&!is.null(datlist$minimum_size)&&!is.null(datlist$maximum_size))
-        {
-          datlist$N_lbinspop<-(datlist$maximum_size-datlist$minimum_size)/datlist$binwidth+1
-          datlist$lbin_vector_pop<-vector()
-          for(j in 0:datlist$N_lbinspop)
-          {
-            datlist$lbin_vector_pop<-c(datlist$lbin_vector_pop,datlist$minimum_size+(j*datlist$binwidth))
-          }
-        }
-      }
-      if(datlist$lbin_method==3) # vector
-      {
-        if(!is.null(datlist$lbin_vector_pop))
-        {
-          datlist$N_lbinspop<-length(datlist$lbin_vector_pop)
-        }
-      }
-    }
   }
   # call function for SS version 3.30 ----
   if(nver>=3.3){
     datlist <- SS_readdat_3.30(file=file, verbose=verbose,
                                echoall=echoall, section=section)
-    datlist$spawn_seas <- datlist$spawn_month
-    # compatibility: get the old number values
-    datlist$Nfleet <- nrow(subset(datlist$fleetinfo,datlist$fleetinfo$type<=2))
-    datlist$Nsurveys <- datlist$Nfleets-datlist$Nfleet
-    totfleets<-datlist$Nfleet+datlist$Nsurveys
-    datlist$N_areas <- datlist$Nareas
-    datlist$Ngenders <- datlist$Nsexes
-    # Note that using NROW on datlist$CPUE that is NA will return 1, when in 
-    # reality the number of years should be 0.
-    datlist$N_cpue <- ifelse(is.null(datlist[["CPUE"]]) || 
-                             (is.null(dim(datlist[["CPUE"]])) && is.na(datlist[["CPUE"]])), 
-                             0,
-                             NROW(datlist[["CPUE"]]))
-    # fleet details
-    datlist$fleetinfo1<-t(datlist$fleetinfo)
-    colnames(datlist$fleetinfo1)<-datlist$fleetinfo$fleetname
-    datlist$fleetinfo1<-datlist$fleetinfo1[1:5,]
-    datlist$fleetinfo2<-datlist$fleetinfo1[4:5,]
-    datlist$fleetinfo1<-datlist$fleetinfo1[c(2:3,1),]
-    rownames(datlist$fleetinfo1)<-c("surveytiming","areas","type")
-    datlist$fleetinfo1<-data.frame(datlist$fleetinfo1)  # convert all to numeric
-    datlist$fleetinfo2<-data.frame(datlist$fleetinfo2)  # convert all to numeric
-    if(!is.null(datlist$discard_fleet_info))colnames(datlist$discard_fleet_info)<-c("Fleet","units","errtype")
-    # compatibility: create the old format catch matrix
-    datlist$catch <- datlist$catch[datlist$catch[, 1] >= -999, ]
-    colnames(datlist$catch) = c("year", "seas", "fleet", "catch", "catch_se")
-    # mean body weight
-    if(datlist$use_meanbodywt==0)
-    {
-      datlist$N_meanbodywt<-0
-    }
-    # length info
-    datlist$comp_tail_compression<-datlist$len_info$mintailcomp
-    datlist$add_to_comp<-datlist$len_info$addtocomp
-    datlist$max_combined_lbin<-datlist$len_info$combine_M_F
-    if(is.null(datlist$lencomp))datlist$N_lencomp<-0
-    if(datlist$use_MeanSize_at_Age_obs==0)
-    {
-      datlist$N_MeanSize_at_Age_obs<-0
-    }
-    ##!!! need to add fixes to pop len bins? (see 3.24)
-    # fix some things
-    if(!is.null(datlist$lbin_method))
-    {
-      if(datlist$lbin_method==1) # same as data bins
-      {
-        datlist$N_lbinspop<-datlist$N_lbins
-        datlist$lbin_vector_pop<-datlist$lbin_vector
-      }
-
-      if(datlist$lbin_method==2) # defined wid, min, max
-      {
-        if(!is.null(datlist$binwidth)&&!is.null(datlist$minimum_size)&&!is.null(datlist$maximum_size))
-        {
-          datlist$N_lbinspop<-(datlist$maximum_size-datlist$minimum_size)/datlist$binwidth+1
-          datlist$lbin_vector_pop<-vector()
-          for(j in 0:datlist$N_lbinspop)
-          {
-            datlist$lbin_vector_pop<-c(datlist$lbin_vector_pop,datlist$minimum_size+(j*datlist$binwidth))
-          }
-        }
-      }
-      if(datlist$lbin_method==3) # vector
-      {
-        if(!is.null(datlist$lbin_vector_pop))
-        {
-          datlist$N_lbinspop<-length(datlist$lbin_vector_pop)
-        }
-      }
-    }
   }
   # return the result
   return(datlist)

--- a/R/SS_readdat_2.00.R
+++ b/R/SS_readdat_2.00.R
@@ -367,6 +367,17 @@ SS_readdat_2.00 <- function(file,verbose=TRUE,echoall=FALSE,section=NULL){
     datlist$eof <- FALSE
   }
 
+  # fixes pulled from the read data wrapper function
+  # get fleet info
+  finfo<-rbind(datlist$fleetinfo,c(rep(1,datlist$Nfleet),rep(3,datlist$Nsurveys)))
+  finfo<-rbind(finfo,c(datlist$units_of_catch,rep(0,datlist$Nsurveys)))
+  rownames(finfo)[3]<-"type"
+  rownames(finfo)[4]<-"units"
+  finfo<-finfo[,1:(length(finfo)-1)]
+  finfo<-as.data.frame(t(finfo))
+  datlist$fleetinfo<-finfo
+  ##!!! need to add fixes to pop len bins? (see 3.24)
+  
   # return the result
   return(datlist)
 }

--- a/R/SS_readdat_3.00.R
+++ b/R/SS_readdat_3.00.R
@@ -489,6 +489,17 @@ SS_readdat_3.00 <- function(file,verbose=TRUE,echoall=FALSE,section=NULL){
     datlist$eof <- FALSE
   }
   
+  # Fixes pulled from the read data wrapper function
+  # get fleet info
+  finfo<-rbind(datlist$fleetinfo1,c(rep(1,datlist$Nfleet),rep(3,datlist$Nsurveys)))
+  finfo<-rbind(finfo,c(datlist$units_of_catch,rep(0,datlist$Nsurveys)))
+  rownames(finfo)[3]<-"type"
+  rownames(finfo)[4]<-"units"
+  finfo<-finfo[,1:(length(finfo)-1)]
+  finfo<-as.data.frame(t(finfo))
+  datlist$fleetinfo<-finfo
+  ##!!! need to add fixes to pop len bins? (see 3.24)
+  
   # return the result
   return(datlist)
 }

--- a/R/SS_readdat_3.24.R
+++ b/R/SS_readdat_3.24.R
@@ -477,6 +477,48 @@ SS_readdat_3.24 <- function(file,verbose=TRUE,echoall=FALSE,section=NULL){
   }else{
     cat("Error: final value is", allnums[i]," but should be 999\n")
   }
+  
+  # get fleet info
+  finfo<-rbind(datlist$fleetinfo1,c(rep(1,datlist$Nfleet),rep(3,datlist$Nsurveys)))
+  finfo<-rbind(finfo,c(datlist$units_of_catch,rep(0,datlist$Nsurveys)))
+  rownames(finfo)[3]<-"type"
+  rownames(finfo)[4]<-"units"
+  finfo<-finfo[,1:(length(finfo)-1)]
+  finfo<-as.data.frame(t(finfo))
+  datlist$fleetinfo<-finfo
+  datlist$NCPUEObs<-array(data=0,dim=datlist$Nfleet+datlist$Nsurveys)
+  for(j in 1:nrow(datlist$CPUE))
+  {
+    if(datlist$CPUE[j,]$index>0)datlist$NCPUEObs[datlist$CPUE[j,]$index]<-datlist$NCPUEObs[datlist$CPUE[j,]$index]+1
+  }
+  # fix some things
+  if(!is.null(datlist$lbin_method))
+  {
+    if(datlist$lbin_method==1) # same as data bins
+    {
+      datlist$N_lbinspop<-datlist$N_lbins
+      datlist$lbin_vector_pop<-datlist$lbin_vector
+    }
+    if(datlist$lbin_method==2) # defined wid, min, max
+    {
+      if(!is.null(datlist$binwidth)&&!is.null(datlist$minimum_size)&&!is.null(datlist$maximum_size))
+      {
+        datlist$N_lbinspop<-(datlist$maximum_size-datlist$minimum_size)/datlist$binwidth+1
+        datlist$lbin_vector_pop<-vector()
+        for(j in 0:datlist$N_lbinspop)
+        {
+          datlist$lbin_vector_pop<-c(datlist$lbin_vector_pop,datlist$minimum_size+(j*datlist$binwidth))
+        }
+      }
+    }
+    if(datlist$lbin_method==3) # vector
+    {
+      if(!is.null(datlist$lbin_vector_pop))
+      {
+        datlist$N_lbinspop<-length(datlist$lbin_vector_pop)
+      }
+    }
+  }
 
   # return the result
   return(datlist)

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -152,32 +152,32 @@ SS_readdat_3.30 <-
   dat <- gsub("[[:blank:]]+$", "", dat)
   ## Remove blank lines.
   dat <- dat[dat != ""]
-  d <- list()
-  d$sourcefile <- file
-  d$type <- "Stock_Synthesis_data_file"
-  d$ReadVersion <- "3.30"
+  datlist <- list()
+  datlist$sourcefile <- file
+  datlist$type <- "Stock_Synthesis_data_file"
+  datlist$ReadVersion <- "3.30"
   if (verbose){
-    message("SS_readdat_3.30 - read version = ", d$ReadVersion)
+    message("SS_readdat_3.30 - read version = ", datlist$ReadVersion)
   }
 
   ##############################################################################
   ## Get general model information ----
   ind <- 1
-  d$styr <- get.val(dat, ind)
-  d$endyr <- get.val(dat, ind)
-  d$nseas <- get.val(dat, ind)
-  d$months_per_seas <- get.vec(dat, ind)
-  d$Nsubseasons <- get.val(dat, ind)
-  d$spawn_month <- get.val(dat, ind)
-  d$Nsexes <- get.val(dat, ind)
-  d$Nages <- get.val(dat, ind)
-  d$Nareas <- get.val(dat, ind)
-  d$Nfleets <- get.val(dat, ind)
+  datlist$styr <- get.val(dat, ind)
+  datlist$endyr <- get.val(dat, ind)
+  datlist$nseas <- get.val(dat, ind)
+  datlist$months_per_seas <- get.vec(dat, ind)
+  datlist$Nsubseasons <- get.val(dat, ind)
+  datlist$spawn_month <- get.val(dat, ind)
+  datlist$Ngenders <- get.val(dat, ind)
+  datlist$Nages <- get.val(dat, ind)
+  datlist$N_areas <- get.val(dat, ind)
+  datlist$Nfleets <- get.val(dat, ind)
 
   ###############################################################################
   ## Fleet data ----
-  d$fleetinfo <- get.df(dat, ind, d$Nfleets)
-  colnames(d$fleetinfo) <- c("type",
+  datlist$fleetinfo <- get.df(dat, ind, datlist$Nfleets)
+  colnames(datlist$fleetinfo) <- c("type",
                              "surveytiming",
                              "area",
                              "units",
@@ -185,21 +185,21 @@ SS_readdat_3.30 <-
                              "fleetname")
   if(echoall){
     message("Fleet information:")
-    print(d$fleetinfo)
+    print(datlist$fleetinfo)
   }
 
-  d$fleetnames <- d$fleetinfo$fleetname
-  d$surveytiming <- as.numeric(d$fleetinfo$surveytiming)
-  d$units_of_catch <- as.numeric(d$fleetinfo$units)
-  d$areas <- as.numeric(d$fleetinfo$area)
+  datlist$fleetnames <- datlist$fleetinfo$fleetname
+  datlist$surveytiming <- as.numeric(datlist$fleetinfo$surveytiming)
+  datlist$units_of_catch <- as.numeric(datlist$fleetinfo$units)
+  datlist$areas <- as.numeric(datlist$fleetinfo$area)
   
   ##############################################################################
   ### Bycatch Data (only added for fleets with type = 2) ----
-  if(any(d$fleetinfo$type == 2)) {
-    nbycatch <- length(d$fleetinfo$type[d$fleetinfo$type == 2])
-    d$bycatch_fleet_info <- get.df(dat, ind, nbycatch)
+  if(any(datlist$fleetinfo$type == 2)) {
+    nbycatch <- length(datlist$fleetinfo$type[datlist$fleetinfo$type == 2])
+    datlist$bycatch_fleet_info <- get.df(dat, ind, nbycatch)
   
-    colnames(d$bycatch_fleet_info) <- c("fleetindex",
+    colnames(datlist$bycatch_fleet_info) <- c("fleetindex",
                                         "includeinMSY",
                                         "Fmult",
                                         "F_or_first_year",
@@ -207,13 +207,13 @@ SS_readdat_3.30 <-
                                         "unused"
                                         )
   # add a fleetname column, as in fleet info.
-    d$bycatch_fleet_info <-cbind(d$bycatch_fleet_info, 
-                                 d$fleetinfo[d$fleetinfo$type == 2, "fleetname", drop = FALSE])
+    datlist$bycatch_fleet_info <-cbind(datlist$bycatch_fleet_info, 
+                                 datlist$fleetinfo[datlist$fleetinfo$type == 2, "fleetname", drop = FALSE])
   }
   ###############################################################################
   ## Catch data ----
-  d$catch <- get.df(dat, ind)
-  colnames(d$catch) <- c("year", 
+  datlist$catch <- get.df(dat, ind)
+  colnames(datlist$catch) <- c("year", 
                          "seas", 
                          "fleet", 
                          "catch", 
@@ -221,226 +221,226 @@ SS_readdat_3.30 <-
 
   ###############################################################################
   ## CPUE data  ----
-  d$CPUEinfo <- get.df(dat, ind, d$Nfleets)
+  datlist$CPUEinfo <- get.df(dat, ind, datlist$Nfleets)
   # note SD_Report column wasn't present in early 3.30 versions of SS
   CPUEinfo_names <- c("Fleet", "Units", "Errtype", "SD_Report")
-  colnames(d$CPUEinfo) <- CPUEinfo_names[1:ncol(d$CPUEinfo)]
-  rownames(d$CPUEinfo) <- d$fleetnames
+  colnames(datlist$CPUEinfo) <- CPUEinfo_names[1:ncol(datlist$CPUEinfo)]
+  rownames(datlist$CPUEinfo) <- datlist$fleetnames
   if(echoall){
     message("CPUE information:")
-    print(d$CPUEinfo)
+    print(datlist$CPUEinfo)
   }
 
   ## CPUE data matrix
   CPUE <- get.df(dat, ind)
   if(!is.null(CPUE)){
-    d$CPUE <- CPUE
-    colnames(d$CPUE) <- c("year", "seas", "index", "obs", "se_log")
+    datlist$CPUE <- CPUE
+    colnames(datlist$CPUE) <- c("year", "seas", "index", "obs", "se_log")
   }else{
-    d$CPUE <- NULL
+    datlist$CPUE <- NULL
   }
   if (echoall) {
     message("CPUE data:")
-    print(d[["CPUE"]])
+    print(datlist[["CPUE"]])
   }
 
   ###############################################################################
   ## Discard data ----
   ## fleet.nums.with.catch is defined in the catch section above.
-  d$N_discard_fleets <- get.val(dat, ind)
-  if(d$N_discard_fleets){
+  datlist$N_discard_fleets <- get.val(dat, ind)
+  if(datlist$N_discard_fleets){
     ## Discard info data
-    d$discard_fleet_info <- get.df(dat, ind, d$N_discard_fleets)
-    colnames(d$discard_fleet_info) <- c("Fleet", "Units", "Errtype")
-    rownames(d$discard_fleet_info) <-
-      d$fleetnames[as.numeric(d$discard_fleet_info$Fleet)]
+    datlist$discard_fleet_info <- get.df(dat, ind, datlist$N_discard_fleets)
+    colnames(datlist$discard_fleet_info) <- c("Fleet", "Units", "Errtype")
+    rownames(datlist$discard_fleet_info) <-
+      datlist$fleetnames[as.numeric(datlist$discard_fleet_info$Fleet)]
 
     ## Discard data
-    d$discard_data <- get.df(dat, ind)
-    colnames(d$discard_data) <- c("Yr", "Seas", "Flt", "Discard", "Std_in")
+    datlist$discard_data <- get.df(dat, ind)
+    colnames(datlist$discard_data) <- c("Yr", "Seas", "Flt", "Discard", "Std_in")
   }else{
-    d$discard_fleet_info <- NULL
-    d$discard_data <- NULL
+    datlist$discard_fleet_info <- NULL
+    datlist$discard_data <- NULL
   }
-  if (echoall & !is.null(d$discard_fleet_info)) {
+  if (echoall & !is.null(datlist$discard_fleet_info)) {
     message("Discard fleet information:")
-    print(d$discard_fleet_info)
+    print(datlist$discard_fleet_info)
   }
-  if (echoall & !is.null(d$discard_data)) {
+  if (echoall & !is.null(datlist$discard_data)) {
     message("Discard data:")
-    print(d$discard_data)
+    print(datlist$discard_data)
 
   }
 
   ###############################################################################
   ## Mean body weight data ----
-  d$use_meanbodywt <- get.val(dat, ind)
-  if(d$use_meanbodywt){
-    d$DF_for_meanbodywt <- get.val(dat, ind)
-    d$meanbodywt <- get.df(dat, ind)
-    colnames(d$meanbodywt) <- c("Year", "Seas", "Fleet", "Partition", "Type",
+  datlist$use_meanbodywt <- get.val(dat, ind)
+  if(datlist$use_meanbodywt){
+    datlist$DF_for_meanbodywt <- get.val(dat, ind)
+    datlist$meanbodywt <- get.df(dat, ind)
+    colnames(datlist$meanbodywt) <- c("Year", "Seas", "Fleet", "Partition", "Type",
                                 "Value", "Std_in")
   }else{
-    d$DF_for_meanbodywt <- NULL
-    d$meanbodywt <- NULL
+    datlist$DF_for_meanbodywt <- NULL
+    datlist$meanbodywt <- NULL
   }
   if (verbose) {
-    message("use_meanbodywt (0/1): ", d$use_meanbodywt)
+    message("use_meanbodywt (0/1): ", datlist$use_meanbodywt)
   }
-  if (echoall & !is.null(d$meanbodywt)) {
+  if (echoall & !is.null(datlist$meanbodywt)) {
     message("meanbodywt:")
-    print(d$meanbodywt)
+    print(datlist$meanbodywt)
   }
 
   ###############################################################################
   ## Population size structure - Length ----
-  d$lbin_method <- get.val(dat, ind)
-  if(d$lbin_method == 2){
+  datlist$lbin_method <- get.val(dat, ind)
+  if(datlist$lbin_method == 2){
     bin_info_tmp <- get.val(dat, ind)
     # if as.numeric doesn't match, probably has 3 values on one line
     if(is.na(bin_info_tmp)){
       ind <- ind - 1 # reset index to allow read of that value again
       bin_info_tmp <- get.vec(dat, ind)
-      d$binwidth <- bin_info_tmp[1]
-      d$minimum_size <- bin_info_tmp[2]
-      d$maximum_size <- bin_info_tmp[3]
+      datlist$binwidth <- bin_info_tmp[1]
+      datlist$minimum_size <- bin_info_tmp[2]
+      datlist$maximum_size <- bin_info_tmp[3]
     }else{
       # otherwise, more likely separate lines
-      d$binwidth <- bin_info_tmp
-      d$minimum_size <- get.val(dat, ind)
-      d$maximum_size <- get.val(dat, ind)
+      datlist$binwidth <- bin_info_tmp
+      datlist$minimum_size <- get.val(dat, ind)
+      datlist$maximum_size <- get.val(dat, ind)
     }
-  }else if(d$lbin_method == 3){
-    d$N_lbinspop <- get.val(dat, ind)
-    d$lbin_vector_pop <- get.vec(dat, ind)
+  }else if(datlist$lbin_method == 3){
+    datlist$N_lbinspop <- get.val(dat, ind)
+    datlist$lbin_vector_pop <- get.vec(dat, ind)
   }else{
-    d$binwidth <- NULL
-    d$minimum_size <- NULL
-    d$maximum_size <- NULL
-    d$N_lbinspop <- NULL
-    d$lbin_vector_pop <- NULL
+    datlist$binwidth <- NULL
+    datlist$minimum_size <- NULL
+    datlist$maximum_size <- NULL
+    datlist$N_lbinspop <- NULL
+    datlist$lbin_vector_pop <- NULL
   }
   if (verbose) {
-    message("N_lbinspop: ", d$N_lbinspop)
+    message("N_lbinspop: ", datlist$N_lbinspop)
   }
   ## Length Comp information matrix (new for 3.30)
-  d$use_lencomp <- get.val(dat, ind)
+  datlist$use_lencomp <- get.val(dat, ind)
   if (verbose) {
-    message("use_lencomp (0/1): ", d$use_lencomp)
+    message("use_lencomp (0/1): ", datlist$use_lencomp)
   }
   # only read all the stuff related to length comps if switch above = 1
-  if(d$use_lencomp){
+  if(datlist$use_lencomp){
     # note: minsamplesize column not present in early 3.30 versions of SS
-    d$len_info <- get.df(dat, ind, d$Nfleets)
-    colnames(d$len_info) <- c("mintailcomp", "addtocomp", "combine_M_F",
+    datlist$len_info <- get.df(dat, ind, datlist$Nfleets)
+    colnames(datlist$len_info) <- c("mintailcomp", "addtocomp", "combine_M_F",
                               "CompressBins", "CompError", "ParmSelect",
-                              "minsamplesize")[1:ncol(d$len_info)]
-    rownames(d$len_info) <- d$fleetnames
+                              "minsamplesize")[1:ncol(datlist$len_info)]
+    rownames(datlist$len_info) <- datlist$fleetnames
     if (echoall) {
       message("\nlen_info:")
-      print(d$len_info)
+      print(datlist$len_info)
     }
     ## Length comp data
-    d$N_lbins <- get.val(dat, ind)
+    datlist$N_lbins <- get.val(dat, ind)
     if (verbose) {
-      message("N_lbins: ", d$N_lbins)
+      message("N_lbins: ", datlist$N_lbins)
     }
-    d$lbin_vector <- get.vec(dat, ind)
-    d$lencomp <- get.df(dat, ind)
-    if(!is.null(d$lencomp)){
-      colnames(d$lencomp) <-
+    datlist$lbin_vector <- get.vec(dat, ind)
+    datlist$lencomp <- get.df(dat, ind)
+    if(!is.null(datlist$lencomp)){
+      colnames(datlist$lencomp) <-
         c("Yr", "Seas", "FltSvy", "Gender", "Part", "Nsamp",
-          if(d$Nsexes == 1){paste0("l", d$lbin_vector)}else{NULL},
-          if(d$Nsexes > 1){c(paste0("f", d$lbin_vector),
-                             paste0("m", d$lbin_vector))}else{NULL})
+          if(datlist$Ngenders == 1){paste0("l", datlist$lbin_vector)}else{NULL},
+          if(datlist$Ngenders > 1){c(paste0("f", datlist$lbin_vector),
+                             paste0("m", datlist$lbin_vector))}else{NULL})
     }
     # echo values
     if (echoall) {
       message("\nFirst 2 rows of lencomp:")
-      print(head(d$lencomp, 2))
+      print(head(datlist$lencomp, 2))
       message("\nLast 2 rows of lencomp:")
-      print(tail(d$lencomp, 2))
+      print(tail(datlist$lencomp, 2))
       cat("\n")
     }
   }
 
   ###############################################################################
   ## Population size structure - Age ----
-  d$N_agebins <- get.val(dat, ind)
+  datlist$N_agebins <- get.val(dat, ind)
   if (verbose) {
-    message("N_agebins: ", d$N_agebins)
+    message("N_agebins: ", datlist$N_agebins)
   }
-  if (d$N_agebins){
-    d$agebin_vector <- get.vec(dat, ind)
+  if (datlist$N_agebins){
+    datlist$agebin_vector <- get.vec(dat, ind)
     if (echoall) {
       message("agebin_vector:")
-      print(d$agebin_vector)
+      print(datlist$agebin_vector)
     }
   }else{
-    d$agebin_vector <- NULL
+    datlist$agebin_vector <- NULL
   }
 
   ## Age error data
-  if (d$N_agebins) {
-    d$N_ageerror_definitions <- get.val(dat, ind)
-    if(d$N_ageerror_definitions){
-      d$ageerror <- get.df(dat, ind, d$N_ageerror_definitions * 2)
-      colnames(d$ageerror) <- paste0("age", 0:d$Nages)
+  if (datlist$N_agebins) {
+    datlist$N_ageerror_definitions <- get.val(dat, ind)
+    if(datlist$N_ageerror_definitions){
+      datlist$ageerror <- get.df(dat, ind, datlist$N_ageerror_definitions * 2)
+      colnames(datlist$ageerror) <- paste0("age", 0:datlist$Nages)
     }else{
-      d$ageerror <- NULL
+      datlist$ageerror <- NULL
     }
     # echo values
     if (echoall) {
       message("\nN_ageerror_definitions:")
-      print(d$N_ageerror_definitions)
+      print(datlist$N_ageerror_definitions)
       message("\nageerror:")
-      print(d$ageerror)
+      print(datlist$ageerror)
     }
   }
 
 
   ###############################################################################
   ## Age Comp information matrix ----
-  if(d$N_agebins){
-    d$age_info <- get.df(dat, ind, d$Nfleets)
+  if(datlist$N_agebins){
+    datlist$age_info <- get.df(dat, ind, datlist$Nfleets)
     # note: minsamplesize column not present in early 3.30 versions of SS
-    colnames(d$age_info) <- c("mintailcomp",
+    colnames(datlist$age_info) <- c("mintailcomp",
                               "addtocomp",
                               "combine_M_F",
                               "CompressBins",
                               "CompError",
                               "ParmSelect",
-                              "minsamplesize")[1:ncol(d$age_info)]
-    rownames(d$age_info) <- d$fleetnames
+                              "minsamplesize")[1:ncol(datlist$age_info)]
+    rownames(datlist$age_info) <- datlist$fleetnames
     ## Length bin method for age data
     # note that Lbin_method below is related to the interpretation of
     # conditional age-at-length data and differs from lbin_method for the length
     # data read above
-    d$Lbin_method <- get.val(dat, ind)
+    datlist$Lbin_method <- get.val(dat, ind)
     if (echoall) {
       message("\nage_info:")
-      print(d$age_info)
+      print(datlist$age_info)
     }
   }
 
   ###############################################################################
   ## Age comp matrix ----
-  if(d$N_agebins){
-    d$agecomp <- get.df(dat, ind)
-    if(!is.null(d$agecomp)){
-      colnames(d$agecomp) <-
+  if(datlist$N_agebins){
+    datlist$agecomp <- get.df(dat, ind)
+    if(!is.null(datlist$agecomp)){
+      colnames(datlist$agecomp) <-
         c("Yr", "Seas", "FltSvy", "Gender",
           "Part", "Ageerr", "Lbin_lo", "Lbin_hi", "Nsamp",
-          if(d$Nsexes == 1){paste0("a", d$agebin_vector)}else{NULL},
-          if(d$Nsexes > 1){c(paste0("f", d$agebin_vector),
-                               paste0("m", d$agebin_vector))}else{NULL})
+          if(datlist$Ngenders == 1){paste0("a", datlist$agebin_vector)}else{NULL},
+          if(datlist$Ngenders > 1){c(paste0("f", datlist$agebin_vector),
+                               paste0("m", datlist$agebin_vector))}else{NULL})
     }
     # echo values
     if (echoall) {
       message("\nFirst 2 rows of agecomp:")
-      print(head(d$agecomp, 2))
+      print(head(datlist$agecomp, 2))
       message("\nLast 2 rows of agecomp:")
-      print(tail(d$agecomp, 2))
+      print(tail(datlist$agecomp, 2))
       cat("\n")
     }
   }else{
@@ -451,23 +451,23 @@ SS_readdat_3.30 <-
 
   ###############################################################################
   ## Mean size-at-age data ----
-  d$use_MeanSize_at_Age_obs <- get.val(dat, ind)
+  datlist$use_MeanSize_at_Age_obs <- get.val(dat, ind)
   if (verbose) {
-    message("use_MeanSize_at_Age_obs (0/1): ", d$use_MeanSize_at_Age_obs)
+    message("use_MeanSize_at_Age_obs (0/1): ", datlist$use_MeanSize_at_Age_obs)
   }
-  if(d$use_MeanSize_at_Age_obs){
+  if(datlist$use_MeanSize_at_Age_obs){
     ind.tmp <- ind # save current position in case necessary to re-read
-    d$MeanSize_at_Age_obs <- get.df(dat, ind)
+    datlist$MeanSize_at_Age_obs <- get.df(dat, ind)
 
     # extra code in case sample sizes are on a separate line from other inputs
     # first check if gender input is outside of normal range
-    if(!all(as.numeric(d$MeanSize_at_Age_obs$V4) %in% 0:3)){
+    if(!all(as.numeric(datlist$MeanSize_at_Age_obs$V4) %in% 0:3)){
       if(verbose){
         message("Format of MeanSize_at_Age_obs appears to have sample sizes",
                 "on separate lines than other inputs.")
       }
       ind <- ind.tmp # reset index to value prior to first attempt to read table
-      N_MeanSize_at_Age_obs <- nrow(d$MeanSize_at_Age_obs)/2
+      N_MeanSize_at_Age_obs <- nrow(datlist$MeanSize_at_Age_obs)/2
       MeanSize_at_Age_obs <- NULL
       for(iobs in 1:N_MeanSize_at_Age_obs){
         # each observation is a combination of pairs of adjacent rows
@@ -479,23 +479,23 @@ SS_readdat_3.30 <-
       if(test[1] != -9999){
         warning("Problem with read of MeanSize_at_Age, terminator value != -9999")
       }
-      d$MeanSize_at_Age_obs <- as.data.frame(MeanSize_at_Age_obs)
+      datlist$MeanSize_at_Age_obs <- as.data.frame(MeanSize_at_Age_obs)
     }
 
-    colnames(d$MeanSize_at_Age_obs) <-
+    colnames(datlist$MeanSize_at_Age_obs) <-
       c("Yr", "Seas", "FltSvy", "Gender", "Part", "AgeErr", "Ignore",
-        if(d$Nsexes == 1){paste0("a", d$agebin_vector)}else{NULL},
-        if(d$Nsexes > 1){c(paste0("f", d$agebin_vector),
-                             paste0("m", d$agebin_vector))}else{NULL},
-        if(d$Nsexes == 1){paste0("N_a", d$agebin_vector)}else{NULL},
-        if(d$Nsexes > 1){c(paste0("N_f", d$agebin_vector),
-                             paste0("N_m", d$agebin_vector))}else{NULL})
+        if(datlist$Ngenders == 1){paste0("a", datlist$agebin_vector)}else{NULL},
+        if(datlist$Ngenders > 1){c(paste0("f", datlist$agebin_vector),
+                             paste0("m", datlist$agebin_vector))}else{NULL},
+        if(datlist$Ngenders == 1){paste0("N_a", datlist$agebin_vector)}else{NULL},
+        if(datlist$Ngenders > 1){c(paste0("N_f", datlist$agebin_vector),
+                             paste0("N_m", datlist$agebin_vector))}else{NULL})
     # echo values
     if (echoall) {
       message("\nFirst 2 rows of MeanSize_at_Age_obs:")
-      print(head(d$MeanSize_at_Age_obs, 2))
+      print(head(datlist$MeanSize_at_Age_obs, 2))
       message("\nLast 2 rows of MeanSize_at_Age_obs:")
-      print(tail(d$MeanSize_at_Age_obs, 2))
+      print(tail(datlist$MeanSize_at_Age_obs, 2))
       cat("\n")
     }
     # The formatting of the mean size at age in data.ss_new has sample sizes
@@ -507,137 +507,137 @@ SS_readdat_3.30 <-
       ind <- ind - 1
     }
   }else{
-    d$MeanSize_at_Age_obs <- NULL
+    datlist$MeanSize_at_Age_obs <- NULL
   }
 
   ###############################################################################
   ## Environment variables ----
-  d$N_environ_variables <- get.val(dat, ind)
+  datlist$N_environ_variables <- get.val(dat, ind)
 
   if (verbose) {
-    message("N_environ_variables: ", d$N_environ_variables)
+    message("N_environ_variables: ", datlist$N_environ_variables)
   }
 
-  if(d$N_environ_variables){
-    d$envdat <- get.df(dat, ind)
-    colnames(d$envdat) <- c("Yr", "Variable", "Value")
+  if(datlist$N_environ_variables){
+    datlist$envdat <- get.df(dat, ind)
+    colnames(datlist$envdat) <- c("Yr", "Variable", "Value")
 
     # echo values
     if (echoall) {
       message("\nFirst 2 rows of envdat:")
-      print(head(d$envdat, 2))
+      print(head(datlist$envdat, 2))
       message("\nLast 2 rows of envdat:")
-      print(tail(d$envdat, 2))
+      print(tail(datlist$envdat, 2))
       cat("\n")
     }
   }else{
-    d$envdat <- NULL
+    datlist$envdat <- NULL
   }
 
   ###############################################################################
   ## Size frequency methods ----
-  d$N_sizefreq_methods <- get.val(dat, ind)
-  if(d$N_sizefreq_methods){
+  datlist$N_sizefreq_methods <- get.val(dat, ind)
+  if(datlist$N_sizefreq_methods){
     ## Get details of generalized size frequency methods
-    d$nbins_per_method <- get.vec(dat, ind)
-    d$units_per_method <- get.vec(dat, ind)
-    d$scale_per_method <- get.vec(dat, ind)
-    d$mincomp_per_method <- get.vec(dat, ind)
-    d$Nobs_per_method <- get.vec(dat, ind)
+    datlist$nbins_per_method <- get.vec(dat, ind)
+    datlist$units_per_method <- get.vec(dat, ind)
+    datlist$scale_per_method <- get.vec(dat, ind)
+    datlist$mincomp_per_method <- get.vec(dat, ind)
+    datlist$Nobs_per_method <- get.vec(dat, ind)
     if(echoall){
       message("Details of generalized size frequency methods:")
-      print(data.frame(method  = 1:d$N_sizefreq_methods,
-                       nbins   = d$nbins_per_method,
-                       units   = d$units_per_method,
-                       scale   = d$scale_per_method,
-                       mincomp = d$mincomp_per_method,
-                       nobs    = d$Nobs_per_method))
+      print(data.frame(method  = 1:datlist$N_sizefreq_methods,
+                       nbins   = datlist$nbins_per_method,
+                       units   = datlist$units_per_method,
+                       scale   = datlist$scale_per_method,
+                       mincomp = datlist$mincomp_per_method,
+                       nobs    = datlist$Nobs_per_method))
     }
     ## get list of bin vectors
-    d$sizefreq_bins_list <- list()
-    for(imethod in seq_len(d$N_sizefreq_methods)) {
-      d$sizefreq_bins_list[[imethod]] <- get.vec(dat, ind)
+    datlist$sizefreq_bins_list <- list()
+    for(imethod in seq_len(datlist$N_sizefreq_methods)) {
+      datlist$sizefreq_bins_list[[imethod]] <- get.vec(dat, ind)
     }
     ## Read generalized size frequency data
-    d$sizefreq_data_list <- list()
-    for(imethod in seq_len(d$N_sizefreq_methods)) {
-      Ncols <- 7 + d$Nsexes * d$nbins_per_method[imethod]
-      Nrows <- d$Nobs_per_method[imethod]
-      d$sizefreq_data_list[[imethod]] <- get.df(dat, ind, Nrows)
-      colnames(d$sizefreq_data_list[[imethod]]) <-
+    datlist$sizefreq_data_list <- list()
+    for(imethod in seq_len(datlist$N_sizefreq_methods)) {
+      Ncols <- 7 + datlist$Ngenders * datlist$nbins_per_method[imethod]
+      Nrows <- datlist$Nobs_per_method[imethod]
+      datlist$sizefreq_data_list[[imethod]] <- get.df(dat, ind, Nrows)
+      colnames(datlist$sizefreq_data_list[[imethod]]) <-
         c("Method", "Yr", "Seas", "FltSvy",
           "Gender", "Part", "Nsamp",
-          if(d$Nsexes == 1){
-            paste0("a", d$sizefreq_bins_list[[imethod]])
+          if(datlist$Ngenders == 1){
+            paste0("a", datlist$sizefreq_bins_list[[imethod]])
           }else{
             NULL
           },
-          if(d$Nsexes > 1){
-            c(paste0("f", d$sizefreq_bins_list[[imethod]]),
-              paste0("m", d$sizefreq_bins_list[[imethod]]))
+          if(datlist$Ngenders > 1){
+            c(paste0("f", datlist$sizefreq_bins_list[[imethod]]),
+              paste0("m", datlist$sizefreq_bins_list[[imethod]]))
           }else{
             NULL
           })
       if(echoall){
         message("Method ", imethod, " (first two rows, ten columns):")
-        print(d$sizefreq_data_list[[imethod]][1:min(Nrows,2), 1:min(Ncols, 10)])
+        print(datlist$sizefreq_data_list[[imethod]][1:min(Nrows,2), 1:min(Ncols, 10)])
       }
-      if(any(d$sizefreq_data_list[[imethod]][, "Method"] != imethod)) {
+      if(any(datlist$sizefreq_data_list[[imethod]][, "Method"] != imethod)) {
         stop("Problem with method in size frequency data:\n",
              "Expecting method: ", imethod, "\n",
              "Read method(s): ",
-             paste(unique(d$sizefreq_data_list$Method), collapse = ", "))
+             paste(unique(datlist$sizefreq_data_list$Method), collapse = ", "))
       }
     }
   }else{
-    d$nbins_per_method   <- NULL
-    d$units_per_method   <- NULL
-    d$scale_per_method   <- NULL
-    d$mincomp_per_method <- NULL
-    d$Nobs_per_method    <- NULL
-    d$sizefreq_bins_list <- NULL
-    d$sizefreq_data_list <- NULL
+    datlist$nbins_per_method   <- NULL
+    datlist$units_per_method   <- NULL
+    datlist$scale_per_method   <- NULL
+    datlist$mincomp_per_method <- NULL
+    datlist$Nobs_per_method    <- NULL
+    datlist$sizefreq_bins_list <- NULL
+    datlist$sizefreq_data_list <- NULL
   }
 
   ###############################################################################
   ## Tag data ----
-  d$do_tags <- get.val(dat, ind)
-  if(d$do_tags){
-    d$N_tag_groups <- get.val(dat, ind)
-    d$N_recap_events <- get.val(dat, ind)
-    d$mixing_latency_period <- get.val(dat, ind)
-    d$max_periods <- get.val(dat, ind)
+  datlist$do_tags <- get.val(dat, ind)
+  if(datlist$do_tags){
+    datlist$N_tag_groups <- get.val(dat, ind)
+    datlist$N_recap_events <- get.val(dat, ind)
+    datlist$mixing_latency_period <- get.val(dat, ind)
+    datlist$max_periods <- get.val(dat, ind)
     ## Read tag release data
-    if(d$N_tag_groups > 0){
+    if(datlist$N_tag_groups > 0){
       Ncols <- 8
-      d$tag_releases <- get.df(dat, ind, d$N_tag_groups)
-      colnames(d$tag_releases) <- c("TG", "Area", "Yr", "Season",
+      datlist$tag_releases <- get.df(dat, ind, datlist$N_tag_groups)
+      colnames(datlist$tag_releases) <- c("TG", "Area", "Yr", "Season",
                                     "tfill", "Gender", "Age", "Nrelease")
       if(echoall){
         message("Head of tag release data:")
-        print(head(d$tag_releases))
+        print(head(datlist$tag_releases))
       }
     }else{
-      d$tag_releases <- NULL
+      datlist$tag_releases <- NULL
     }
     ## Read tag recapture data
-    if(d$N_recap_events > 0){
+    if(datlist$N_recap_events > 0){
       Ncols <- 5
-      d$tag_recaps <- get.df(dat, ind, d$N_recap_events)
-      colnames(d$tag_recaps) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
+      datlist$tag_recaps <- get.df(dat, ind, datlist$N_recap_events)
+      colnames(datlist$tag_recaps) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
       if(echoall){
         message("Head of tag recapture data:")
-        print(head(d$tag_recaps))
+        print(head(datlist$tag_recaps))
       }
     }else{
-      d$tag_recaps <- NULL
+      datlist$tag_recaps <- NULL
     }
   }
 
   ###############################################################################
   ## Morphometrics composition data ----
-  d$morphcomp_data <- get.val(dat, ind)
-  if(d$morphcomp_data){
+  datlist$morphcomp_data <- get.val(dat, ind)
+  if(datlist$morphcomp_data){
     warning("Morph comp data not yet supported by SS_readdat_3.30\n",
             "  Please post issue to https://github.com/r4ss/r4ss/issues\n",
             "  or email ian.taylor@noaa.gov",
@@ -646,7 +646,7 @@ SS_readdat_3.30 <-
   
   ###############################################################################
   ## Selectivity priors ----
-  d$use_selectivity_priors <- get.val(dat, ind)
+  datlist$use_selectivity_priors <- get.val(dat, ind)
 
   ###############################################################################
   ## End of file ----
@@ -659,7 +659,80 @@ SS_readdat_3.30 <-
               " of data file complete. Final value = ", eof)
     }
   }
-  d$eof <- FALSE
-  if(eof==999)d$eof <- TRUE
-  return(d)
+  datlist$eof <- FALSE
+  if(eof==999)datlist$eof <- TRUE
+  
+  ###############################################################################
+  ## Fixes pulled in from SS_readdat wrapper
+  
+  datlist$spawn_seas <- datlist$spawn_month
+  # compatibility: get the old number values
+  datlist$Nfleet <- nrow(subset(datlist$fleetinfo,datlist$fleetinfo$type<=2))
+  datlist$Nsurveys <- datlist$Nfleets-datlist$Nfleet
+  totfleets<-datlist$Nfleet+datlist$Nsurveys
+  # Note that using NROW on datlist$CPUE that is NA will return 1, when in 
+  # reality the number of years should be 0.
+  datlist$N_cpue <- ifelse(is.null(datlist[["CPUE"]]) || 
+                             (is.null(dim(datlist[["CPUE"]])) && is.na(datlist[["CPUE"]])), 
+                           0,
+                           NROW(datlist[["CPUE"]]))
+  # fleet details
+  datlist$fleetinfo1<-t(datlist$fleetinfo)
+  colnames(datlist$fleetinfo1)<-datlist$fleetinfo$fleetname
+  datlist$fleetinfo1<-datlist$fleetinfo1[1:5,]
+  datlist$fleetinfo2<-datlist$fleetinfo1[4:5,]
+  datlist$fleetinfo1<-datlist$fleetinfo1[c(2:3,1),]
+  rownames(datlist$fleetinfo1)<-c("surveytiming","areas","type")
+  datlist$fleetinfo1<-data.frame(datlist$fleetinfo1)  # convert all to numeric
+  datlist$fleetinfo2<-data.frame(datlist$fleetinfo2)  # convert all to numeric
+  if(!is.null(datlist$discard_fleet_info))colnames(datlist$discard_fleet_info)<-c("Fleet","units","errtype")
+  # compatibility: create the old format catch matrix
+  datlist$catch <- datlist$catch[datlist$catch[, 1] >= -999, ]
+  colnames(datlist$catch) = c("year", "seas", "fleet", "catch", "catch_se")
+  # mean body weight
+  if(datlist$use_meanbodywt==0)
+  {
+    datlist$N_meanbodywt<-0
+  }
+  # length info
+  datlist$comp_tail_compression<-datlist$len_info$mintailcomp
+  datlist$add_to_comp<-datlist$len_info$addtocomp
+  datlist$max_combined_lbin<-datlist$len_info$combine_M_F
+  if(is.null(datlist$lencomp))datlist$N_lencomp<-0
+  if(datlist$use_MeanSize_at_Age_obs==0)
+  {
+    datlist$N_MeanSize_at_Age_obs<-0
+  }
+  ##!!! need to add fixes to pop len bins? (see 3.24)
+  # fix some things
+  if(!is.null(datlist$lbin_method))
+  {
+    if(datlist$lbin_method==1) # same as data bins
+    {
+      datlist$N_lbinspop<-datlist$N_lbins
+      datlist$lbin_vector_pop<-datlist$lbin_vector
+    }
+    
+    if(datlist$lbin_method==2) # defined wid, min, max
+    {
+      if(!is.null(datlist$binwidth)&&!is.null(datlist$minimum_size)&&!is.null(datlist$maximum_size))
+      {
+        datlist$N_lbinspop<-(datlist$maximum_size-datlist$minimum_size)/datlist$binwidth+1
+        datlist$lbin_vector_pop<-vector()
+        for(j in 0:datlist$N_lbinspop)
+        {
+          datlist$lbin_vector_pop<-c(datlist$lbin_vector_pop,datlist$minimum_size+(j*datlist$binwidth))
+        }
+      }
+    }
+    if(datlist$lbin_method==3) # vector
+    {
+      if(!is.null(datlist$lbin_vector_pop))
+      {
+        datlist$N_lbinspop<-length(datlist$lbin_vector_pop)
+      }
+    }
+  }
+  
+  return(datlist)
 }

--- a/R/SS_writectl_3.30.R
+++ b/R/SS_writectl_3.30.R
@@ -174,7 +174,7 @@ SS_writectl_3.30 <- function(ctllist, outfile, overwrite, verbose) {
   # Movement ----
   if(ctllist$N_areas > 1) {
     wl("N_moveDef", 
-       comment = "#_N_movement_definitions goes here if Nareas > 1")
+       comment = "#_N_movement_definitions goes here if N_areas > 1")
     if(ctllist$N_moveDef>0) {
     wl("firstAgeMove", 
        comment = paste0("#_first age that moves (real age at begin of season, ",
@@ -348,17 +348,17 @@ SS_writectl_3.30 <- function(ctllist, outfile, overwrite, verbose) {
                       "function of SR curvature"))
   # SR parms ----
   # change column names to match control.ss_new
-  colnames(ctllist$SRparm) <- c("LO", "HI", "INIT", "PRIOR", "PR_SD", "PR_type",
+  colnames(ctllist$SR_parms) <- c("LO", "HI", "INIT", "PRIOR", "PR_SD", "PR_type",
                                 "PHASE", "env-var", "use_dev", "dev_mnyr", 
                                 "dev_mxyr", "dev_PH", "Block", 
                                 "Blk_Fxn # parm_name", "PType") 
   # "Blk_Fxn # parm_name" is just to get the parm_name header printed, too.
-  printdf("SRparm")
+  printdf("SR_parms")
   # reset column names back.
-  colnames(ctllist$SRparm) <- c(lng_par_colnames, "PType")
+  colnames(ctllist$SR_parms) <- c(lng_par_colnames, "PType")
   
   # SR tv parms ----
-  if(any(ctllist$SRparm[, c("env_var&link", "dev_link", "Block")] != 0) &
+  if(any(ctllist$SR_parms[, c("env_var&link", "dev_link", "Block")] != 0) &
      ctllist$time_vary_auto_generation[2] != 0) {
     writeComment("# timevary SR parameters")
     printdf("SR_parms_tv")

--- a/R/SS_writedat_3.30.R
+++ b/R/SS_writedat_3.30.R
@@ -187,9 +187,9 @@ SS_writedat_3.30 <- function(datlist,
   wl.vector("months_per_seas", comment = "#_months_per_seas")
   wl("Nsubseasons")
   wl("spawn_month")
-  wl("Nsexes")
+  wl("Ngenders")
   wl("Nages")
-  wl("Nareas")
+  wl("N_areas")
   wl("Nfleets")
 
   # write table of info on each fleet
@@ -283,7 +283,7 @@ SS_writedat_3.30 <- function(datlist,
     writeComment("#\n#_lencomp")
     if(is.null(d$lencomp) & d$use_lencomp==1){
       # empty data.frame with correct number of columns needed for terminator row
-      d$lencomp <- data.frame(matrix(vector(), 0, 6 + d$N_lbins * d$Nsexes))
+      d$lencomp <- data.frame(matrix(vector(), 0, 6 + d$N_lbins * d$Ngenders))
     }
     print.df(d$lencomp)
   }
@@ -310,7 +310,7 @@ SS_writedat_3.30 <- function(datlist,
     # age comps
     if (is.null(d$agecomp)) {
       # empty data.frame with correct number of columns needed for terminator row
-      d$agecomp <- data.frame(matrix(vector(), 0, 9 + d$N_agebins * d$Nsexes))
+      d$agecomp <- data.frame(matrix(vector(), 0, 9 + d$N_agebins * d$Ngenders))
     }
     print.df(d$agecomp)
   }

--- a/man/SS_readctl.Rd
+++ b/man/SS_readctl.Rd
@@ -14,6 +14,7 @@ SS_readctl(
   Nages = 20,
   Ngenders = 1,
   Npopbins = NA,
+  Nfleets = 4,
   Nfleet = 2,
   Nsurveys = 2,
   N_tag_groups = NA,
@@ -55,11 +56,14 @@ also not explicitly available in control file and this information is only
 required if length based
  maturity vector is directly supplied (Maturity option of 6), and not yet tested}
 
-\item{Nfleet}{number of fisheries in the model. This information is also not
-explicitly available in control file}
+\item{Nfleets}{number of fishery + Survey fleets in the model. This 
+information is also not explicitly available in control file 3.30 syntax}
+
+\item{Nfleet}{number of fishery fleets in the model. This information is also not
+explicitly available in control file 3.24 syntax}
 
 \item{Nsurveys}{number of survey fleets in the model. This information is also not
-explicitly available in control file}
+explicitly available in control file 3.24 syntax}
 
 \item{N_tag_groups}{number of tag release groups in the model.
 This information is also not explicitly available in control file.}

--- a/man/SS_readctl_3.30.Rd
+++ b/man/SS_readctl_3.30.Rd
@@ -14,8 +14,7 @@ SS_readctl_3.30(
   Nages = 20,
   Ngenders = 1,
   Npopbins = NA,
-  Nfleet = 2,
-  Nsurveys = 2,
+  Nfleets = 2,
   Do_AgeKey = FALSE,
   N_tag_groups = NA,
   N_CPUE_obs = c(0, 0, 9, 12),
@@ -54,10 +53,7 @@ explicitly available in control file}
 explicitly available in control file and this information is only required if length based
 maturity vector is directly supplied (Maturity option of 6), and not yet tested}
 
-\item{Nfleet}{number of fisheries in the model. This information is also not
-explicitly available in control file}
-
-\item{Nsurveys}{number of survey fleets in the model. This information is also not
+\item{Nfleets}{number of fishery and survey fleets in the model. This information is also not
 explicitly available in control file}
 
 \item{Do_AgeKey}{Flag to indicate if 7 additional ageing error parameters to be read
@@ -67,7 +63,7 @@ to disable them. This information is not explicitly available in control file, t
 \item{N_tag_groups}{number of tag release group. Default =NA. This information is not explicitly available
 control file. This information is only required if custom tag parameters is enabled (TG_custom=1)}
 
-\item{N_CPUE_obs}{integer vector of length=Nfleet+Nsurveys containing number of data points of each CPUE time series}
+\item{N_CPUE_obs}{integer vector of length=Nfleets containing number of data points of each CPUE time series}
 
 \item{catch_mult_fleets}{integer vector of fleets using the catch multiplier 
 option. Defaults to NULL and should be left as such if 1) the catch 

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -37,6 +37,65 @@ test_that("SS_readctl and SS_writectl works for 3.30.13", {
               outfile = file.path(sim_3.30.13,"testctl.ss"))
   expect_true(file.exists(file.path(sim_3.30.13,"testctl.ss")))
 })
+
+test_that("SS_readctl and SS_writectl works for 3.30.13 when not reading from data", {
+  # read data file b/c necessary input to read control
+  dat_3.30.13 <- SS_readdat(file.path(sim_3.30.13, "simple_data.ss"),
+                            verbose = FALSE)
+
+  # read the control file so that test can run on it
+  ctl_3.30.13 <- SS_readctl(
+    file.path(sim_3.30.13, "simple_control.ss"),
+    verbose = FALSE,
+    use_datlist = FALSE,
+    nseas = dat_3.30.13[["nseas"]], 
+    N_areas = dat_3.30.13[["N_areas"]], 
+    Nages = dat_3.30.13[["Nages"]], 
+    Ngender = dat_3.30.13[["Ngenders"]], 
+    Nfleets = dat_3.30.13[["Nfleets"]], 
+    N_CPUE_obs = dat_3.30.13[["N_cpue"]])
+  
+  expect_type(ctl_3.30.13, "list")
+  #check write control
+  if(file.exists(file.path(sim_3.30.13,"testctl.ss"))) {
+    file.remove(file.path(sim_3.30.13,"testctl.ss"))
+  }
+  SS_writectl(ctllist = ctl_3.30.13,
+              verbose = FALSE,
+              overwrite = FALSE,
+              outfile = file.path(sim_3.30.13,"testctl.ss"))
+  expect_true(file.exists(file.path(sim_3.30.13,"testctl.ss")))
+})
+
+test_that(paste0("SS_readctl_3,30, SS_writectl_3.30, SS_readdat_3.30, and ",
+                " SS_writedat_3.30 works for 3.30.13 using funs directly"), {
+   # read data file b/c necessary input to read control
+   dat_3.30.13 <- SS_readdat_3.30(file.path(sim_3.30.13, "simple_data.ss"),
+                                  verbose = FALSE)
+   # test write dat
+   if(file.exists(file.path(sim_3.30.13,"testdat.ss"))) {
+     file.remove(file.path(sim_3.30.13,"testdat.ss"))
+   }
+   SS_writedat_3.30(dat_3.30.13, file.path(sim_3.30.13, "testdat.ss"))
+   expect_true(file.exists(file.path(sim_3.30.13,"testdat.ss")))
+   # read the control file so that test can run on it
+   ctl_3.30.13 <- SS_readctl_3.30(
+     file.path(sim_3.30.13, "simple_control.ss"),
+     verbose = FALSE,
+     use_datlist = TRUE,
+     datlist = dat_3.30.13)
+   expect_type(ctl_3.30.13, "list")
+   #check write control
+   if(file.exists(file.path(sim_3.30.13,"testctl.ss"))) {
+     file.remove(file.path(sim_3.30.13,"testctl.ss"))
+   }
+   SS_writectl_3.30(ctllist = ctl_3.30.13,
+                    verbose = FALSE,
+                    overwrite = FALSE,
+                    outfile = file.path(sim_3.30.13,"testctl.ss"))
+   expect_true(file.exists(file.path(sim_3.30.13,"testctl.ss")))
+ })
+
 test_that("SS_readctl and SS_writectl works for 3.24", {
   # read data file b/c necessary input to read control
   dat_3.24 <- SS_readdat(file.path(sim_3.24, "simple.dat"),
@@ -49,7 +108,7 @@ test_that("SS_readctl and SS_writectl works for 3.24", {
                          version = "3.24")
   expect_type(ctl_3.24, "list")
   #check write control
-  if(file.exists(file.path(sim_3.24,"testctl.ss"))){
+  if(file.exists(file.path(sim_3.24,"testctl.ss"))) {
     file.remove(file.path(sim_3.24,"testctl.ss"))
   }
   SS_writectl(ctllist = ctl_3.24,
@@ -58,6 +117,63 @@ test_that("SS_readctl and SS_writectl works for 3.24", {
               outfile = file.path(sim_3.24, "testctl.ss"))
   expect_true(file.exists(file.path(sim_3.24, "testctl.ss")))
 })
+
+test_that("SS_readctl and SS_writectl works for 3.24 when datlist = FALSE", {
+  # read data file b/c necessary input to read control
+  dat_3.24 <- SS_readdat(file.path(sim_3.24, "simple.dat"),
+                         verbose = FALSE, version = "3.24")
+  # read the control file
+  ctl_3.24 <- SS_readctl(file = file.path(sim_3.24, "simple.ctl"),
+                         verbose = FALSE,
+                         use_datlist = FALSE,
+                         nseas = dat_3.24[["nseas"]],
+                         N_areas = dat_3.24[["N_areas"]], 
+                         Nages = dat_3.24[["Nages"]], 
+                         Ngenders = dat_3.24[["Ngenders"]],
+                         Nfleet = dat_3.24[["Nfleet"]],
+                         Nsurveys = dat_3.24[["Nsurveys"]],
+                         N_CPUE_obs = dat_3.24[["N_cpue"]],
+                         version = "3.24")
+  expect_type(ctl_3.24, "list")
+  #check write control
+  if(file.exists(file.path(sim_3.24,"testctl.ss"))) {
+    file.remove(file.path(sim_3.24,"testctl.ss"))
+  }
+  SS_writectl(ctllist = ctl_3.24,
+              verbose = FALSE,
+              overwrite = TRUE,
+              outfile = file.path(sim_3.24, "testctl.ss"))
+  expect_true(file.exists(file.path(sim_3.24, "testctl.ss")))
+})
+
+test_that(paste0("SS_readctl_3.24, SS_writectl_3.24, SS_readdat_3.24, and ",
+                 " SS_writedat_3.24 works using funs directly"), {
+   # read data file b/c necessary input to read control
+   dat_3.24 <- SS_readdat_3.24(file.path(sim_3.24, "simple.dat"),
+                               verbose = FALSE)
+   # test write dat
+   if(file.exists(file.path(sim_3.24,"testdat.ss"))) {
+     file.remove(file.path(sim_3.24,"testdat.ss"))
+   }
+   SS_writedat_3.24(dat_3.24, file.path(sim_3.24, "testdat.ss"))
+   expect_true(file.exists(file.path(sim_3.24,"testdat.ss")))
+   # read the control file so that test can run on it
+   ctl_3.24 <- SS_readctl_3.24(
+     file.path(sim_3.24, "simple.ctl"),
+     verbose = FALSE,
+     use_datlist = TRUE,
+     datlist = dat_3.24)
+   expect_type(ctl_3.24, "list")
+   #check write control
+   if(file.exists(file.path(sim_3.24,"testctl.ss"))) {
+     file.remove(file.path(sim_3.24,"testctl.ss"))
+   }
+   SS_writectl_3.24(ctllist = ctl_3.24,
+                    verbose = FALSE,
+                    overwrite = FALSE,
+                    outfile = file.path(sim_3.24,"testctl.ss"))
+   expect_true(file.exists(file.path(sim_3.24,"testctl.ss")))
+ })
 
 #clean up
 unlink(tmp_path, recursive = TRUE)


### PR DESCRIPTION
Moved all code out of read/write wrapper files and into version specific functions. Unified variable names between data and control read/write with previous versions to avoid any compatibility issues. Also fixed a small bug in SR_parms in readctl_3.30 that had naming errors. (Note: naming convention issues with nseas, N_areas, and Ngenders remain but can be addressed in a later commit when we decide on a best option moving forward)