### PR TITLE
fix: readpar variable names write ctl overwrite

### DIFF
--- a/R/SS_readpar_3.30.R
+++ b/R/SS_readpar_3.30.R
@@ -21,29 +21,27 @@
 #' \code{\link{SS_writestarter}},
 #' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
 SS_readpar_3.30 <- function(parfile,datsource,ctlsource,verbose=TRUE){
-  par.file<-parfile
-  dat.source<-datlist
-  ctl.source<-ctllist
-  if(is.character(dat.source)){
-    datlist<-SS_readdat(file=dat.source,version="3.30",verbose=FALSE)
-  }else if(is.list(dat.source)){
-    datlist<-dat.source
+  
+  if(is.character(datsource)){
+    datlist<-SS_readdat(file=datsource,version="3.30",verbose=FALSE)
+  }else if(is.list(datsource)){
+    datlist<-datsource
   }else{
     stop("Reading parameter file contents requires a data file location or list object be specified")
   }
   
-  if(is.character(ctl.source)){
-    ctllist<-SS_readctl(file=ctl.source,use_datlist=TRUE,
+  if(is.character(ctlsource)){
+    ctllist<-SS_readctl(file=ctlsource,use_datlist=TRUE,
                         datlist=datlist)
-  }else if(is.list(ctl.source)){
-    ctllist<-ctl.source
+  }else if(is.list(ctlsource)){
+    ctllist<-ctlsource
   }else{
     stop("Reading parameter file contents requires a control file location or list object be specified")
   }
   
   # function to read Stock Synthesis parameter files
   if(verbose) cat("running SS_readpar_3.30\n")
-  parvals <- readLines(par.file,warn=FALSE)
+  parvals <- readLines(parfile,warn=FALSE)
   
   parlist <- list()
   parlist$headerlines <- parvals[1:3]

--- a/R/SS_writectl_3.30.R
+++ b/R/SS_writectl_3.30.R
@@ -16,8 +16,17 @@
 #' \code{\link{SS_writestarter}}, \code{\link{SS_writeforecast}},
 #' \code{\link{SS_writedat}}
 #' 
-SS_writectl_3.30 <- function(ctllist, outfile, overwrite, verbose) {
+SS_writectl_3.30 <- function(ctllist, outfile, overwrite=FALSE, verbose) {
   if(verbose) message("Running SS_writectl_3.30\n")
+  
+  if(file.exists(outfile)){
+    if(!overwrite){
+      cat("File exists and input 'overwrite'=FALSE:",outfile,"\n")
+      return()
+    }else{
+      file.remove(outfile)
+    }
+  }
   
   if(verbose) message("Opening connection to ", outfile, "\n")
   zz <- file(outfile, open = "at") #open = "at" means open for appending in text mode.

--- a/R/SS_writepar_3.30.R
+++ b/R/SS_writepar_3.30.R
@@ -20,6 +20,15 @@ SS_writepar_3.30 <- function(parlist, outfile, overwrite=TRUE, verbose=FALSE){
   # function to write Stock Synthesis parameter files
   if(verbose) cat("running SS_writepar_3.30\n")
   
+  if(file.exists(outfile)){
+    if(!overwrite){
+      cat("File exists and input 'overwrite'=FALSE:",outfile,"\n")
+      return()
+    }else{
+      file.remove(outfile)
+    }
+  }
+  
   if(verbose) message("Opening connection to ", outfile, "\n")
   zz <- file(outfile, open = "at") #open = "at" means open for appending in text mode.
   on.exit(close(zz)) # Needed in case the function exits early.


### PR DESCRIPTION
Fix a variable name issue in SS_readpar_3.30 and fix file overwrite function in control and par file writing functions for 3.30.