### PR TITLE
Revised comp output

### DIFF
--- a/R/SSMethod.Cond.TA1.8.R
+++ b/R/SSMethod.Cond.TA1.8.R
@@ -140,8 +140,8 @@ SSMethod.Cond.TA1.8 <-
         Intermediate[j,'Obsmn'] <- AbarNObs
         Intermediate[j,'Expmn'] <- AbarNPre
         Intermediate[j,'Varn'] <- AbarVarn
-        Intermediate[j,'N'] <- mean(subsubdbase$N)
-        Intermediate[j,'Resid'] <- (AbarNObs-AbarNPre)/sqrt(AbarVarn/mean(subsubdbase$N))
+        Intermediate[j,'N'] <- mean(subsubdbase$Nsamp_adj)
+        Intermediate[j,'Resid'] <- (AbarNObs-AbarNPre)/sqrt(AbarVarn/mean(subsubdbase$Nsamp_adj))
       }
     }
     Total <- sum(Intermediate[,'N'])

--- a/R/SSMethod.TA1.8.R
+++ b/R/SSMethod.TA1.8.R
@@ -194,7 +194,7 @@ SSMethod.TA1.8 <-
     pldat[i,'Obsmn'] <- sum(subdbase$Obs*xvar)/sum(subdbase$Obs)
     pldat[i,'Expmn'] <- sum(subdbase$Exp*xvar)/sum(subdbase$Exp)
     pldat[i,'semn'] <- sqrt((sum(subdbase$Exp*xvar^2)/sum(subdbase$Exp)-
-                             pldat[i,'Expmn']^2)/mean(subdbase$N))
+                             pldat[i,'Expmn']^2)/mean(subdbase$Nsamp_adj))
     pldat[i,'Obslo'] <- pldat[i,'Obsmn']-2*pldat[i,'semn']
     pldat[i,'Obshi'] <- pldat[i,'Obsmn']+2*pldat[i,'semn']
     pldat[i,'Std.res'] <- (pldat[i,'Obsmn']-pldat[i,'Expmn'])/pldat[i,'semn']

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -269,12 +269,12 @@ SS_output <-
     if(length(compend)==0) compend <- 999
     comptime <- findtime(comphead)
     if(is.null(comptime) || is.null(repfiletime)){
-      cat("problem comparing the file creation times:\n")
-      cat("  Report.sso:",repfiletime,"\n")
-      cat("  CompReport.sso:",comptime,"\n")
+      messages("problem comparing the file creation times:\n",
+               "  Report.sso:", repfiletime, "\n",
+               "  CompReport.sso:", comptime, "\n")
     }else{
       if(comptime != repfiletime){
-        cat("CompReport time:",comptime,"\n")
+        message("CompReport time:",comptime,"\n")
         stop(shortrepfile," and ",compfile," were from different model runs.")
       }
     }
@@ -286,7 +286,7 @@ SS_output <-
   }
 
   # read report file
-  if(verbose) cat("Reading full report file\n")
+  if(verbose) message("Reading full report file\n")
   flush.console()
 
   if(is.null(ncols)) ncols <- get_ncol(repfile)
@@ -674,10 +674,10 @@ SS_output <-
       endfile <- grep("End_comp_data",rawcompdbase[,1])
       compdbase <- rawcompdbase[2:(endfile-2),] # subtract header line and last 2 lines
 
-      # update to naming convention associated with 3.30.12
+      # update to naming convention associated with 3.30.12 (Nsamp_adj added in 3.30.15)
       compdbase <- df.rename(compdbase,
-                             oldnames=c("Pick_sex", "Pick_gender", "Gender"),
-                             newnames=c("Sexes",    "Sexes",       "Sex"))
+                             oldnames=c("Pick_sex", "Pick_gender", "Gender", "N"),
+                             newnames=c("Sexes",    "Sexes",       "Sex",    "Nsamp_adj"))
       # "Sexes" (formerly "Pick_sex" or "Pick_gender"):
       #         0 (unknown), 1 (female), 2 (male), or 3 (females and then males)
       # this is the user input in the data file

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -719,7 +719,7 @@ SS_output <-
       }
       compdbase$SuprPer[is.na(compdbase$SuprPer)] <- "No"
 
-      n <- sum(is.na(compdbase$N) & compdbase$Used!="skip" & compdbase$Kind!="TAG2")
+      n <- sum(is.na(compdbase$Nsamp_adj) & compdbase$Used!="skip" & compdbase$Kind!="TAG2")
       if(n>0){
         warning(n,"rows from composition database have NA sample size\n",
             "but are not part of a super-period. (Maybe input as N=0?)\n")
@@ -773,17 +773,17 @@ SS_output <-
         # older designation of ghost fleets from negative samp size to negative fleet
         lendbase    <- compdbase[compdbase$Kind=="LEN"  &
                                    (compdbase$SuprPer=="Sup" |
-                                      (!is.na(compdbase$N) & compdbase$N > 0)),]
+                                      (!is.na(compdbase$Nsamp_adj) & compdbase$Nsamp_adj > 0)),]
         sizedbase   <- compdbase[compdbase$Kind=="SIZE" &
                                    (compdbase$SuprPer=="Sup" |
-                                      (!is.na(compdbase$N) & compdbase$N > 0)),]
+                                      (!is.na(compdbase$Nsamp_adj) & compdbase$Nsamp_adj > 0)),]
         agedbase    <- compdbase[compdbase$Kind=="AGE"  &
                                    (compdbase$SuprPer=="Sup" |
-                                      (!is.na(compdbase$N) & compdbase$N > 0)) &
+                                      (!is.na(compdbase$Nsamp_adj) & compdbase$Nsamp_adj > 0)) &
                                         notconditional,]
         condbase    <- compdbase[compdbase$Kind=="AGE"  &
                                    (compdbase$SuprPer=="Sup" |
-                                      (!is.na(compdbase$N) & compdbase$N > 0)) &
+                                      (!is.na(compdbase$Nsamp_adj) & compdbase$Nsamp_adj > 0)) &
                                         conditional,]
       }
       ghostagedbase <- compdbase[compdbase$Kind=="AGE"  &
@@ -825,10 +825,10 @@ SS_output <-
         sizebinlist <- NA
       }
 
-      if(is.null(compdbase$N)){
+      if(is.null(compdbase$Nsamp_adj)){
         good <- TRUE
       }else{
-        good <- !is.na(compdbase$N)
+        good <- !is.na(compdbase$Nsamp_adj)
       }
       ladbase          <- compdbase[compdbase$Kind=="L@A" & good,]
       wadbase          <- compdbase[compdbase$Kind=="W@A" & good,]
@@ -1177,7 +1177,7 @@ SS_output <-
           }
           sub <- agedbase$Fleet == f
           agedbase$DM_effN[sub] <-
-            1 / (1+Theta) + agedbase$N[sub] * Theta / (1+Theta)
+            1 / (1+Theta) + agedbase$Nsamp_adj[sub] * Theta / (1+Theta)
         } # end test for D-M likelihood for this fleet
       } # end loop over fleets within agedbase
 
@@ -1193,7 +1193,7 @@ SS_output <-
           }
           sub <- lendbase$Fleet == f
           lendbase$DM_effN[sub] <-
-            1 / (1+Theta) + lendbase$N[sub] * Theta / (1+Theta)
+            1 / (1+Theta) + lendbase$Nsamp_adj[sub] * Theta / (1+Theta)
         } # end test for D-M likelihood for this fleet
       } # end loop over fleets within lendbase
 
@@ -1209,7 +1209,7 @@ SS_output <-
           }
           sub <- condbase$Fleet == f
           condbase$DM_effN[sub] <-
-            1 / (1+Theta) + condbase$N[sub] * Theta / (1+Theta)
+            1 / (1+Theta) + condbase$Nsamp_adj[sub] * Theta / (1+Theta)
         } # end test for D-M likelihood for this fleet
       } # end loop over fleets within condbase
     } # end test for whether CompReport.sso info is available
@@ -1631,7 +1631,7 @@ SS_output <-
     lenntune <- matchfun2("FIT_AGE_COMPS",-(nfleets+1),"FIT_AGE_COMPS",-1,cols=1:10,header=TRUE)
     names(lenntune)[10] <- "FleetName"
     # reorder columns (leaving out sample sizes perhaps to save space)
-    lenntune <- lenntune[lenntune$N>0, c(10,1,4:9)]
+    lenntune <- lenntune[lenntune$Nsamp_adj>0, c(10,1,4:9)]
     # avoid NA warnings by removing #IND values
     lenntune$"MeaneffN/MeaninputN"[lenntune$"MeaneffN/MeaninputN"=="-1.#IND"] <- NA
     lenntune <- type.convert(lenntune, as.is = TRUE)
@@ -1648,7 +1648,7 @@ SS_output <-
       lenntune <- type.convert(lenntune, as.is = TRUE)
     }else{
       # reorder columns (leaving out sample sizes perhaps to save space)
-      lenntune <- lenntune[lenntune$N>0, ]
+      lenntune <- lenntune[lenntune$Nsamp_adj>0, ]
       lenntune <- type.convert(lenntune, as.is = TRUE)
       ## new column "Recommend_Var_Adj" in 3.30 now matches calculation below
       #lenntune$"HarMean/MeanInputN" <- lenntune$"HarMean"/lenntune$"mean_inputN*Adj"
@@ -1707,7 +1707,7 @@ SS_output <-
   }else{
     if(!is.null(dim(agentune))){
       names(agentune)[ncol(agentune)] <- "Fleet_name"
-      agentune <- agentune[agentune$N>0, ]
+      agentune <- agentune[agentune$Nsamp_adj>0, ]
 
       # avoid NA warnings by removing #IND values
       agentune$"MeaneffN/MeaninputN"[agentune$"MeaneffN/MeaninputN"=="-1.#IND"] <- NA

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -475,34 +475,46 @@ SS_output <-
     get.def <- function(string){
       # function to grab numeric value from 2nd column matching string in 1st column
       row <- grep(string, rawdefs$X1)[1]
-      return(as.numeric(rawdefs[row, 2]))
+      if(length(row) > 0){
+        return(as.numeric(rawdefs[row, 2]))
+      }else{
+        return(NULL)
+      }
     }
     # apply function above to get a bunch of things
-    nseasons        <- get.def("N_seasons")
-    nsubseas        <- get.def("N_sub_seasons")
-    seasdurations   <- as.numeric(rawdefs[grep("Season_Durations", rawdefs$X1),
-                                          1+1:nseasons])
-    spawnmonth      <- get.def("Spawn_month")
-    spawnseas       <- get.def("Spawn_seas")
-    spawn_timing    <- get.def("Spawn_timing_in_season")
-    nareas          <- get.def("N_areas")
-    startyr         <- get.def("Start_year")
-    endyr           <- get.def("End_year")
-    Retro_year      <- get.def("Retro_year")
-    N_forecast_yrs  <- get.def("N_forecast_yrs")
-    nsexes          <- get.def("N_sexes")
-    accuage <- Max_age <- get.def("Max_age")
-    use_wtatage     <- get.def("Empirical_wt_at_age(0,1)")
-    N_bio_patterns  <- get.def("N_bio_patterns")
-    N_platoons      <- get.def("N_platoons")
-    Start_from_par  <- get.def("Start_from_par(0,1)")
-    Do_all_priors   <- get.def("Do_all_priors(0,1)")
-    Use_softbound   <- get.def("Use_softbound(0,1)")
-    N_nudata        <- get.def("N_nudata")
-    Max_phase       <- get.def("Max_phase")
-    Current_phase   <- get.def("Current_phase")
-    Jitter          <- get.def("Jitter")
-    ALK_tolerance   <- get.def("ALK_tolerance")
+    # in some cases, duplicate names are used for backward compatibility
+    N_seasons         <- nseasons       <- get.def("N_seasons")
+    N_sub_seasons                       <- get.def("N_sub_seasons")
+    Season_Durations  <- seasdurations  <- as.numeric(rawdefs[grep("Season_Durations",
+                                                                   rawdefs$X1),
+                                                              1+1:nseasons])
+    Spawn_month       <- spawnmonth     <- get.def("Spawn_month")
+    Spawn_seas        <- spawnseas      <- get.def("Spawn_seas")
+    Spawn_timing_in_season              <- get.def("Spawn_timing_in_season")
+    N_areas           <- nareas         <- get.def("N_areas")
+    Start_year        <- startyr        <- get.def("Start_year")
+    End_year          <- endyr          <- get.def("End_year")
+    Retro_year                          <- get.def("Retro_year")
+    N_forecast_yrs                      <- get.def("N_forecast_yrs")
+    N_sexes           <- nsexes         <- get.def("N_sexes")
+    Max_age           <- accuage        <- get.def("Max_age")
+    Empirical_wt_at_age                 <- get.def("Empirical_wt_at_age")
+    N_bio_patterns                      <- get.def("N_bio_patterns")
+    N_platoons                          <- get.def("N_platoons")
+    # following quants added in 3.30.13
+    NatMort_option                      <- get.def("NatMort")
+    GrowthModel_option                  <- get.def("GrowthModel")
+    Maturity_option                     <- get.def("Maturity")
+    Fecundity_option                    <- get.def("Fecundity")
+    # end quants added in 3.30.13
+    Start_from_par                      <- get.def("Start_from_par")
+    Do_all_priors                       <- get.def("Do_all_priors")
+    Use_softbound                       <- get.def("Use_softbound")
+    N_nudata                            <- get.def("N_nudata")
+    Max_phase                           <- get.def("Max_phase")
+    Current_phase                       <- get.def("Current_phase")
+    Jitter                              <- get.def("Jitter")
+    ALK_tolerance                       <- get.def("ALK_tolerance")
     # table starting with final occurrence of "Fleet" in column 1
     fleetdefs <- rawdefs[tail(grep("Fleet", rawdefs$X1),1):nrow(rawdefs),]
     names(fleetdefs) <- fleetdefs[1,] # set names equal to first row
@@ -1658,7 +1670,7 @@ SS_output <-
                               which(names(lenntune) %in% end.names))]
     }
   }
-  stats$Length_comp_Eff_N_tuning_check <- lenntune
+  stats$Length_Comp_Fit_Summary <- lenntune
 
   ## FIT_AGE_COMPS
   if(SS_versionNumeric < 3.3){
@@ -1708,7 +1720,7 @@ SS_output <-
       agentune$Recommend_Var_Adj <-
         agentune$Var_Adj * agentune$"HarMean(effN)/mean(inputN*Adj)"
 
-      # remove distracting columns
+      # remove distracting columns (no longer present in recent versions of SS)
       badnames <- c("mean_effN","Mean(effN/inputN)","MeaneffN/MeaninputN")
       agentune <- agentune[,!names(agentune) %in% badnames]
 
@@ -1724,7 +1736,7 @@ SS_output <-
       agentune <- NULL
     }
   }
-  stats$Age_comp_Eff_N_tuning_check <- agentune
+  stats$Age_Comp_Fit_Summary <- agentune
 
   ## FIT_SIZE_COMPS
   fit_size_comps <- NULL
@@ -1772,7 +1784,7 @@ SS_output <-
         names(sizentune) <- sizentune[1,]
         sizentune <- sizentune[sizentune$Factor==7,]
         sizentune <- type.convert(sizentune, as.is = TRUE)
-        stats$Size_comp_Eff_N_tuning_check <- sizentune
+        stats$Size_Comp_Fit_Summary <- sizentune
         # format fit_size_comps: remove extra rows, make numeric
         fit_size_comps <- fit_size_comps[fit_size_comps$Fleet_Name %in% FleetNames,]
       } # end check for non-empty fit_size_comps
@@ -1852,9 +1864,9 @@ SS_output <-
   # section that were added with SS version 3.30.12
   return.def <- function(x){
     if(exists(x)){
-      returndat[[x]] <- get(x)
+      get(x)
     }else{
-      returndat[[x]] <- NULL
+      NULL
     }
   }
 
@@ -1884,24 +1896,28 @@ SS_output <-
   returndat$endyr       <- endyr
   returndat$nseasons    <- nseasons
   returndat$seasfracs   <- seasfracs
-  returndat$seasdurations  <- seasdurations
-  return.def("N_sub_seasons")
-  return.def("Spawn_month")
-  return.def("Spawn_seas")
-  return.def("Spawn_timing_in_season")
-  return.def("Retro_year")
-  return.def("N_forecast_yrs")
-  return.def("Empirical_wt_at_age(0,1)")
-  return.def("N_bio_patterns")
-  return.def("N_platoons")
-  return.def("Start_from_par(0,1)")
-  return.def("Do_all_priors(0,1)")
-  return.def("Use_softbound(0,1)")
-  return.def("N_nudata")
-  return.def("Max_phase")
-  return.def("Current_phase")
-  return.def("Jitter")
-  return.def("ALK_tolerance")
+  returndat$seasdurations <- seasdurations
+  returndat$N_sub_seasons <- return.def("N_sub_seasons")
+  returndat$Spawn_month   <- return.def("Spawn_month")
+  returndat$Spawn_seas    <- return.def("Spawn_seas")
+  returndat$Spawn_timing_in_season <- return.def("Spawn_timing_in_season")
+  returndat$Retro_year     <- return.def("Retro_year")
+  returndat$N_forecast_yrs <- return.def("N_forecast_yrs")
+  returndat$Empirical_wt_at_age <- return.def("Empirical_wt_at_age")
+  returndat$N_bio_patterns <- return.def("N_bio_patterns")
+  returndat$N_platoons     <- return.def("N_platoons")
+  returndat$NatMort_option <- return.def("NatMort_option")
+  returndat$GrowthModel_option <- return.def("GrowthModel_option")
+  returndat$Maturity_option  <- return.def("Maturity_option")
+  returndat$Fecundity_option <- return.def("Fecundity_option")
+  returndat$Start_from_par <- return.def("Start_from_par")
+  returndat$Do_all_priors  <- return.def("Do_all_priors")
+  returndat$Use_softbound  <- return.def("Use_softbound")
+  returndat$N_nudata       <- return.def("N_nudata")
+  returndat$Max_phase      <- return.def("Max_phase")
+  returndat$Current_phase  <- return.def("Current_phase")
+  returndat$Jitter         <- return.def("Jitter")
+  returndat$ALK_tolerance  <- return.def("ALK_tolerance")
   returndat$nforecastyears <- nforecastyears
   returndat$morph_indexing <- morph_indexing
 #  returndat$MGParm_dev_details <- MGParm_dev_details

--- a/R/SS_plots.R
+++ b/R/SS_plots.R
@@ -1211,7 +1211,9 @@ SS_plots <-
     #
     igroup <- 20
     if(igroup %in% plot){
-      if(verbose) cat("Starting mean length-at-age and mean weight-at-age plots (group ",igroup,")\n",sep="")
+      if(verbose){
+        message("Starting mean length-at-age and mean weight-at-age plots (group ",igroup,")")
+      }
       if(datplot){
         # data-only plot of mean length at age
         plotinfo <-

--- a/R/SS_tune_comps.R
+++ b/R/SS_tune_comps.R
@@ -66,14 +66,14 @@ SS_tune_comps <- function(replist, fleets='all', option="Francis",
       if(verbose) message("calculating ",type," tunings for fleet ",fleet,"\n")
       if(type=="len"){
         # table of info from SS
-        tunetable <- replist$Length_comp_Eff_N_tuning_check
+        tunetable <- replist$Length_Comp_Fit_Summary
         Factor <- 4 # code for Control file
         has_marginal <- fleet %in% replist$lendbase$Fleet
         has_conditional <- FALSE
       }
       if(type=="age"){
         # table of info from SS
-        tunetable <- replist$Age_comp_Eff_N_tuning_check
+        tunetable <- replist$Age_Comp_Fit_Summary
         Factor <- 5 # code for Control file
         has_marginal <- fleet %in% replist$agedbase$Fleet
         has_conditional <- fleet %in% replist$condbase$Fleet
@@ -179,7 +179,7 @@ SS_tune_comps <- function(replist, fleets='all', option="Francis",
   rownames(tuning_table) <- 1:nrow(tuning_table)
 
   # stuff related to generalized size frequency data
-  tunetable_size <- replist$Size_comp_Eff_N_tuning_check
+  tunetable_size <- replist$Size_Comp_Fit_Summary
   if(!is.null(tunetable_size)){
     warning("\n  Generalized size composition data doesn't have\n",
             "  Francis weighting available and the table of tunings\n",

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -199,16 +199,20 @@ function(replist, plot = TRUE, print = FALSE, add = FALSE,
     Grow_std <- NULL
   }else{
     # convert things like "Grow_std_1_Fem_A_25" into
+    #  in more recent 3.30.14 versions, the label appears as
+    #                     "Grow_std_GP:_1_Fem_A_25"
+    # so the "shift" below = 0 or 1 to adjust the position accordingly
     # "pattern 1, female, age 25"
     Grow_std$pattern <- NA
     Grow_std$sex_char <- NA
     Grow_std$sex <- NA
     Grow_std$age <- NA
+    shift <- length(grep("GP:", Grow_std$Label[1]))
     for(irow in 1:nrow(Grow_std)){
       tmp <- strsplit(Grow_std$Label[irow], split="_")[[1]]
-      Grow_std$pattern[irow] <- as.numeric(tmp[3])
-      Grow_std$sex_char[irow] <- tmp[4]
-      Grow_std$age[irow] <- as.numeric(tmp[6])
+      Grow_std$pattern[irow] <- as.numeric(tmp[3 + shift])
+      Grow_std$sex_char[irow] <- tmp[4 + shift]
+      Grow_std$age[irow] <- as.numeric(tmp[6 + shift])
     }
     Grow_std$sex[Grow_std$sex_char=="Fem"] <- 1
     Grow_std$sex[Grow_std$sex_char=="Mal"] <- 2

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -206,9 +206,9 @@ function(replist, plot = TRUE, print = FALSE, add = FALSE,
     Grow_std$age <- NA
     for(irow in 1:nrow(Grow_std)){
       tmp <- strsplit(Grow_std$Label[irow], split="_")[[1]]
-      Grow_std$pattern[irow] <- as.numeric(tmp[4])
-      Grow_std$sex_char[irow] <- tmp[5]
-      Grow_std$age[irow] <- as.numeric(tmp[7])
+      Grow_std$pattern[irow] <- as.numeric(tmp[3])
+      Grow_std$sex_char[irow] <- tmp[4]
+      Grow_std$age[irow] <- as.numeric(tmp[6])
     }
     Grow_std$sex[Grow_std$sex_char=="Fem"] <- 1
     Grow_std$sex[Grow_std$sex_char=="Mal"] <- 2
@@ -221,7 +221,7 @@ function(replist, plot = TRUE, print = FALSE, add = FALSE,
     ## Grow_std_GP:_1_Fem_A_5      NA       1      Fem   1   5
   }
 
-  # get any derived quantities related to growth curve uncertainty
+  # get any derived quantities related to M uncertainty
   NatM_std <- replist$derived_quants[grep("NatM_std_", replist$derived_quants$Label),]
   if(nrow(NatM_std)==0){
     NatM_std <- NULL
@@ -741,8 +741,16 @@ function(replist, plot = TRUE, print = FALSE, add = FALSE,
          yaxs='i', ylim=c(0,1.0*lab1max),
          axes=FALSE)
     # add line for lab1 vs. Age
-    lines(growdatF$Age_Beg, growdatF[[lab1]], col=colvec[col_index1],
-          lwd=1, lty='12')
+    if(option == 1){
+      lines(growdatF$Age_Beg, growdatF[[lab1]], col=colvec[col_index1],
+            lwd=1, lty='12')
+    }
+    if(option == 2){
+      # maturity curve is product of age-based and length-based factors
+      lines(growdatF$Age_Beg, growdatF[["Len_Mat"]] * growdatF[["Age_Mat"]],
+            col=colvec[col_index1], lwd=1, lty='12')
+    }
+    
     # add line for lab2 vs. Age
     lines(growdatF$Age_Beg, growdatF[[lab2]]*lab2_to_lab1_scale, col=colvec[col_index1],
           lwd=3)
@@ -767,7 +775,9 @@ function(replist, plot = TRUE, print = FALSE, add = FALSE,
 
     # restore default single panel settings
     par(mfcol=par_old$mfcol, mar=par_old$mar, oma=par_old$oma)
-  }
+  } # end growth_curve_plus_fn()
+
+  
   # make plots of growth curve with CV and SD of length
   if(plot & 2 %in% subplots & !wtatage_switch){
     growth_curve_plus_fn(option=1)

--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -381,7 +381,7 @@ SSplotComps <-
     }
   }
   if(kind=="L@A"){
-    dbase_kind <- ladbase[ladbase$N!=0,] # remove values with 0 sample size
+    dbase_kind <- ladbase[ladbase$Nsamp_adj!=0,] # remove values with 0 sample size
     kindlab=labels[2]
     if(datonly){
       filenamestart <- "comp_LAAdat_"
@@ -393,7 +393,7 @@ SSplotComps <-
     dbase_kind$SD <- dbase_kind$Lbin_lo/dbase_kind$N
   }
   if(kind=="W@A"){
-    dbase_kind <- wadbase[wadbase$N!=0,] # remove values with 0 sample size
+    dbase_kind <- wadbase[wadbase$Nsamp_adj!=0,] # remove values with 0 sample size
     kindlab=labels[2]
     if(datonly){
       filenamestart <- "comp_WAAdat_"
@@ -520,7 +520,7 @@ SSplotComps <-
                 # Dirichlet-Multinomial likelihood
                 make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,
                               linesx=dbase$Bin,linesy=dbase$Exp,
-                              sampsize=dbase$N,
+                              sampsize=dbase$Nsamp_adj,
                               effN=dbase$DM_effN,
                               showsampsize=showsampsize,showeffN=showeffN,
                               sampsize_label="N input=",
@@ -539,7 +539,7 @@ SSplotComps <-
                 # standard multinomial likelihood
                 make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,
                               linesx=dbase$Bin,linesy=dbase$Exp,
-                              sampsize=dbase$N,effN=dbase$effN,
+                              sampsize=dbase$Nsamp_adj,effN=dbase$effN,
                               showsampsize=showsampsize,showeffN=showeffN,
                               sampsize_label="N adj.=",
                               effN_label="N eff.=",
@@ -557,7 +557,7 @@ SSplotComps <-
             }
             if(kind=="GSTAGE"){
               make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-                            sampsize=dbase$N,effN=dbase$effN,
+                            sampsize=dbase$Nsamp_adj,effN=dbase$effN,
                             showsampsize=FALSE,showeffN=FALSE,
                             bars=bars,linepos=(1-datonly)*linepos,
                             nlegends=3,legtext=list(dbase$YrSeasName,"sampsize","effN"),
@@ -571,7 +571,7 @@ SSplotComps <-
             }
             if(kind=="GSTLEN"){
               make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-                            sampsize=dbase$N,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
+                            sampsize=dbase$Nsamp_adj,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
                             bars=bars,linepos=(1-datonly)*linepos,
                             nlegends=3,legtext=list(dbase$YrSeasName,"sampsize","effN"),
                             main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=labels[6],
@@ -585,7 +585,7 @@ SSplotComps <-
             if(kind %in% c("L@A","W@A")){
               make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
                             ptsSD=dbase$SD,
-                            sampsize=dbase$N,effN=0,showsampsize=FALSE,showeffN=FALSE,
+                            sampsize=dbase$Nsamp_adj,effN=0,showsampsize=FALSE,showeffN=FALSE,
                             nlegends=1,legtext=list(dbase$YrSeasName),
                             bars=bars,linepos=(1-datonly)*linepos,
                             main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=ifelse(kind=="W@A",labels[9],labels[1]),
@@ -657,7 +657,7 @@ SSplotComps <-
         if(datonly){
           z <- dbase$Obs
           if(scalebubbles){
-            z <- dbase$N*dbase$Obs # if requested, scale by sample sizes
+            z <- dbase$Nsamp_adj*dbase$Obs # if requested, scale by sample sizes
           }
           col <- rep("black",2)
           titletype <- titledata
@@ -782,10 +782,10 @@ SSplotComps <-
           effNline.old <- effNline
           if(is.logical(sampsizeline) && sampsizeline){
             # scaling when displaying only adjusted input sample size
-            sampsizeline <- max(dbase$Bin)/max(dbase$N,na.rm=TRUE)
+            sampsizeline <- max(dbase$Bin)/max(dbase$Nsamp_adj,na.rm=TRUE)
             if(!datonly && is.logical(effNline) && effNline){
               # scaling when displaying both input and effective
-              sampsizeline <- effNline  <- max(dbase$Bin)/max(dbase$N,dbase$effN,na.rm=TRUE)
+              sampsizeline <- effNline  <- max(dbase$Bin)/max(dbase$Nsamp_adj,dbase$effN,na.rm=TRUE)
               cat("  Fleet ",f," ",titlesex,"adj. input & effective N in red & green scaled by ",effNline,"\n",sep="")
             }else{
               cat("  Fleet ",f," ",titlesex,"adj. input N in red scaled by ",sampsizeline,"\n",sep="")
@@ -799,7 +799,7 @@ SSplotComps <-
             cols <- colvec[col.index]
             yrvec <- dbase$Yr.S + dbase$sex*1e-6
             make_multifig(ptsx=dbase$Bin,ptsy=dbase$Lbin_mid,yr=yrvec,size=z,
-                          sampsize=dbase$N,showsampsize=showsampsize,effN=dbase$effN,
+                          sampsize=dbase$Nsamp_adj,showsampsize=showsampsize,effN=dbase$effN,
                           showeffN=FALSE,
                           cexZ1=cexZ1,
                           bublegend=bublegend,
@@ -861,7 +861,7 @@ SSplotComps <-
                 tempfun4 <- function(ipage,...){ # temporary function to aid repeating the big function call
                   make_multifig(ptsx=ydbase$Bin,ptsy=ydbase$Obs,yr=ydbase$Lbin_lo,
                                 linesx=ydbase$Bin,linesy=ydbase$Exp,
-                                sampsize=ydbase$N,effN=ydbase$effN,showsampsize=showsampsize,showeffN=showeffN,
+                                sampsize=ydbase$Nsamp_adj,effN=ydbase$effN,showsampsize=showsampsize,showeffN=showeffN,
                                 nlegends=3,legtext=list(lenbinlegend,"sampsize","effN"),
                                 bars=FALSE,linepos=linepos,main=ptitle,cex.main=cex.main,
                                 xlab=labels[2],ylab=labels[6],maxrows=maxrows,maxcols=maxcols,rows=rows,cols=cols,
@@ -966,7 +966,7 @@ SSplotComps <-
                 titles <- c(ptitle,titles) # compiling list of all plot titles
                 tempfun6 <- function(ipage,...){ # temporary function to aid repeating the big function call
                   make_multifig(ptsx=abindbase$Bin,ptsy=abindbase$Obs,yr=abindbase$Yr.S,linesx=abindbase$Bin,linesy=abindbase$Exp,
-                                sampsize=abindbase$N,effN=abindbase$effN,showsampsize=showsampsize,showeffN=showeffN,
+                                sampsize=abindbase$Nsamp_adj,effN=abindbase$effN,showsampsize=showsampsize,showeffN=showeffN,
                                 nlegends=3,legtext=list(abindbase$YrSeasName,"sampsize","effN"),
                                 bars=bars,linepos=(1-datonly)*linepos,
                                 main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=labels[6],
@@ -1353,10 +1353,10 @@ SSplotComps <-
 
           Bins <- sort(unique(dbase$Bin))
           nbins <- length(Bins)
-          df <- data.frame(N=dbase$N,
+          df <- data.frame(N=dbase$Nsamp_adj,
                            effN=dbase$effN,
-                           obs=dbase$Obs*dbase$N,
-                           exp=dbase$Exp*dbase$N)
+                           obs=dbase$Obs*dbase$Nsamp_adj,
+                           exp=dbase$Exp*dbase$Nsamp_adj)
           if("DM_effN" %in% names(dbase) && any(!is.na(dbase$DM_effN))){
             df$DM_effN <- dbase$DM_effN
           }
@@ -1469,7 +1469,7 @@ SSplotComps <-
             # haven't configured this aggregated plot for other types
             ## if(kind=="GSTAGE"){
             ##   make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-            ##                 sampsize=dbase$N,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
+            ##                 sampsize=dbase$Nsamp_adj,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
             ##                 bars=bars,linepos=(1-datonly)*linepos,
             ##                 nlegends=3,legtext=list(dbase$YrSeasName,"sampsize","effN"),
             ##                 main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=labels[6],
@@ -1478,7 +1478,7 @@ SSplotComps <-
             ## }
             ## if(kind %in% c("L@A","W@A")){
             ##   make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-            ##                 sampsize=dbase$N,effN=0,showsampsize=FALSE,showeffN=FALSE,
+            ##                 sampsize=dbase$Nsamp_adj,effN=0,showsampsize=FALSE,showeffN=FALSE,
             ##                 nlegends=1,legtext=list(dbase$YrSeasName),
             ##                 bars=bars,linepos=(1-datonly)*linepos,
             ##                 main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=ifelse(kind=="W@A",labels[9],labels[1]),
@@ -1552,10 +1552,10 @@ SSplotComps <-
 
             Bins <- sort(unique(dbase$Bin))
             nbins <- length(Bins)
-            df <- data.frame(N=dbase$N,
+            df <- data.frame(N=dbase$Nsamp_adj,
                              effN=dbase$effN,
-                             obs=dbase$Obs*dbase$N,
-                             exp=dbase$Exp*dbase$N)
+                             obs=dbase$Obs*dbase$Nsamp_adj,
+                             exp=dbase$Exp*dbase$Nsamp_adj)
             agg <- aggregate(x=df, by=list(bin=dbase$Bin,f=dbase$Fleet,s=dbase$Seas), FUN=sum)
             agg <- agg[agg$f %in% fleets,]
             if(any(agg$s<=0)){
@@ -1601,7 +1601,7 @@ SSplotComps <-
          # haven't configured this aggregated plot for other types
               ## if(kind=="GSTAGE"){
               ##   make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-              ##                 sampsize=dbase$N,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
+              ##                 sampsize=dbase$Nsamp_adj,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
               ##                 bars=bars,linepos=(1-datonly)*linepos,
               ##                 nlegends=3,legtext=list(dbase$YrSeasName,"sampsize","effN"),
               ##                 main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=labels[6],
@@ -1610,7 +1610,7 @@ SSplotComps <-
               ## }
               ## if(kind %in% c("L@A","W@A")){
               ##   make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-              ##                 sampsize=dbase$N,effN=0,showsampsize=FALSE,showeffN=FALSE,
+              ##                 sampsize=dbase$Nsamp_adj,effN=0,showsampsize=FALSE,showeffN=FALSE,
               ##                 nlegends=1,legtext=list(dbase$YrSeasName),
               ##                 bars=bars,linepos=(1-datonly)*linepos,
               ##                 main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=ifelse(kind=="W@A",labels[9],labels[1]),
@@ -1692,10 +1692,10 @@ SSplotComps <-
 
               Bins <- sort(unique(dbase$Bin))
               nbins <- length(Bins)
-              df <- data.frame(N=dbase$N,
+              df <- data.frame(N=dbase$Nsamp_adj,
                                effN=dbase$effN,
-                               obs=dbase$Obs*dbase$N,
-                               exp=dbase$Exp*dbase$N)
+                               obs=dbase$Obs*dbase$Nsamp_adj,
+                               exp=dbase$Exp*dbase$Nsamp_adj)
               agg <- aggregate(x=df, by=list(bin=dbase$Bin,f=dbase$Fleet,y=floor(dbase$Yr.S)), FUN=sum)
               agg <- agg[agg$f %in% fleets,]
               agg$obs <- agg$obs/agg$N
@@ -1744,7 +1744,7 @@ SSplotComps <-
                 # haven't configured this aggregated plot for other types
                 ## if(kind=="GSTAGE"){
                 ##   make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-                ##                 sampsize=dbase$N,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
+                ##                 sampsize=dbase$Nsamp_adj,effN=dbase$effN,showsampsize=FALSE,showeffN=FALSE,
                 ##                 bars=bars,linepos=(1-datonly)*linepos,
                 ##                 nlegends=3,legtext=list(dbase$YrSeasName,"sampsize","effN"),
                 ##                 main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=labels[6],
@@ -1753,7 +1753,7 @@ SSplotComps <-
                 ## }
                 ## if(kind %in% c("L@A","W@A")){
                 ##   make_multifig(ptsx=dbase$Bin,ptsy=dbase$Obs,yr=dbase$Yr.S,linesx=dbase$Bin,linesy=dbase$Exp,
-                ##                 sampsize=dbase$N,effN=0,showsampsize=FALSE,showeffN=FALSE,
+                ##                 sampsize=dbase$Nsamp_adj,effN=0,showsampsize=FALSE,showeffN=FALSE,
                 ##                 nlegends=1,legtext=list(dbase$YrSeasName),
                 ##                 bars=bars,linepos=(1-datonly)*linepos,
                 ##                 main=ptitle,cex.main=cex.main,xlab=kindlab,ylab=ifelse(kind=="W@A",labels[9],labels[1]),
@@ -1925,7 +1925,7 @@ SSplotComps <-
           # determine bubble size and colors
           if(datonly){
             z <- dbase$Obs
-            if(scalebubbles) z <- dbase$N*dbase$Obs # if requested, scale by sample sizes
+            if(scalebubbles) z <- dbase$Nsamp_adj*dbase$Obs # if requested, scale by sample sizes
             titletype <- titledata
             filetype <- "bub"
             allopen <- TRUE

--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -1018,7 +1018,7 @@ SSplotComps <-
             if(nrow(dbasegood)>0){
               # thinning out columns and removing rows with redundant information
               # (for the purposes of this function)
-              dbasegood2 <- dbasegood[,c("YrSeasName","N","effN")]
+              dbasegood2 <- dbasegood[,c("YrSeasName","Nsamp_adj","effN")]
               dbasegood2 <- unique(dbasegood2)
               plot(dbasegood2$N,dbasegood2$effN,xlab=labels[4],main=ptitle,
                    cex.main=cex.main,

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -216,7 +216,7 @@ SSplotData <- function(replist,
           }
           if(typename %in% c("lendbase", "sizedbase", "agedbase")){
             # aggregate sample sizes by year
-            dat.agg <- aggregate(dat.f$N, by=list(dat.f$Yr), FUN=sum)
+            dat.agg <- aggregate(dat.f$Nsamp_adj, by=list(dat.f$Yr), FUN=sum)
             allyrs <- dat.agg$Group.1
             size <- dat.agg$x
           }
@@ -238,7 +238,7 @@ SSplotData <- function(replist,
             # check for observations within this fleet
             if(nrow(dat.sub) > 0){
               # aggregate sample sizes by year
-              dat.agg <- aggregate(dat.sub$N, by=list(dat.sub$Yr), FUN=sum)
+              dat.agg <- aggregate(dat.sub$Nsamp_adj, by=list(dat.sub$Yr), FUN=sum)
               allyrs <- dat.agg$Group.1
               size <- dat.agg$x
             }
@@ -267,7 +267,7 @@ SSplotData <- function(replist,
             dat.f <- dat.f[dat.f$Used == "yes",]
             if(nrow(dat.f) > 0){ # skip of all values are excluded
               # aggregate sample sizes by year
-              dat.agg <- aggregate(dat.f$N, by=list(dat.f$Yr), FUN=sum)
+              dat.agg <- aggregate(dat.f$Nsamp_adj, by=list(dat.f$Yr), FUN=sum)
               allyrs <- dat.agg$Group.1
               size <- dat.agg$x
             }

--- a/R/make_multifig_sexratio.R
+++ b/R/make_multifig_sexratio.R
@@ -117,9 +117,9 @@ make_multifig_sexratio <-
       lwr <- NA
       upr <- NA
       if(nm == 1 & nf == 0){
-        effN <- male$effN; N <- male$N; e <- NA; o <- 0
+        effN <- male$effN; Nsamp_adj <- male$Nsamp_adj; e <- NA; o <- 0
       } else if(nm == 0 & nf == 1) {
-        effN <- female$effN; N <- female$N; e <- NA; o <- Inf
+        effN <- female$effN; Nsamp_adj <- female$Nsamp_adj; e <- NA; o <- Inf
       } else if(nrow(female)==1 & nrow(male)==1){
         ## Calculate the ratio if data exists for both. Use delta method for
         ## multinomial estimators to get approximate SE for the ratio of the
@@ -130,7 +130,7 @@ make_multifig_sexratio <-
         # sample size is shared across both vectors (at least if Sexes==3)
         # IGT 2019-05-02: should check for case where sexes are input separately
         effN <- female$effN
-        N <- female$N
+        Nsamp_adj <- female$Nsamp_adj
         if(sexratio.option == 1){ # females:males
           e <- (female$Exp - minobs)/(male$Exp - minobs)
           o <- (female$Obs - minobs)/(male$Obs - minobs)
@@ -148,14 +148,14 @@ make_multifig_sexratio <-
         # calculate SE of the ratio
         if(sexratio.option == 1){ # females:males
           se.ratio <-
-            sqrt((pf/pm)^2*( (1-pf)/(pf*N) + (1-pm)/(pm*N) +2/N ))
+            sqrt((pf/pm)^2*( (1-pf)/(pf*Nsamp_adj) + (1-pm)/(pm*Nsamp_adj) +2/Nsamp_adj ))
           lwr <- qnorm((1 - CI)/2, o, se.ratio)
           upr <- qnorm(1 - (1 - CI)/2, o, se.ratio)
         }
         if(sexratio.option == 2){ # female:total
           pt <- female$Obs + male$Obs - 2*minobs
           # assuming sample size for this bin is at least 1
-          Nbin <- max(pt*N, 1)
+          Nbin <- max(pt*Nsamp_adj, 1)
           if(pt > 0){
             # Jeffreys interval
             # https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Jeffreys_interval
@@ -184,10 +184,10 @@ make_multifig_sexratio <-
         lwr[pf == 0 & pm == 0] <- NA
         upr[pf == 0 & pm == 0] <- NA
       } else {
-        o <- e <- se.ratio <- lwr <- upr <- effN <- N <- NA
+        o <- e <- se.ratio <- lwr <- upr <- effN <- Nsamp_adj <- NA
       }
       df.list[[k]] <- data.frame(Yr=yr.temp, Bin=bin, Exp=e, Obs=o,
-                                 lwr=lwr, upr=upr, effN=effN, N=N)
+                                 lwr=lwr, upr=upr, effN=effN, Nsamp_adj=Nsamp_adj)
       k <- k+1
     }
   }
@@ -279,7 +279,8 @@ make_multifig_sexratio <-
         ## all rows should be same so grab first
         text_i <- paste0('effN=', round(df2$effN[1], sampsizeround))
       } else if(legtext_i == "N" & nrow(df2)>0){
-        text_i <- paste0('N=', round(df2$N[1], sampsizeround)) # all rows should be same so grab first
+        # all rows should be same so grab first
+        text_i <- paste0('N=', round(df2$Nsamp_adj[1], sampsizeround)) 
       } else {
         text_i <- ''
       }


### PR DESCRIPTION
Merging a branch which includes changes related to the following elements of the upcoming release of SS version 3.30.15 which has changes in the output related to length and age composition data including:
- sample size column `N` in tables within Report.sso and CompReport.sso replaced by `Nsamp_adj` and a new `Nsamp_in` column showing the unadjusted input sample size has been added
- a new `Nsamp_DM` table has been added to the `FIT_AGE_COMPS` table (`$age_comp_fit_table`) and corresponding tables for length comps showing the estimated sample size associated with the Dirichlet-Multinomial likelihood. These values aren't yet being utilized in the figures to replace the internal calculations discussed at https://github.com/r4ss/r4ss/issues/129.

The tables with names like `$Age_comp_Eff_N_tuning_check` have now been changed to $Age_Comp_Fit_Summary to match the names used in Report.sso although a larger renaming as discussed in #233 hasn't happened yet.