### PR TITLE
Fixes and improve SS_readctl_3.24

### DIFF
--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -476,6 +476,20 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
                                 comments=MGparmLabel)
     ctllist$MG_parms<-cbind(ctllist$MG_parms,PType)
 
+    
+  # environmental linkage lines
+  if(any(ctllist$MG_parms$env_var > 0)) {
+    ctllist <- add_elem(ctllist, "read_MG_custom_env_var")
+    if(ctllist$read_MG_custom_env_var == 1) {
+      tmp_nrow <- length(ctllist$MG_parms$env_var[ctllist$MG_parms$env_var > 0])
+      tmp_lab <- paste0("MG_env_var_", seq_len(tmp_nrow))
+      ctllist <- add_df(ctllist, name = "MG_custom_env_var", nrow = tmp_nrow,
+                      ncol = length(srt_par_colnames),
+                      col.names = srt_par_colnames, 
+                      comments = tmp_lab)
+    }
+  }
+
   # time block parameters
   nbp<-0
   cnt<-1

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -478,10 +478,10 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
 
     
   # environmental linkage lines
-  if(any(ctllist$MG_parms$env_var > 0)) {
+  if(any(ctllist$MG_parms$env_var != 0)) {
     ctllist <- add_elem(ctllist, "read_MG_custom_env_var")
     if(ctllist$read_MG_custom_env_var == 1) {
-      tmp_nrow <- length(ctllist$MG_parms$env_var[ctllist$MG_parms$env_var > 0])
+      tmp_nrow <- length(ctllist$MG_parms$env_var[ctllist$MG_parms$env_var != 0])
       tmp_lab <- paste0("MG_env_var_", seq_len(tmp_nrow))
       ctllist <- add_df(ctllist, name = "MG_custom_env_var", nrow = tmp_nrow,
                       ncol = length(srt_par_colnames),
@@ -489,7 +489,6 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
                       comments = tmp_lab)
     }
   }
-
   # time block parameters
   nbp<-0
   cnt<-1

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -51,117 +51,123 @@
 #' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
 #' \code{\link{SS_writestarter}},
 #' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
-SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
-## Parameters that are not defined in control file
-    nseas=4,
-    N_areas=1,
-    Nages=20,
-    Ngenders=1,
-    Npopbins=NA,
-    Nfleet=2,
-    Nsurveys=2,
-    Do_AgeKey=FALSE,
-    N_tag_groups=NA,
-    N_CPUE_obs=c(0,0,9,12), # This information is needed if Q_type of 3 or 4 is used
+SS_readctl_3.24 <- function(file,
+                            verbose = TRUE,
+                            echoall = FALSE,
+                            version = "3.24",
+# Parameters that are not defined in control file:
+                            nseas = 4,
+                            N_areas = 1,
+                            Nages = 20,
+                            Ngenders = 1,
+                            Npopbins = NA,
+                            Nfleet = 2,
+                            Nsurveys = 2,
+                            Do_AgeKey = FALSE,
+                            N_tag_groups = NA,
+# This information is needed if Q_type of 3 or 4 is used
+                            N_CPUE_obs = c(0, 0, 9, 12), 
 ##################################
-    use_datlist=FALSE,
-    datlist=NULL,
-    ptype=TRUE
-    ){
+                            use_datlist = FALSE,
+                            datlist = NULL,
+                            ptype = TRUE) {
   # internally used fun definitions ----
   # function to read Stock Synthesis data files
 
   if(verbose) message("running SS_readctl_3.24\n")
-  dat <- readLines(file,warn=FALSE)
+  dat <- readLines(file, warn = FALSE)
 
-  nver=as.numeric(substring(version,1,4))
+  nver <- as.numeric(substring(version, 1, 4))
   # parse all the numeric values into a long vector (allnums)
-  temp <- strsplit(dat[2]," ")[[1]][1]
-  if(!is.na(temp) && temp=="Start_time:") dat <- dat[-(1:2)]
+  temp <- strsplit(dat[2], " ")[[1]][1]
+  if(!is.na(temp) && temp == "Start_time:") dat <- dat[-(1:2)]
   allnums <- NULL
-  for(i in 1:length(dat)){
+  for(i in 1:length(dat)) {
     # split along blank spaces
-    mysplit <- strsplit(dat[i],split="[[:blank:]]+")[[1]]
-    mysplit <- mysplit[mysplit!=""]
+    mysplit <- strsplit(dat[i], split = "[[:blank:]]+")[[1]]
+    mysplit <- mysplit[mysplit != ""]
     # if final value is a number is followed immediately by a pound ("1#"),
     # this needs to be split
     nvals <- length(mysplit)
-    if(nvals>0) mysplit[nvals] <- strsplit(mysplit[nvals],"#")[[1]][1]
+    if(nvals > 0) mysplit[nvals] <- strsplit(mysplit[nvals], "#")[[1]][1]
     # convert to numeric
     nums <- suppressWarnings(as.numeric(mysplit))
-    if(sum(is.na(nums)) > 0) maxcol <- min((1:length(nums))[is.na(nums)])-1
+    if(sum(is.na(nums)) > 0) maxcol <- min((1:length(nums))[is.na(nums)]) - 1
     else maxcol <- length(nums)
-    if(maxcol > 0){
+    if(maxcol > 0) {
       nums <- nums[1:maxcol]
       allnums <- c(allnums, nums)
     }
   }
   # Function to add vector to ctllist
 
-  add_vec<-function(ctllist,length,name,comments=NULL){
-    i<-ctllist$'.i'
-    dat<-ctllist$'.dat'
-    ctllist$temp<-dat[i+1:length-1]
-    ctllist$'.i'<-i+length
-    if(is.null(comments)){
-      names(ctllist$temp)<-paste0(paste0("#_",name,"_",collapse=""),1:length)
-    }else{
-      names(ctllist$temp)<-comments
+  add_vec <- function(ctllist, length, name, comments = NULL) {
+    i <- ctllist$'.i'
+    dat <- ctllist$'.dat'
+    ctllist$temp <- dat[i+1:length-1]
+    ctllist$'.i' <- i + length
+    if(is.null(comments)) {
+      names(ctllist$temp) <- paste0(paste0("#_", name, "_", collapse = ""),
+                                    1:length)
+    } else {
+      names(ctllist$temp) <- comments
     }
-    if(!is.na(name))names(ctllist)[names(ctllist)=="temp"]<-name
+    if(!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
     if(verbose) {
-	  message(name,",i=",ctllist$'.i',"\n")
+	  message(name, ", i = ", ctllist$'.i', "\n")
 	  print(ctllist[name])
 	}
     return(ctllist)
   }
   # Function to add data as data.frame to ctllist
-  add_df<-function(ctllist,nrow,ncol,col.names,name,comments=NULL){
-    k<-nrow*ncol
-    i<-ctllist$'.i'
-    dat<-ctllist$'.dat'
-    df0<-as.data.frame(matrix(dat[i+1:k-1],nrow=nrow,ncol=ncol,byrow=TRUE))
-    colnames(df0)<-col.names
-    if(is.null(comments)){
-      rownames(df0)<-paste0(paste0("#_",name,collapse=""),1:nrow)
-    }else{
-      rownames(df0)<-comments
+  add_df <- function(ctllist, nrow, ncol, col.names, name, comments = NULL) {
+    k <- nrow * ncol
+    i <- ctllist$'.i'
+    dat <- ctllist$'.dat'
+    df0 <- as.data.frame(matrix(dat[i+1:k-1], nrow = nrow, ncol = ncol,
+                                byrow = TRUE))
+    colnames(df0) <- col.names
+    if(is.null(comments)) {
+      rownames(df0) <- paste0(paste0("#_", name, collapse = ""), 1:nrow)
+    } else {
+      rownames(df0) <- comments
     }
     i <- i+k
-    ctllist$temp<-df0
-    ctllist$'.i'<-i
-    if(!is.na(name))names(ctllist)[names(ctllist)=="temp"]<-name
-    if(verbose){
-      message(name,",i=",ctllist$'.i',"\n")
-      print(ctllist[[which(names(ctllist)==name)]])
+    ctllist$temp <- df0
+    ctllist$'.i' <- i
+    if(!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
+    if(verbose) {
+      message(name, ", i = ", ctllist$'.i', "\n")
+      print(ctllist[[which(names(ctllist) == name)]])
     }
     return(ctllist)
   }
   ## function to add an element to ctllist
-  add_elem<-function(ctllist=NA,name){
-    i<-ctllist$'.i'
-    dat<-ctllist$'.dat'
-    ctllist$temp<-dat[i]
-    ctllist$'.i'<-i+1
-    if(!is.na(name))names(ctllist)[names(ctllist)=="temp"]<-name
-    if(verbose){
-	  message(name, ",i=", ctllist$'.i', " ;",
+  add_elem <- function(ctllist=NA,name) {
+    i <- ctllist$'.i'
+    dat <- ctllist$'.dat'
+    ctllist$temp <- dat[i]
+    ctllist$'.i' <- i + 1
+    if(!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
+    if(verbose) {
+	  message(name, ", i = ", ctllist$'.i', " ;",
 	          ctllist[[which(names(ctllist) == name)]])
     }
 	return(ctllist)
   }
 
   ## function to add list  to ctllist
-  add_list<-function(ctllist=NA,name,length,length_each){
-    i<-ctllist$'.i'
-    dat<-ctllist$'.dat'
-     ctllist$temp<-list()
-    for(j in 1:length){
-      ctllist$temp[[j]]<-dat[i+1:length_each[j]-1]; i <- i+length_each[j]
+  add_list <- function(ctllist = NA, name, length, length_each) {
+    i <- ctllist$'.i'
+    dat <- ctllist$'.dat'
+     ctllist$temp <- list()
+    for(j in 1:length) {
+      ctllist$temp[[j]] <- dat[i+1:length_each[j]-1]
+      i <- i + length_each[j]
     }
-    ctllist$'.i'<-i
-    if(!is.null(name))names(ctllist)[names(ctllist)=="temp"]<-name
-    if(verbose) message(name,",i=",ctllist$'.i')
+    ctllist$'.i' <- i
+    if(!is.null(name)) names(ctllist)[names(ctllist) == "temp"] <- name
+    if(verbose) message(name,", i = ", ctllist$'.i')
     return(ctllist)
   }
   # setup ----
@@ -169,41 +175,48 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
   i <- 1
   # create empty list to store quantities
   ctllist <- list()
-  ctllist$'.i'<-i
-  ctllist$'.dat'<-allnums
-  ctllist$warnings<-""
-  if(!use_datlist){
-    ctllist$nseas<-nseas
-    ctllist$N_areas<-N_areas
-    ctllist$Nages<-Nages
-    ctllist$Ngenders<-Ngenders
-    ctllist$Npopbins<-Npopbins
-    ctllist$Nfleet<-Nfleet
-    ctllist$Nsurveys<-Nsurveys
-    ctllist$Do_AgeKey<-Do_AgeKey
-    ctllist$N_tag_groups<-N_tag_groups
-    ctllist$N_CPUE_obs<-N_CPUE_obs
-#    ctllist$fleetnames<-fleetnames<-c(paste0("FL",1:Nfleet),paste0("S",1:Nsurveys))
-    fleetnames<-paste0("FL",1:Nfleet)
-    if(Nsurveys>0)fleetnames<-c(fleetnames,paste0("S",1:Nsurveys))
-    ctllist$fleetnames<-fleetnames
-  }else{
-    if(is.character(datlist))datlist<-SS_readdat(file=datlist)
-    if(is.null(datlist))stop("datlist from SS_readdat is needed if use_datlist is TRUE")
-    ctllist$nseas<-nseas<-datlist$nseas
-    ctllist$N_areas<-N_areas<-datlist$N_areas
-    ctllist$Nages<-Nages<-datlist$Nages
-    ctllist$Ngenders<-Ngenders<-datlist$Ngenders
-    ctllist$Npopbins<-Npopbins<-datlist$N_lbinspop
-    ctllist$Nfleet<-Nfleet<-datlist$Nfleet
-    ctllist$Nsurveys<-Nsurveys<-datlist$Nsurveys
-    if(datlist$N_ageerror_definition>0){
-      ctllist$Do_AgeKey<-Do_AgeKey<-ifelse(any(datlist$ageerror[1:(nrow(datlist$ageerror)/2)*2,1]<0),1,0)
+  ctllist$'.i' <- i
+  ctllist$'.dat' <- allnums
+  ctllist$warnings <- ""
+  if(!use_datlist) {
+    ctllist$nseas <- nseas
+    ctllist$N_areas <- N_areas
+    ctllist$Nages <- Nages
+    ctllist$Ngenders <- Ngenders
+    ctllist$Npopbins <- Npopbins
+    ctllist$Nfleet <- Nfleet
+    ctllist$Nsurveys <- Nsurveys
+    ctllist$Do_AgeKey <- Do_AgeKey
+    ctllist$N_tag_groups <- N_tag_groups
+    ctllist$N_CPUE_obs <- N_CPUE_obs
+    fleetnames <- paste0("FL", 1:Nfleet)
+    if(Nsurveys > 0) fleetnames <- c(fleetnames, paste0("S", 1:Nsurveys))
+    ctllist$fleetnames <- fleetnames
+  } else {
+    if(is.character(datlist)) datlist <- SS_readdat(file = datlist)
+    if(is.null(datlist)) {
+      stop("datlist from SS_readdat is needed if use_datlist is TRUE")
     }
-    ctllist$N_tag_groups<-N_tag_groups<-datlist$N_tag_groups
-    N_CPUE_obs<-sapply(1:(Nfleet+Nsurveys),function(i){sum(datlist$CPUE[,"index"]==i)})
-    ctllist$N_CPUE_obs<-N_CPUE_obs
-    ctllist$fleetnames <- fleetnames<-datlist$fleetnames
+    ctllist$nseas <- nseas <- datlist$nseas
+    ctllist$N_areas <- N_areas <- datlist$N_areas
+    ctllist$Nages <- Nages <- datlist$Nages
+    ctllist$Ngenders <- Ngenders <- datlist$Ngenders
+    ctllist$Npopbins <- Npopbins <- datlist$N_lbinspop
+    ctllist$Nfleet <- Nfleet <- datlist$Nfleet
+    ctllist$Nsurveys <- Nsurveys <- datlist$Nsurveys
+    if(datlist$N_ageerror_definition > 0) {
+      ctllist$Do_AgeKey <- Do_AgeKey <- 
+        ifelse(any(datlist$ageerror[1:(nrow(datlist$ageerror)/2)*2, 1] < 0),
+               1,
+               0)
+    }
+    ctllist$N_tag_groups <- N_tag_groups <- datlist$N_tag_groups
+    N_CPUE_obs <- sapply(1:(Nfleet + Nsurveys), 
+                         function(i) {
+                           sum(datlist$CPUE[, "index"] == i)
+                         })
+    ctllist$N_CPUE_obs <- N_CPUE_obs
+    ctllist$fleetnames <- fleetnames <- datlist$fleetnames
   }
   # specifications ----
   ctllist$sourcefile <- file
@@ -213,272 +226,283 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
   ctllist$eof <- FALSE
   # internally used commmon values ----
   lng_par_colnames <- c("LO", "HI", "INIT", "PRIOR", "PR_type", "SD", "PHASE",
-                        "env_var","use_dev", "dev_minyr", "dev_maxyr", "dev_stddev",
-                        "Block", "Block_Fxn")
+                        "env_var","use_dev", "dev_minyr", "dev_maxyr", 
+                        "dev_stddev", "Block", "Block_Fxn")
   srt_par_colnames <- c("LO", "HI", "INIT", "PRIOR", "PR_type", "SD", "PHASE")
   if(verbose) message("SS_readctl_3.24 - read version = ", ctllist$ReadVersion)
  
   # beginning of ctl ----
   # model dimensions
-  ctllist<-add_elem(ctllist,"N_GP")
+  ctllist <- add_elem(ctllist, "N_GP")
 
-  # Currently I do not how MGparms are sorted when N_GP>1
-  ctllist<-add_elem(ctllist,"N_platoon")
-  if(ctllist$N_platoon>1){
+  ctllist <- add_elem(ctllist, "N_platoon")
+  if(ctllist$N_platoon > 1) {
     stop("sub morphs are not supported yet")
-#    ctllist<-add_elem(ctllist,"N_platoon")
-    ctllist<-add_elem(ctllist,"submorphdist")
-  }else{
-    ctllist$sd_ratio<- 1.
-    ctllist$submorphdist<-1.
+    ctllist <- add_elem(ctllist, "submorphdist")
+  } else {
+    ctllist$sd_ratio <- 1.0
+    ctllist$submorphdist <- 1.0
   }
-  if(ctllist$submorphdist[1]<0.){
-    if(ctllist$N_platoon==1){
-      ctllist$submorphdist<- 1.;
-    }else if (ctllist$N_platoon==3){
-      ctllist$submorphdist<-c(0.15,0.70,0.15)
-    }else if (ctllist$N_platoon==5){
+  if(ctllist$submorphdist[1] < 0.0) {
+    if(ctllist$N_platoon == 1) {
+      ctllist$submorphdist <- 1.0
+    } else if (ctllist$N_platoon == 3) {
+      ctllist$submorphdist<-c(0.15, 0.70, 0.15)
+    } else if (ctllist$N_platoon == 5) {
       ctllist$submorphdist<-c(0.031, 0.237, 0.464, 0.237, 0.031)
     }
   }
-  ctllist$submorphdist<-ctllist$submorphdist/sum(ctllist$submorphdist)
-  if(ctllist$N_GP*ctllist$nseas*ctllist$N_areas>1) {
-    ctllist<-add_elem(ctllist,"recr_dist_read")
-    recr_dist_read<-ctllist$recr_dist_read
+  ctllist$submorphdist <- ctllist$submorphdist / sum(ctllist$submorphdist)
+  if(ctllist$N_GP * ctllist$nseas * ctllist$N_areas > 1) {
+    ctllist <- add_elem(ctllist, "recr_dist_read")
+    recr_dist_read <- ctllist$recr_dist_read
     #  number of recruitment assignments (overrides GP*area*seas parameter values)
-    ctllist<-add_elem(ctllist,"recr_dist_inx")
+    ctllist <- add_elem(ctllist, "recr_dist_inx")
     # recruitment interaction requested
-    ctllist<-add_df(ctllist,"recr_dist_pattern",nrow=recr_dist_read,ncol=3,
-      col.names=c("GP","seas","area"))
-  }else{
-    ctllist$recr_dist_inx<-FALSE
+    ctllist <- add_df(ctllist, "recr_dist_pattern", nrow = recr_dist_read,
+                      ncol = 3, col.names = c("GP", "seas", "area"))
+  } else {
+    ctllist$recr_dist_inx <- FALSE
   }
 
-  ctllist$recr_dist_method<-1 # compatibility with v 3.30
+  ctllist$recr_dist_method <- 1 # compatibility with v 3.30
 
-  if(ctllist$N_areas>1){
-    ctllist<-add_elem(ctllist,"N_moveDef") #_N_movement_definitions goes here if N_areas > 1
-    if(ctllist$N_moveDef>0)
-    {
-      ctllist<-add_elem(ctllist,"firstAgeMove") #_first age that moves (real age at begin of season, not integer) also cond on do_migration>0
-      ctllist<-add_df(ctllist,"moveDef",nrow=ctllist$N_moveDef,ncol=6,col.names=c("seas", "morph", "source", "dest", "age", "age2"))
+  if(ctllist$N_areas > 1) {
+    ctllist <- add_elem(ctllist, "N_moveDef") #_N_movement_definitions goes here if N_areas > 1
+    if(ctllist$N_moveDef > 0) {
+      ctllist <- add_elem(ctllist, "firstAgeMove") #_first age that moves (real age at begin of season, not integer) also cond on do_migration>0
+      ctllist <- add_df(ctllist, "moveDef", nrow = ctllist$N_moveDef, ncol = 6,
+        col.names = c("seas", "morph", "source", "dest", "age", "age2"))
     }
   }
   # block setup ----
-  ctllist<-add_elem(ctllist,"N_Block_Designs") #_Nblock_Patterns
-  if(ctllist$N_Block_Designs>0){
-    ctllist<-add_vec(ctllist,name="blocks_per_pattern",length=ctllist$N_Block_Designs)
+  ctllist <- add_elem(ctllist, "N_Block_Designs") #_Nblock_Patterns
+  if(ctllist$N_Block_Designs > 0) {
+    ctllist <- add_vec(ctllist, name = "blocks_per_pattern",
+                       length = ctllist$N_Block_Designs)
     #_blocks_per_pattern
   # begin and end years of blocks
-    ctllist<-add_list(ctllist,name="Block_Design",length=ctllist$N_Block_Designs,
-      length_each=ctllist$blocks_per_pattern*2)
+    ctllist <- add_list(ctllist, name = "Block_Design", 
+                        length = ctllist$N_Block_Designs, 
+                        length_each = ctllist$blocks_per_pattern * 2)
   }
   
-  ctllist$time_vary_adjust_method<-3  # compatibility with v 3.30
-  ctllist$time_vary_auto_generation<-c(1,1,1,1,1) # compatibility with v 3.30
+  ctllist$time_vary_adjust_method <- 3  # compatibility with v 3.30
+  # compatibility with v 3.30
+  ctllist$time_vary_auto_generation <- c(1, 1, 1, 1, 1)
 
   # MG setup ----
   # M setup ----
-  ctllist<-add_elem(ctllist,"fracfemale") #_fracfemale
-  ctllist<-add_elem(ctllist,"natM_type") #_natM_type
-  if(ctllist$natM_type==0){
-    N_natMparms<-1
-  }else if(ctllist$natM_type==1){
-    ctllist<-add_elem(ctllist,name="N_natM") #_Number of M_segments
-    ctllist<-add_vec(ctllist,name="M_ageBreakPoints",length=ctllist$N_natM) # age(real) at M breakpoints
-    N_natMparms<-ctllist$N_natM
-  }else if(ctllist$natM_type==2){
-    N_natMparms<-1
+  ctllist <- add_elem(ctllist, "fracfemale") #_fracfemale
+  ctllist <- add_elem(ctllist, "natM_type") #_natM_type
+  if(ctllist$natM_type == 0) {
+    N_natMparms <- 1
+  } else if(ctllist$natM_type == 1) {
+    ctllist <- add_elem(ctllist, name = "N_natM") #_Number of M_segments
+    ctllist <- add_vec(ctllist, name = "M_ageBreakPoints",
+                       length = ctllist$N_natM) # age(real) at M breakpoints
+    N_natMparms <- ctllist$N_natM
+  } else if(ctllist$natM_type == 2) {
+    N_natMparms <- 1
     ctllist <- add_elem(ctllist, "Lorenzen_refage") #_natM_type
-  }else if(ctllist$natM_type %in% c(3,4)){
-    N_natMparms<-0
-    ctllist<-add_df(ctllist,name="natM",nrow=ctllist$N_GP*ctllist$Ngenders,ncol=Nages+1,col.names=paste0("Age_",0:Nages))
-  }else{
-    stop("natM_type =", ctllist$natM_type," is not yet implemented in this script")
+  } else if(ctllist$natM_type %in% c(3, 4)) {
+    N_natMparms <- 0
+    ctllist <- add_df(ctllist, name = "natM",
+                      nrow = ctllist$N_GP*ctllist$Ngenders,
+                      ncol = Nages + 1,
+                      col.names = paste0("Age_", 0:Nages))
+  } else {
+    stop("natM_type = ", ctllist$natM_type," is not yet implemented in this script")
   }
-  if(verbose) message("N_natMparms=",N_natMparms)
+  if(verbose) message("N_natMparms = ", N_natMparms)
   # growth setup ----
-  ctllist<-add_elem(ctllist,name="GrowthModel")
+  ctllist <- add_elem(ctllist, name = "GrowthModel")
     # GrowthModel: 1=vonBert with L1&L2; 2=Richards with L1&L2; 3=age_specific_K; 4=not implemented
-  ctllist<-add_elem(ctllist,name="Growth_Age_for_L1") #_Growth_Age_for_L1
-  ctllist<-add_elem(ctllist,name="Growth_Age_for_L2") #_Growth_Age_for_L2 (999 to use as Linf)
-  ctllist$Exp_Decay<-0.2 #Exponential decay for growth above maximum age - default 0.2
-  if(ctllist$GrowthModel==3){
-    ctllist<-add_elem(ctllist,name="N_ageK")
+  ctllist <- add_elem(ctllist, name = "Growth_Age_for_L1") #_Growth_Age_for_L1
+  ctllist <- add_elem(ctllist, name = "Growth_Age_for_L2") #_Growth_Age_for_L2 (999 to use as Linf)
+  ctllist$Exp_Decay <- 0.2 #Exponential decay for growth above maximum age - default 0.2
+  if(ctllist$GrowthModel == 3) {
+    ctllist <- add_elem(ctllist, name = "N_ageK")
   }
-  if(ctllist$GrowthModel==1)  # 1=vonBert with L1&L2
-  {
-    N_growparms<-5
-  #  AFIX=tempvec5(1);
-  #  AFIX2=tempvec5(2);
-  }
-  else if(ctllist$GrowthModel==2) # 2=Richards with L1&L2
-  {
-    N_growparms<-6
-  #  AFIX=tempvec5(1);
-  #  AFIX2=tempvec5(2);
-  }else if(ctllist$GrowthModel==3){ # 3=age_specific_K
-  #  AFIX=tempvec5(1);
-  #  AFIX2=tempvec5(2);
+  if(ctllist$GrowthModel == 1) {  # 1=vonBert with L1&L2
+    N_growparms <- 5
+  } else if(ctllist$GrowthModel == 2) { # 2=Richards with L1&L2
+    N_growparms <- 6
+  } else if(ctllist$GrowthModel == 3) { # 3=age_specific_K
     N_growparms <- 5 + ctllist$N_ageK
-    ctllist<-add_vec(ctllist,name="Age_K_points",length=ctllist$N_ageK)
+    ctllist <- add_vec(ctllist, name = "Age_K_points", length = ctllist$N_ageK)
     #  points at which age-specific multipliers to K will be applied
-
-  }else if(ctllist$GrowthModel==4){
-  ##  I found some portion of source code for GrowthModel=4
-  ##  But for now I disabled it
-    stop("GrowthModel==4 is not implemented")
-    N_growparms<-2  # for the two CV parameters
-    k1<-ctllist$N_GP*ctllist$Ngenders  # for reading age_natmort
-    ctllist<-add_df(ctllist,name="Len_At_Age_rd",nrow=k1,ncol=Nages+1,col.names=paste0("Age_",0:Nages))
-  #!!if(k1>0) echoinput<<"  Len_At_Age_rd"<<Len_At_Age_rd<<endl; Need check
-  }else{
-    stop("GrowthModel ", ctllist$GrowthModel," is not supported yet.")
+  } else if(ctllist$GrowthModel == 4) {
+    stop("GrowthModel == 4 is not implemented")
+    N_growparms <- 2  # for the two CV parameters
+    k1 <- ctllist$N_GP*ctllist$Ngenders  # for reading age_natmort
+    ctllist <- add_df(ctllist, name = "Len_At_Age_rd", nrow = k1,
+                      ncol = Nages+1, col.names = paste0("Age_", 0:Nages))
+  } else {
+    stop("GrowthModel ", ctllist$GrowthModel, " is not supported yet.")
   }
-  MGparm_per_def<-N_natMparms+N_growparms
-  ctllist$N_natMparms<-N_natMparms
+  MGparm_per_def <- N_natMparms + N_growparms
+  ctllist$N_natMparms <- N_natMparms
 
-  ctllist<-add_elem(ctllist,name="SD_add_to_LAA") #_SD_add_to_LAA (set to 0.1 for SS2 V1.x compatibility)
-  ctllist<-add_elem(ctllist,name="CV_Growth_Pattern")
+  ctllist <- add_elem(ctllist, name = "SD_add_to_LAA") #_SD_add_to_LAA (set to 0.1 for SS2 V1.x compatibility)
+  ctllist <- add_elem(ctllist, name = "CV_Growth_Pattern")
     #_CV_Growth_Pattern:  0 CV=f(LAA); 1 CV=F(A); 2 SD=F(LAA); 3 SD=F(A); 4 logSD=F(A)
   # maturity and MG options setup ----
-  ctllist<-add_elem(ctllist,name="maturity_option")
-    #_maturity_option:  1=length logistic; 2=age logistic; 3=read age-maturity by GP; 4=read age-fecundity by GP; 5=read fec and wt from wtatage.ss; 6=read length-maturity by GP
-  if(ctllist$maturity_option==6)ctllist$EmpiricalWAA<-1
-  else ctllist$EmpiricalWAA<-0
-
-  if(ctllist$maturity_option %in% c(3,4)){
-    ctllist<-add_df(ctllist,name="Age_Maturity",nrow=ctllist$N_GP,ncol=Nages+1,col.names=paste0("Age_",0:Nages))
-  }else if(ctllist$maturity_option==6){
-    ctllist<-add_df(ctllist,name="Length_Maturity",nrow=ctllist$N_GP,ncol=Npopbins,col.names=paste0("Len_",1:Npopbins))
+  ctllist <- add_elem(ctllist, name = "maturity_option")
+    # maturity_option:  1=length logistic; 2=age logistic; 
+    # 3=read age-maturity by GP; 4=read age-fecundity by GP; 5=read fec and wt 
+    # from wtatage.ss; 6=read length-maturity by GP
+  if(ctllist$maturity_option == 6) {
+    ctllist$EmpiricalWAA <- 1
+  } else {
+    ctllist$EmpiricalWAA <- 0
+  }
+  if(ctllist$maturity_option %in% c(3, 4)) {
+    ctllist <- add_df(ctllist, name = "Age_Maturity", nrow = ctllist$N_GP,
+                      ncol = Nages+1, col.names = paste0("Age_", 0:Nages))
+  } else if(ctllist$maturity_option == 6) {
+    ctllist <- add_df(ctllist, name = "Length_Maturity", nrow = ctllist$N_GP,
+                      ncol = Npopbins, col.names = paste0("Len_", 1:Npopbins))
   }
 
-  ctllist<-add_elem(ctllist,"First_Mature_Age") #_First_Mature_Age
-  ctllist<-add_elem(ctllist,"fecundity_option")  #_fecundity_option
-  ctllist<-add_elem(ctllist,"hermaphroditism_option")   #_hermaphroditism_option
-  if(ctllist$hermaphroditism_option>0)
-  {
-    ctllist<-add_elem(ctllist,"Herm_season") #_Hermaphroditism_season
-    ctllist<-add_elem(ctllist,"Herm_MalesInSSB")  #_Hermaphroditism_males_in_SSB
+  ctllist <- add_elem(ctllist, "First_Mature_Age")
+  ctllist <- add_elem(ctllist, "fecundity_option")
+  ctllist <- add_elem(ctllist, "hermaphroditism_option")
+  if(ctllist$hermaphroditism_option > 0) {
+    ctllist <- add_elem(ctllist, "Herm_season")
+    ctllist <- add_elem(ctllist,"Herm_MalesInSSB")
   }
-  ctllist<-add_elem(ctllist,"parameter_offset_approach")    #_parameter_offset_approach
-  ctllist<-add_elem(ctllist,"env_block_dev_adjust_method")   #_env/block/dev_adjust_method
+  ctllist <- add_elem(ctllist, "parameter_offset_approach")
+  ctllist <- add_elem(ctllist, "env_block_dev_adjust_method")
   # MG parlines -----
-  N_MGparm<-MGparm_per_def*ctllist$N_GP*ctllist$Ngenders  ## Parmeters for M and Growth multiplied by N_GP and Ngenders
-  MGparmLabel<-list()
-  cnt<-1
-  PType<-array() # store parameter types M=1, Growth=2, WtLn = 3, Maturity = 4, Fecundity = 5,
-                 # Hermaph = 6, RecDevs GP = 7 Areas = 8 Seas= 9, RecDev Interactions = 10,
-                 # GrowthDevs = 11, Movement = 12
+  N_MGparm <- MGparm_per_def * ctllist$N_GP * ctllist$Ngenders
+  MGparmLabel <- list()
+  cnt <- 1
+  # store parameter types M=1, Growth=2, WtLn = 3, Maturity = 4, Fecundity = 5,
+  # Hermaph = 6, RecDevs GP = 7 Areas = 8 Seas= 9, RecDev Interactions = 10,
+  # GrowthDevs = 11, Movement = 12
+  PType <- array() 
 
-  GenderLabel<-c("Fem","Mal")
-  for(i in 1:ctllist$Ngenders){
-    for(j in 1:ctllist$N_GP){
-      if(N_natMparms>0){
-        MGparmLabel[1:N_natMparms+cnt-1]<-paste0("NatM_p_",1:N_natMparms,"_",GenderLabel[i],"_GP_",j)
-        PType[cnt:(N_natMparms+cnt-1)]<-1
-        cnt<-cnt+N_natMparms
+  GenderLabel <- c("Fem", "Mal")
+  for(i in 1:ctllist$Ngenders) {
+    for(j in 1:ctllist$N_GP) {
+      if(N_natMparms > 0) {
+        MGparmLabel[1:N_natMparms+cnt-1] <- 
+          paste0("NatM_p_", 1:N_natMparms, "_", GenderLabel[i], "_GP_", j)
+        PType[cnt:(N_natMparms+cnt-1)] <- 1
+        cnt <- cnt + N_natMparms
       }
-      if(ctllist$GrowthModel==1){ # VB
-        tmp<-c("L_at_Amin_","L_at_Amax_","VonBert_K_","CV_young_","CV_old_")
-        MGparmLabel[1:5+cnt-1]<-paste0(tmp,"_",GenderLabel[i],"_GP_",j)
-        PType[cnt:(5+cnt-1)]<-2
-        cnt<-cnt+5
-      }else if(ctllist$GrowthModel==2){ # Richards
-        tmp<-c("L_at_Amin_","L_at_Amax_","VonBert_K_","Richards_","CV_young_","CV_old_")
-        MGparmLabel[1:6+cnt-1]<-paste0(tmp,"_",GenderLabel[i],"_GP_",j)
-        PType[cnt:(6+cnt-1)]<-2
-        cnt<-cnt+6
-      }else if(ctllist$GrowthModel==3){
-        tmp<-c("L_at_Amin_","L_at_Amax_","VonBert_K_",paste0("Age_K_",1:ctllist$N_ageK),"CV_young_","CV_old_")
-        MGparmLabel[1:(5+ctllist$N_ageK)+cnt-1]<-paste0(tmp,"_",GenderLabel[i],"_GP_",j)
-        PType[cnt:((5+ctllist$N_ageK)+cnt-1)]<-2
-        cnt<-cnt+5+ctllist$N_ageK
+      if(ctllist$GrowthModel == 1) { # VB
+        tmp <- c("L_at_Amin_", "L_at_Amax_", "VonBert_K_", "CV_young_", 
+                 "CV_old_")
+        MGparmLabel[1:5+cnt-1] <- paste0(tmp, "_", GenderLabel[i], "_GP_", j)
+        PType[cnt:(5+cnt-1)] <- 2
+        cnt <- cnt + 5
+      } else if(ctllist$GrowthModel == 2) { # Richards
+        tmp <- c("L_at_Amin_","L_at_Amax_","VonBert_K_","Richards_","CV_young_",
+               "CV_old_")
+        MGparmLabel[1:6+cnt-1] <- paste0(tmp, "_", GenderLabel[i], "_GP_", j)
+        PType[cnt:(6+cnt-1)] <- 2
+        cnt <- cnt + 6
+      } else if(ctllist$GrowthModel == 3) {
+        tmp <- c("L_at_Amin_", "L_at_Amax_", "VonBert_K_", 
+                 paste0("Age_K_", 1:ctllist$N_ageK), "CV_young_", "CV_old_")
+        MGparmLabel[1:(5+ctllist$N_ageK)+cnt-1] <- 
+          paste0(tmp, "_", GenderLabel[i], "_GP_", j)
+        PType[cnt:((5+ctllist$N_ageK)+cnt-1)] <- 2
+        cnt <- cnt + 5 + ctllist$N_ageK
       }
     }
   }
 
-  N_MGparm<-N_MGparm+2*ctllist$Ngenders+2+2 #add for wt-len(by gender), mat-len parms; eggs
-  MGparmLabel[cnt]<-paste0("Wtlen_1_",GenderLabel[1]);PType[cnt]<-3;cnt<-cnt+1
-  MGparmLabel[cnt]<-paste0("Wtlen_2_",GenderLabel[1]);PType[cnt]<-3;cnt<-cnt+1
-  MGparmLabel[cnt]<-paste0("Mat50%_",GenderLabel[1]);PType[cnt]<-4;cnt<-cnt+1
-  MGparmLabel[cnt]<-paste0("Mat_slope_",GenderLabel[1]);PType[cnt]<-4;cnt<-cnt+1
-  if(ctllist$fecundity_option==1){
-    MGparmLabel[cnt]<-paste0("Eggs/kg_inter_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Eggs/kg_slope_wt_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-  }else if(ctllist$fecundity_option==2){
-    MGparmLabel[cnt]<-paste0("Eggs_scalar_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Eggs_exp_len_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-  }else  if(ctllist$fecundity_option==3){
-    MGparmLabel[cnt]<-paste0("Eggs_scalar_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Eggs_exp_wt_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-  }else  if(ctllist$fecundity_option==4){
-    MGparmLabel[cnt]<-paste0("Eggs_intercept_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Eggs_slope_len_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-  }else   if(ctllist$fecundity_option==5){
-    MGparmLabel[cnt]<-paste0("Eggs_intercept_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Eggs_slope_wt_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-  }else   if(ctllist$fecundity_option==6){  # check what to do with option 6
-    MGparmLabel[cnt]<-paste0("Eggs_intercept_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Eggs_slope_wt_",GenderLabel[1]);PType[cnt]<-5;cnt<-cnt+1
-  }else{
+  N_MGparm <- N_MGparm + 2*ctllist$Ngenders + 2 + 2 #add for wt-len(by gender), mat-len parms; eggs
+  MGparmLabel[cnt] <- paste0("Wtlen_1_", GenderLabel[1]); PType[cnt] <- 3; cnt <- cnt + 1
+  MGparmLabel[cnt] <- paste0("Wtlen_2_", GenderLabel[1]); PType[cnt] <- 3; cnt <- cnt + 1
+  MGparmLabel[cnt] <- paste0("Mat50%_", GenderLabel[1]); PType[cnt] <- 4; cnt <- cnt + 1
+  MGparmLabel[cnt] <- paste0("Mat_slope_", GenderLabel[1]); PType[cnt] <- 4; cnt <- cnt + 1
+  if(ctllist$fecundity_option == 1) {
+    MGparmLabel[cnt] <- paste0("Eggs/kg_inter_", GenderLabel[1]); PType[cnt] <- 5; cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Eggs/kg_slope_wt_", GenderLabel[1]); PType[cnt] <- 5; cnt <- cnt + 1
+  } else if(ctllist$fecundity_option == 2) {
+    MGparmLabel[cnt] <- paste0("Eggs_scalar_", GenderLabel[1]); PType[cnt] <- 5; cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Eggs_exp_len_", GenderLabel[1]);PType[cnt] <- 5; cnt <- cnt + 1
+  } else if(ctllist$fecundity_option == 3) {
+    MGparmLabel[cnt] <- paste0("Eggs_scalar_", GenderLabel[1]); PType[cnt] <- 5; cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Eggs_exp_wt_", GenderLabel[1]); PType[cnt] <- 5; cnt <- cnt + 1
+  } else if(ctllist$fecundity_option==4){
+    MGparmLabel[cnt] <- paste0("Eggs_intercept_",GenderLabel[1]);PType[cnt]<-5;cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Eggs_slope_len_",GenderLabel[1]);PType[cnt]<-5;cnt <- cnt + 1
+  } else if(ctllist$fecundity_option==5){
+    MGparmLabel[cnt] <- paste0("Eggs_intercept_",GenderLabel[1]);PType[cnt]<-5;cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Eggs_slope_wt_",GenderLabel[1]);PType[cnt]<-5;cnt <- cnt + 1
+  }else if(ctllist$fecundity_option == 6) {  # check what to do with option 6
+    MGparmLabel[cnt] <- paste0("Eggs_intercept_",GenderLabel[1]);PType[cnt]<-5;cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Eggs_slope_wt_",GenderLabel[1]);PType[cnt]<-5;cnt <- cnt + 1
+  } else {
     stop("Fecundity option ", ctllist$fecundity_option, " is not supported")
   }
-  if(ctllist$Ngenders==2){
-    MGparmLabel[cnt]<-paste0("Wtlen_1_",GenderLabel[2]);PType[cnt]<-3;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Wtlen_2_",GenderLabel[2]);PType[cnt]<-3;cnt<-cnt+1
+  if (ctllist$Ngenders == 2) {
+    MGparmLabel[cnt] <- paste0("Wtlen_1_",GenderLabel[2]);PType[cnt]<-3;cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Wtlen_2_",GenderLabel[2]);PType[cnt]<-3;cnt <- cnt + 1
   }
-  if(ctllist$hermaphroditism_option){
-    MGparmLabel[cnt]<-paste0("Herm_Infl_age",GenderLabel[1]);PType[cnt]<-6;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Herm_stdev",GenderLabel[1]);PType[cnt]<-6;cnt<-cnt+1
-    MGparmLabel[cnt]<-paste0("Herm_asymptote",GenderLabel[1]);PType[cnt]<-6;cnt<-cnt+1
-    N_MGparm<-N_MGparm+3
+  if (ctllist$hermaphroditism_option) {
+    MGparmLabel[cnt] <- paste0("Herm_Infl_age",GenderLabel[1]);PType[cnt]<-6;cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Herm_stdev",GenderLabel[1]);PType[cnt]<-6;cnt <- cnt + 1
+    MGparmLabel[cnt] <- paste0("Herm_asymptote",GenderLabel[1]);PType[cnt]<-6;cnt <- cnt + 1
+    N_MGparm <- N_MGparm + 3
   }
-  N_MGparm<-N_MGparm+ctllist$N_GP+N_areas+nseas         # add for the assignment to areas
-  MGparmLabel[cnt+1:ctllist$N_GP-1]<-paste0("RecrDist_GP_",1:ctllist$N_GP);PType[cnt:(cnt+ctllist$N_GP-1)]<-7;cnt<-cnt+ctllist$N_GP
-  MGparmLabel[cnt+1:N_areas-1]<-paste0("RecrDist_Area_",1:N_areas);PType[cnt:(cnt+N_areas)]<-8;cnt<-cnt+N_areas
-  MGparmLabel[cnt+1:nseas-1]<-paste0("RecrDist_Seas_",1:nseas);PType[cnt:(cnt+nseas-1)]<-9;cnt<-cnt+nseas
+  N_MGparm <- N_MGparm + ctllist$N_GP + N_areas + nseas # add for the assignment to areas
+  MGparmLabel[cnt+1:ctllist$N_GP-1] <- paste0("RecrDist_GP_", 1:ctllist$N_GP); PType[cnt:(cnt+ctllist$N_GP-1)]<-7; cnt <- cnt + ctllist$N_GP
+  MGparmLabel[cnt+1:N_areas-1] <- paste0("RecrDist_Area_", 1:N_areas); PType[cnt:(cnt+N_areas)] <- 8; cnt <- cnt + N_areas
+  MGparmLabel[cnt+1:nseas-1] <- paste0("RecrDist_Seas_", 1:nseas); PType[cnt:(cnt+nseas-1)] <- 9; cnt <- cnt + nseas
 
   ## number of recruiment distribution parameters
-  N_RecrDist_parms<-ctllist$N_GP+ctllist$N_areas+ctllist$nseas
-  if(ctllist$recr_dist_inx){
+  N_RecrDist_parms <- ctllist$N_GP + ctllist$N_areas + ctllist$nseas
+  if(ctllist$recr_dist_inx) {
   ## Interactions
-    N_MGparm<-N_MGparm+ctllist$N_GP*N_areas*nseas
-    N_RecrDist_parms<-N_RecrDist_parms+ctllist$N_GP*N_areas*nseas
-    for(i in 1:ctllist$N_GP){
-      for(j in 1:nseas){
-        for(k in 1:N_areas){
-          MGparmLabel[cnt]<-paste0("RecrDist_interaction_GP_",i,"_seas_",j,"_area_",k);PType[cnt]<-10;cnt<-cnt+1
+    N_MGparm <- N_MGparm + ctllist$N_GP*N_areas*nseas
+    N_RecrDist_parms <- N_RecrDist_parms + ctllist$N_GP*N_areas*nseas
+    for(i in 1:ctllist$N_GP) {
+      for(j in 1:nseas) {
+        for(k in 1:N_areas) {
+          MGparmLabel[cnt] <- 
+            paste0("RecrDist_interaction_GP_", i, "_seas_", j, "_area_", k)
+          PType[cnt] <- 10
+          cnt <- cnt + 1
         }
       }
     }
     # add for the morph assignments within each area
   }
 #  MGparms
-
-  N_MGparm<-N_MGparm+1 # add 1 parameter for cohort-specific growth parameter
-  MGparmLabel[cnt]<-"CohortGrowDev";PType[cnt]<-11;cnt<-cnt+1
-  if((N_areas>1)&&(ctllist$N_moveDef>0)){
-    N_MGparm<-N_MGparm+ctllist$N_moveDef*2 # add 2 * N_moveDef for movement params
-#    M_Move_parms<-ctllist$N_moveDef*2
-    for(i in 1:ctllist$N_moveDef){
-      seas<-ctllist$moveDef[i,1]
-      GP<-ctllist$moveDef[i,2]
-      from<-ctllist$moveDef[i,3]
-      to<-ctllist$moveDef[i,4]
-      MGparmLabel[cnt+0:1]<-paste0("MoveParm_",c("A","B"),"_seas_",seas,"_GP_",GP,"_from_",from,"_to_",to);PType[cnt:(cnt+1)]<-12;cnt<-cnt+2
+  N_MGparm <- N_MGparm + 1 # add 1 parameter for cohort-specific growth parameter
+  MGparmLabel[cnt] <- "CohortGrowDev"
+  PType[cnt] <- 11
+  cnt<-cnt+1
+  if((N_areas > 1) && (ctllist$N_moveDef > 0)) {
+    N_MGparm <- N_MGparm + ctllist$N_moveDef*2
+    for(i in 1:ctllist$N_moveDef) {
+      seas <- ctllist$moveDef[i, 1]
+      GP <- ctllist$moveDef[i, 2]
+      from <- ctllist$moveDef[i, 3]
+      to <- ctllist$moveDef[i, 4]
+      MGparmLabel[cnt+0:1] <- paste0("MoveParm_", c("A", "B"), "_seas_", seas,
+                                     "_GP_", GP, "_from_", from, "_to_", to)
+      PType[cnt:(cnt + 1)] <- 12
+      cnt <- cnt + 2
     }
   }
 
-  if(Do_AgeKey){
-    MGparmLabel[cnt+0:6]<-paste0("AgeKeyParm",1:7);PType[cnt:(cnt+6)]<-13;cnt<-cnt+7
-    N_MGparm<-N_MGparm+7
+  if(Do_AgeKey) {
+    MGparmLabel[cnt+0:6] <- paste0("AgeKeyParm", 1:7)
+    PType[cnt:(cnt+6)] <- 13
+    cnt <- cnt + 7
+    N_MGparm <- N_MGparm + 7
   }
 
-  ctllist<-add_df(ctllist,name="MG_parms",nrow=N_MGparm,ncol=14,
-                    col.names = lng_par_colnames,
-                                comments=MGparmLabel)
-    ctllist$MG_parms<-cbind(ctllist$MG_parms,PType)
+  ctllist <- add_df(ctllist, name = "MG_parms", nrow = N_MGparm, ncol = 14,
+                    col.names = lng_par_colnames,comments = MGparmLabel)
+    ctllist$MG_parms <- cbind(ctllist$MG_parms, PType)
 
   # MG timevarying parlines ------
   # environmental linkage lines
@@ -494,196 +518,196 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
     }
   }
   # time block parameters
-  nbp<-0
-  cnt<-1
-  PType<-array()
-  MGblockLabel<-list()
-  for(i in 1:N_MGparm)
-  {
-    if(ctllist$MG_parms[i,]$Block>0)
-    {
-      nv<-as.numeric(ctllist$blocks_per_pattern[ctllist$MG_parms[i,]$Block])
-      MGblockLabel[(nbp+1):(nbp+nv)]<-paste0(rownames(ctllist$MG_parms[i,]),"#",(nbp+1):(nbp+nv))
-      nbp<-nbp+nv
-      PType[cnt:(nv+cnt-1)]<-15
-      cnt<-cnt+nv
+  nbp <- 0
+  cnt <- 1
+  PType <- array()
+  MGblockLabel <- list()
+  for(i in 1:N_MGparm) {
+    if(ctllist$MG_parms[i,]$Block > 0) {
+      nv <- as.numeric(ctllist$blocks_per_pattern[ctllist$MG_parms[i,]$Block])
+      MGblockLabel[(nbp+1):(nbp+nv)] <- 
+        paste0(rownames(ctllist$MG_parms[i, ]), "#", (nbp+1):(nbp+nv))
+      nbp <- nbp + nv
+      PType[cnt:(nv+cnt-1)] <- 15
+      cnt <- cnt + nv
     }
   }
 
-  if(nbp>0)
-  {
-    ctllist<-add_elem(ctllist,"custom_MG_block")
-    ctllist<-add_df(ctllist,name="MG_parms_blocks",nrow=nbp,ncol=7,
-                           col.names= srt_par_colnames,
-                           comments=MGblockLabel)
-    ctllist$MG_parms_blocks<-cbind(ctllist$MG_parms_blocks,PType)
+  if(nbp > 0) {
+    ctllist <- add_elem(ctllist, "custom_MG_block")
+    ctllist <- add_df(ctllist, name = "MG_parms_blocks", nrow = nbp, ncol = 7,
+                      col.names = srt_par_colnames, comments = MGblockLabel)
+    ctllist$MG_parms_blocks <- cbind(ctllist$MG_parms_blocks, PType)
   }
   # Read seasonal effects ----
-  ctllist<-add_vec(ctllist,name="MGparm_seas_effects",length=10)
+  ctllist <- add_vec(ctllist, name = "MGparm_seas_effects", length = 10)
 
-  PType<-array()
-  N_seas_effects<-length(ctllist$MGparm_seas_effects[ctllist$MGparm_seas_effects>0])
-  if(N_seas_effects>0){
-    ctllist<-add_df(ctllist,"MG_parms_seas",nrow=N_seas_effects*ctllist$nseas, 
-                    ncol=7,
-                    col.names = srt_par_colnames)
-    PType[1:(N_seas_effects*ctllist$nseas)]<-16
-    ctllist$MG_parms_seas<-cbind(ctllist$MG_parms_seas,PType)
-
+  PType <- array()
+  N_seas_effects <- 
+    length(ctllist$MGparm_seas_effects[ctllist$MGparm_seas_effects > 0])
+  if(N_seas_effects > 0) {
+    ctllist <- add_df(ctllist, "MG_parms_seas",
+                      nrow = N_seas_effects*ctllist$nseas, ncol=7,
+                      col.names = srt_par_colnames)
+    PType[1:(N_seas_effects*ctllist$nseas)] <- 16
+    ctllist$MG_parms_seas <- cbind(ctllist$MG_parms_seas, PType)
   }
 
-  #  DoParmDev<-sum(ctllist$M_parms[,9])+
-  #             sum(ctllist$G_parms[,9])+sum(ctllist$cohortG_parm[,9])+
-  #             sum(ctllist$RecrDist_parms[,9])+sum(ctllist$Move_parms[,9])
-  DoParmDev<-sum(ctllist$MG_parms[,9])
-  if(DoParmDev>0){
-    ctllist<-add_elem(ctllist,"MGparm_Dev_Phase") #_MGparm_Dev_Phase
+  DoParmDev <- sum(ctllist$MG_parms[, 9])
+  if(DoParmDev > 0) {
+    ctllist <- add_elem(ctllist, "MGparm_Dev_Phase")
   }
 
  # SR ----
-  ctllist<-add_elem(ctllist,"SR_function")   #_SR_function
-  N_SRparm<-c(0,2,2,2,3,2,3,3,0,0)
-  N_SRparm2<-N_SRparm[as.numeric(ctllist$SR_function)]+4
+  ctllist <- add_elem(ctllist,"SR_function")
+  N_SRparm <- c(0, 2, 2, 2, 3, 2, 3, 3, 0, 0)
+  N_SRparm2 <- N_SRparm[as.numeric(ctllist$SR_function)] + 4
 
   if(is.na(ctllist$SR_function)) {
     stop("SR_function is NA")
   }
   # SR parms ----
-  SRparmsLabels<-if(ctllist$SR_function ==3){
+  SRparmsLabels <- if(ctllist$SR_function == 3) {
     # B-H SRR
-    c("SR_LN(R0)","SR_BH_steep","SR_sigmaR","SR_envlink","SR_R1_offset","SR_autocorr")
-  }else if(ctllist$SR_function==2){
+    c("SR_LN(R0)", "SR_BH_steep", "SR_sigmaR", "SR_envlink", "SR_R1_offset",
+      "SR_autocorr")
+  } else if(ctllist$SR_function == 2){
     # Ricker SRR
-    c("SR_LN(R0)","SR_Ricker","SR_sigmaR","SR_envlink","SR_R1_offset","SR_autocorr")  ## Need to rivise with example inputs
-  }else if(ctllist$SR_function==4){
+    c("SR_LN(R0)", "SR_Ricker", "SR_sigmaR", "SR_envlink", "SR_R1_offset", 
+      "SR_autocorr")  ## Need to rivise with example inputs
+  } else if(ctllist$SR_function == 4) {
     # SCAA
-    c("SR_LN(R0)","SR_SCAA_null","SR_sigmaR","SR_envlink","SR_R1_offset","SR_autocorr")
-  }else if(ctllist$SR_function==5){
+    c("SR_LN(R0)", "SR_SCAA_null", "SR_sigmaR", "SR_envlink", "SR_R1_offset",
+      "SR_autocorr")
+  } else if(ctllist$SR_function == 5) {
     # Hockey stick
-    c("SR_LN(R0)","SR_hockey_infl","SR_hockey_min_R","SR_sigmaR","SR_envlink","SR_R1_offset","SR_autocorr")
-  }else if(ctllist$SR_function ==6){
+    c("SR_LN(R0)", "SR_hockey_infl", "SR_hockey_min_R", "SR_sigmaR",
+      "SR_envlink", "SR_R1_offset", "SR_autocorr")
+  } else if(ctllist$SR_function == 6) {
     # B-H-flat SRR
-    c("SR_LN(R0)","SR_BH_flat_steep","SR_sigmaR","SR_envlink","SR_R1_offset","SR_autocorr")
-  }else if(ctllist$SR_function==7){
+    c("SR_LN(R0)", "SR_BH_flat_steep", "SR_sigmaR", "SR_envlink",
+      "SR_R1_offset", "SR_autocorr")
+  } else if(ctllist$SR_function == 7) {
     # survival_3Parm
-    c("SR_LN(R0)","SR_surv_Sfrac","SR_surv_Beta","SR_sigmaR","SR_envlink","SR_R1_offset","SR_autocorr")
-  }else if(ctllist$SR_function==8){
+    c("SR_LN(R0)", "SR_surv_Sfrac", "SR_surv_Beta", "SR_sigmaR", "SR_envlink",
+      "SR_R1_offset", "SR_autocorr")
+  } else if(ctllist$SR_function == 8) {
     # Shepard_3Parm
-    c("SR_LN(R0)","SR_steepness","SR_Shepard_c","SR_sigmaR","SR_envlink","SR_R1_offset","SR_autocorr")
-  }else{
+    c("SR_LN(R0)", "SR_steepness", "SR_Shepard_c", "SR_sigmaR", "SR_envlink",
+      "SR_R1_offset", "SR_autocorr")
+  } else {
     stop("SR_function ", ctllist$SR_function, " is not supported yet.")
   }
 
-  PType<-array()
-  ctllist<-add_df(ctllist,name="SR_parms",nrow=N_SRparm2,ncol=7,
-            col.names = srt_par_colnames, comments=SRparmsLabels)
-  PType[1:N_SRparm2]<-17
-  ctllist$SR_parms<-cbind(ctllist$SR_parms,PType)
+  PType <- array()
+  ctllist <- add_df(ctllist, name = "SR_parms", nrow = N_SRparm2, ncol = 7,
+            col.names = srt_par_colnames, comments = SRparmsLabels)
+  PType[1:N_SRparm2] <- 17
+  ctllist$SR_parms <- cbind(ctllist$SR_parms, PType)
   #SR timevarying parlines ----
-  ctllist<-add_elem(ctllist,"SR_env_link") #_SR_env_link
-  ctllist<-add_elem(ctllist,"SR_env_target") #_SR_env_target_0=none;1=devs;_2=R0;_3=steepness
+  ctllist <- add_elem(ctllist, "SR_env_link") #_SR_env_link
+  ctllist <- add_elem(ctllist, "SR_env_target") #_SR_env_target_0=none;1=devs;_2=R0;_3=steepness
   # recdevs ----
-  ctllist<-add_elem(ctllist,"do_recdev") #do_recdev:  0=none; 1=devvector; 2=simple deviations
-  ctllist<-add_elem(ctllist,"MainRdevYrFirst") # first year of main recr_devs; early devs can preceed this era
-  ctllist<-add_elem(ctllist,"MainRdevYrLast") # last year of main recr_devs; forecast devs start in following year
-  ctllist<-add_elem(ctllist,"recdev_phase") #_recdev phase
-  ctllist<-add_elem(ctllist,"recdev_adv") # (0/1) to read 13 advanced options
+  ctllist <- add_elem(ctllist, "do_recdev") #do_recdev:  0=none; 1=devvector; 2=simple deviations
+  ctllist <- add_elem(ctllist, "MainRdevYrFirst") # first year of main recr_devs; early devs can preceed this era
+  ctllist <- add_elem(ctllist, "MainRdevYrLast") # last year of main recr_devs; forecast devs start in following year
+  ctllist <- add_elem(ctllist, "recdev_phase") #_recdev phase
+  ctllist <- add_elem(ctllist, "recdev_adv") # (0/1) to read 13 advanced options
 
-  if(ctllist$recdev_adv){
-    ctllist<-add_elem(ctllist,"recdev_early_start") #_recdev_early_start (0=none; neg value makes relative to recdev_start)
-    ctllist<-add_elem(ctllist,"recdev_early_phase") #_recdev_early_phase
-    ctllist<-add_elem(ctllist,"Fcast_recr_phase") #_forecast_recruitment phase (incl. late recr) (0 value resets to maxphase+1)
-    ctllist<-add_elem(ctllist,"lambda4Fcast_recr_like") #_lambda for Fcast_recr_like occurring before endyr+1
-    ctllist<-add_elem(ctllist,"last_early_yr_nobias_adj") #_last_early_yr_nobias_adj_in_MPD
-    ctllist<-add_elem(ctllist,"first_yr_fullbias_adj") #_first_yr_fullbias_adj_in_MPD
-    ctllist<-add_elem(ctllist,"last_yr_fullbias_adj") #_last_yr_fullbias_adj_in_MPD
-    ctllist<-add_elem(ctllist,"first_recent_yr_nobias_adj") #_first_recent_yr_nobias_adj_in_MPD
-    ctllist<-add_elem(ctllist,"max_bias_adj") #_max_bias_adj_in_MPD (-1 to override ramp and set biasadj=1.0 for all estimated recdevs)
-    ctllist<-add_elem(ctllist,"period_of_cycles_in_recr") #_period of cycles in recruitment (N parms read below)
-    ctllist<-add_elem(ctllist,"min_rec_dev") #min rec_dev
-    ctllist<-add_elem(ctllist,"max_rec_dev") #max rec_dev
-    ctllist<-add_elem(ctllist,"N_Read_recdevs") #_read_recdevs
-    #_end of advanced SR options
-#
-    if(ctllist$period_of_cycles_in_recr>0){
+  if(ctllist$recdev_adv) {
+    ctllist <- add_elem(ctllist, "recdev_early_start") #_recdev_early_start (0=none; neg value makes relative to recdev_start)
+    ctllist <- add_elem(ctllist, "recdev_early_phase") #_recdev_early_phase
+    ctllist <- add_elem(ctllist, "Fcast_recr_phase") #_forecast_recruitment phase (incl. late recr) (0 value resets to maxphase+1)
+    ctllist <- add_elem(ctllist, "lambda4Fcast_recr_like") #_lambda for Fcast_recr_like occurring before endyr+1
+    ctllist <- add_elem(ctllist, "last_early_yr_nobias_adj") #_last_early_yr_nobias_adj_in_MPD
+    ctllist <- add_elem(ctllist, "first_yr_fullbias_adj") #_first_yr_fullbias_adj_in_MPD
+    ctllist <- add_elem(ctllist, "last_yr_fullbias_adj") #_last_yr_fullbias_adj_in_MPD
+    ctllist <- add_elem(ctllist, "first_recent_yr_nobias_adj") #_first_recent_yr_nobias_adj_in_MPD
+    ctllist <- add_elem(ctllist, "max_bias_adj") #_max_bias_adj_in_MPD (-1 to override ramp and set biasadj=1.0 for all estimated recdevs)
+    ctllist <- add_elem(ctllist, "period_of_cycles_in_recr") #_period of cycles in recruitment (N parms read below)
+    ctllist <- add_elem(ctllist, "min_rec_dev") #min rec_dev
+    ctllist <- add_elem(ctllist, "max_rec_dev") #max rec_dev
+    ctllist <- add_elem(ctllist, "N_Read_recdevs") #_read_recdevs
+
+    if(ctllist$period_of_cycles_in_recr > 0) {
       stop("Reading full parameters for recr cycles is not yet coded")
     }
-    if(ctllist$N_Read_recdevs>0){
-  #    stop("Reading specific recdev is not coded in this R code")
-      ctllist<-add_df(ctllist,"recdev_input",ncol=2,nrow=ctllist$N_Read_recdevs,col.names=c("Year","recdev"))
+    if(ctllist$N_Read_recdevs > 0) {
+      ctllist <- add_df(ctllist, "recdev_input", ncol = 2,
+                        nrow = ctllist$N_Read_recdevs,
+                        col.names = c("Year", "recdev"))
     }
   }
 
-
   # F setup ----
-  ctllist<-add_elem(ctllist,"F_ballpark") # F ballpark for annual F (=Z-M) for specified year
-  ctllist<-add_elem(ctllist,"F_ballpark_year") # F ballpark year (neg value to disable)
-  ctllist<-add_elem(ctllist,"F_Method") # F_Method:  1=Pope; 2=instan. F; 3=hybrid (hybrid is recommended)
-  ctllist<-add_elem(ctllist,"maxF") # max F or harvest rate, depends on F_Method
-  if(ctllist$F_Method==1){
+  ctllist <- add_elem(ctllist, "F_ballpark") # F ballpark for annual F (=Z-M) for specified year
+  ctllist <- add_elem(ctllist, "F_ballpark_year") # F ballpark year (neg value to disable)
+  ctllist <- add_elem(ctllist, "F_Method") # F_Method:  1=Pope; 2=instan. F; 3=hybrid (hybrid is recommended)
+  ctllist <- add_elem(ctllist, "maxF") # max F or harvest rate, depends on F_Method
+  if(ctllist$F_Method == 1) {
  #   stop("stop currently F_method:1 is not implemented")
   }else if(ctllist$F_Method==2){
  #   stop("stop currently F_method:2 is not implemented")
-    ctllist<-add_vec(ctllist,"F_setup",length=3) # overall start F value; overall phase; N detailed inputs to read
+    ctllist <- add_vec(ctllist, "F_setup", length = 3) # overall start F value; overall phase; N detailed inputs to read
     if(ctllist$F_setup[3] > 0) {
-      ctllist<-add_df(ctllist,name="F_setup2",nrow=ctllist$F_setup[3],ncol=6,
-                      col.names=c("fleet", "yr", "seas", "Fvalue", "se", "phase"))
+      ctllist <- add_df(ctllist, name = "F_setup2", nrow = ctllist$F_setup[3],
+                        ncol = 6, 
+                        col.names = c("fleet", "yr", "seas", "Fvalue", "se",
+                                      "phase"))
     }
-  }else if(ctllist$F_Method==3){
-    ctllist<-add_elem(ctllist,"F_iter") # N iterations for tuning F in hybrid method (recommend 3 to 7)
+  } else if(ctllist$F_Method == 3) {
+    ctllist <- add_elem(ctllist, "F_iter") # N iterations for tuning F in hybrid method (recommend 3 to 7)
   }
   #
   #_initial_F_parms
-  comments_initF<-paste0("InitF_",1:Nfleet,"_",fleetnames[1:Nfleet])
+  comments_initF <- paste0("InitF_", 1:Nfleet, "_", fleetnames[1:Nfleet])
 
-  PType<-array()
-  #_LO HI INIT PRIOR PR_type SD PHASE
-  ctllist<-add_df(ctllist,name="init_F",nrow=Nfleet,ncol=7,
-    col.names = srt_par_colnames,comments=comments_initF)
-  PType[1:Nfleet]<-18
-  ctllist$init_F<-cbind(ctllist$init_F,PType)
+  PType <- array()
+  ctllist <- add_df(ctllist, name = "init_F", nrow = Nfleet, ncol = 7,
+                    col.names = srt_par_colnames, comments = comments_initF)
+  PType[1:Nfleet] <- 18
+  ctllist$init_F <- cbind(ctllist$init_F, PType)
 
   # Q_setup ----
-  comments_fl<-paste0(1:(Nfleet+Nsurveys)," ",fleetnames)
-  ctllist<-add_df(ctllist,name="Q_setup",nrow=Nfleet+Nsurveys,ncol=4,
-                  col.names=c("Den_dep","env_var","extra_se","Q_type"),comments=comments_fl)
+  comments_fl <- paste0(1:(Nfleet+Nsurveys), " ", fleetnames)
+  ctllist <- add_df(ctllist, name = "Q_setup", nrow = Nfleet + Nsurveys,
+                    ncol = 4, 
+                    col.names=c("Den_dep","env_var","extra_se","Q_type"),
+                    comments = comments_fl)
 
-  Do_Q_detail<-FALSE
-  if(sum(ctllist$Q_setup[,4] %in% c(3,4))>0){
-    ctllist<-add_elem(ctllist,name="Do_Q_detail")  ##
-    Do_Q_detail<-ctllist$Do_Q_detail
+  Do_Q_detail <- FALSE
+  if(sum(ctllist$Q_setup[, 4] %in% c(3, 4)) > 0) {
+    ctllist <- add_elem(ctllist, name = "Do_Q_detail")  ##
+    Do_Q_detail <- ctllist$Do_Q_detail
   }
 
-  nqp<-0
-  comments_Q_type<-list()
+  nqp <- 0
+  comments_Q_type <- list()
 
   # Density dependant Q(Q-power)
-  for(i in 1:(Nfleet+Nsurveys))
-  {
-    if(ctllist$Q_setup[i,]$Den_dep>0)
-    {
-      comments_Q_type[(nqp+1)]<-paste0("Q_power_",i,"_",fleetnames[i],collapse="")
-      nqp<-nqp+1
+  for(i in 1:(Nfleet+Nsurveys)) {
+    if(ctllist$Q_setup[i, ]$Den_dep > 0) {
+      comments_Q_type[(nqp+1)] <-
+        paste0("Q_power_", i, "_", fleetnames[i], collapse="")
+      nqp <- nqp + 1
     }
   }
 
   # Q-env
-  for(i in 1:(Nfleet+Nsurveys))
-  {
-    if(ctllist$Q_setup[i,]$env_var>0)
-    {
-      comments_Q_type[(nqp+1)]<-paste0("Q_env_",i,"_",fleetnames[i],collapse="")
-      nqp<-nqp+1
+  for(i in 1:(Nfleet+Nsurveys)) {
+    if(ctllist$Q_setup[i, ]$env_var > 0) {
+      comments_Q_type[(nqp+1)] <- paste0("Q_env_", i, "_", fleetnames[i],
+                                         collapse = "")
+      nqp <- nqp + 1
     }
   }
 
   # Q_extraSD
-  for(i in 1:(Nfleet+Nsurveys))
-  {
-    if(ctllist$Q_setup[i,]$extra_se>0)
-    {
-      comments_Q_type[(nqp+1)]<-paste0("Q_extraSD_",i,"_",fleetnames[i],collapse="")
-      nqp<-nqp+1
+  for(i in 1:(Nfleet+Nsurveys)) {
+    if(ctllist$Q_setup[i, ]$extra_se > 0) {
+      comments_Q_type[(nqp+1)] <- paste0("Q_extraSD_", i, "_", fleetnames[i],
+                                         collapse="")
+      nqp <- nqp + 1
     }
   }
 
@@ -696,61 +720,67 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
   ## If yes, read 1 number for flag to see if to read single parameter for each random Q or
   ## one parameter for each data point
   # Q-type
-  N_Q_parms<-nqp
-  i<-nqp+1
-  for(fl in 1:(Nfleet+Nsurveys)){
-    flname<-fleetnames[fl]
-    .Q_type<-ctllist$Q_setup[fl,4]
-    if(.Q_type==2){ # One Q parameter
-      N_Q_parms<-N_Q_parms+1
-      comments_Q_type[[i]]<-paste0("LnQ_base_",fl,"_",flname,collapse="");i<-i+1
-    }else if(.Q_type==3){ # Random Q deviations
-      N_Q_parms<-N_Q_parms+1
-      comments_Q_type[[i]]<-paste0("LnQ_base_",fl,"_",flname,collapse="");i<-i+1
-      if(Do_Q_detail){
-        for(j in 1:(N_CPUE_obs[fl]))
-        {
-          comments_Q_type[[i+j-1]]<-paste0("Q_dev_",j,"_",fl,"_",flname)
+  N_Q_parms <- nqp
+  i <- nqp + 1
+  for(fl in 1:(Nfleet + Nsurveys)) {
+    flname <- fleetnames[fl]
+    .Q_type <- ctllist$Q_setup[fl, 4]
+    if(.Q_type == 2) { # One Q parameter
+      N_Q_parms <- N_Q_parms + 1
+      comments_Q_type[[i]] <- 
+        paste0("LnQ_base_", fl, "_", flname, collapse = "")
+      i <- i + 1
+    }else if(.Q_type == 3) { # Random Q deviations
+      N_Q_parms <- N_Q_parms + 1
+      comments_Q_type[[i]] <- paste0("LnQ_base_", fl, "_", flname,
+                                     collapse = "")
+      i <- i + 1
+      if(Do_Q_detail) {
+        for(j in 1:(N_CPUE_obs[fl])) {
+          comments_Q_type[[i+j-1]] <- paste0("Q_dev_", j, "_", fl, "_", flname)
         }
-        N_Q_parms<-N_Q_parms+N_CPUE_obs[fl]
-        i<-i+j
+        N_Q_parms <- N_Q_parms + N_CPUE_obs[fl]
+        i <- i + j
       }
-    }else if(.Q_type==4){# Random walk W
-      N_Q_parms<-N_Q_parms+1
-      comments_Q_type[[i]]<-paste0("LnQ_base_",fl,"_",flname,collapse="");i<-i+1
-      if(Do_Q_detail){
-        for(j in 1:(N_CPUE_obs[fl]-1))
-        {
-          comments_Q_type[[i+j-1]]<-paste0("Q_walk_",j,"_",fl,"_",flname)
+    } else if(.Q_type == 4) {# Random walk W
+      N_Q_parms <- N_Q_parms + 1
+      comments_Q_type[[i]] <- paste0("LnQ_base_", fl, "_", flname,
+                                     collapse = "")
+      i <- i + 1
+      if(Do_Q_detail) {
+        for(j in 1:(N_CPUE_obs[fl]-1)) {
+          comments_Q_type[[i+j-1]] <- paste0("Q_walk_", j, "_", fl, "_", flname)
         }
-        N_Q_parms<-N_Q_parms+N_CPUE_obs[fl]-1
-        i<-i+j
-        # comments_Q_type[[i]][2:N_CPUE_obs[fl]]<-paste0("Q_walk_",1:(N_CPUE_obs[fl]-1),"_",fl,"_",flname)
+        N_Q_parms <- N_Q_parms + N_CPUE_obs[fl] - 1
+        i <- i + j
       }
-    }else if(.Q_type==5){
-      N_Q_parms<-N_Q_parms+1
-      comments_Q_type[[i]]<-paste0("LnQ_base_",fl,"_",flname,collapse="");i<-i+1
+    } else if(.Q_type == 5) {
+      N_Q_parms <- N_Q_parms + 1
+      comments_Q_type[[i]] <- paste0("LnQ_base_", fl, "_", flname,
+                                     collapse = "")
+      i <- i + 1
     }
   }
 
-  if(N_Q_parms>0){
-    ctllist<-add_df(ctllist,name="Q_parms",nrow=N_Q_parms,ncol=7,
+  if(N_Q_parms > 0) {
+    ctllist <- add_df(ctllist, name = "Q_parms", nrow = N_Q_parms, ncol = 7,
                 col.names = srt_par_colnames,
-                comments=unlist(comments_Q_type))
+                comments = unlist(comments_Q_type))
   }
   # selecitivty -----
 # size_selex_types
-  comments_selex_types<-fleetnames
-  ctllist<-add_df(ctllist,name="size_selex_types",nrow=Nfleet+Nsurveys,ncol=4,
-              col.names=c("Pattern","Discard","Male","Special"),comments=comments_selex_types)
-  size_selex_pattern_vec<-as.vector(ctllist$size_selex_types[,1])
-#
-#_age_selex_types
-#_Pattern ___ Male Special
+  comments_selex_types <- fleetnames
+  ctllist <- add_df(ctllist, name = "size_selex_types", 
+                    nrow = Nfleet + Nsurveys, ncol = 4,
+                    col.names = c("Pattern", "Discard", "Male", "Special"),
+                    comments = comments_selex_types)
+  size_selex_pattern_vec <- as.vector(ctllist$size_selex_types[, 1])
 
-  ctllist<-add_df(ctllist,name="age_selex_types",nrow=Nfleet+Nsurveys,ncol=4,
-              col.names=c("Pattern","Discard","Male","Special"),comments=comments_selex_types)
-  age_selex_pattern_vec<-as.vector(ctllist$age_selex_types[,1])
+  ctllist <- add_df(ctllist, name = "age_selex_types", nrow = Nfleet + Nsurveys,
+                    ncol = 4,
+                    col.names = c("Pattern", "Discard", "Male", "Special"),
+                    comments = comments_selex_types)
+  age_selex_pattern_vec <- as.vector(ctllist$age_selex_types[, 1])
 
 
   #                 0 1 2 3 4 5 6 7 8 9 10
@@ -762,17 +792,18 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
   #                31 32 33 34
                     0, 0, 0, 0)
 #########################################################
-  size_selex_Nparms<-vector(mode="numeric",length=Nfleet+Nsurveys)
-  size_selex_label<-list()
-  for(j in 1:(Nfleet+Nsurveys)){
+  size_selex_Nparms <- vector(mode = "numeric", length = Nfleet + Nsurveys)
+  size_selex_label <- list()
+  for(j in 1:(Nfleet+Nsurveys)) {
        #    size_selex_pattern_vec
-    size_selex_Nparms[j]<-selex_patterns[size_selex_pattern_vec[j]+1]
+    size_selex_Nparms[j] <- selex_patterns[size_selex_pattern_vec[j] + 1]
     ## some patterns need special treatment
     special_selex <- FALSE	# change flag to TRUE if need special treatment
-    if(size_selex_pattern_vec[j]==27){ # spline
+    if(size_selex_pattern_vec[j] == 27) { # spline
 	  special_selex <- TRUE				 
-      size_selex_Nparms[j]<-size_selex_Nparms[j]+ctllist$size_selex_types[j,4]*2
-      size_selex_label[[j]]<-c(paste0("SizeSpline_Code_",fleetnames[j],"_",j),
+      size_selex_Nparms[j] <- size_selex_Nparms[j] +
+                                ctllist$size_selex_types[j, 4]*2
+      size_selex_label[[j]] <- c(paste0("SizeSpline_Code_",fleetnames[j],"_",j),
                              paste0("SizeSpline_GradLo_",fleetnames[j],"_",j),
                              paste0("SizeSpline_GradHi_",fleetnames[j],"_",j),
                              paste0("SizeSpline_Knot_",1:ctllist$size_selex_types[j,4],"_",fleetnames[j],"_",j),

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -316,9 +316,8 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
   }else if(ctllist$GrowthModel==3){ # 3=age_specific_K
   #  AFIX=tempvec5(1);
   #  AFIX2=tempvec5(2);
-    Age_K_count<-ctllist$N_ageK
-    N_growparms=5+Age_K_count
-    ctllist<-add_vec(ctllist,name="Age_K_points",length=Age_K_count)
+    N_growparms <- 5 + ctllist$N_ageK
+    ctllist<-add_vec(ctllist,name="Age_K_points",length=ctllist$N_ageK)
     #  points at which age-specific multipliers to K will be applied
 
   }else if(ctllist$GrowthModel==4){
@@ -386,10 +385,10 @@ SS_readctl_3.24 <- function(file,verbose=TRUE,echoall=FALSE,version="3.24",
         PType[cnt:(6+cnt-1)]<-2
         cnt<-cnt+6
       }else if(ctllist$GrowthModel==3){
-        tmp<-c("L_at_Amin_","L_at_Amax_","VonBert_K_",paste0("Age_K_",1:Age_K_count),"CV_young_","CV_old_")
-        MGparmLabel[1:(5+Age_K_count)+cnt-1]<-paste0(tmp,"_",GenderLabel[i],"_GP_",j)
-        PType[cnt:((5+Age_K_count)+cnt-1)]<-2
-        cnt<-cnt+5+Age_K_count
+        tmp<-c("L_at_Amin_","L_at_Amax_","VonBert_K_",paste0("Age_K_",1:ctllist$N_ageK),"CV_young_","CV_old_")
+        MGparmLabel[1:(5+ctllist$N_ageK)+cnt-1]<-paste0(tmp,"_",GenderLabel[i],"_GP_",j)
+        PType[cnt:((5+ctllist$N_ageK)+cnt-1)]<-2
+        cnt<-cnt+5+ctllist$N_ageK
       }
     }
   }

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -192,7 +192,10 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
   wl("GrowthModel",comment="# GrowthModel: 1=vonBert with L1&L2; 2=Richards with L1&L2; 3=age_speciific_K; 4=not implemented")
   wl("Growth_Age_for_L1")
   wl("Growth_Age_for_L2",comment="#_Growth_Age_for_L2 (999 to use as Linf)")
-
+  if(ctllist$GrowthModel == 3) {
+    wl("N_ageK", comment = "# number of K multipliers to read")
+    wl.vector("Age_K_points", comment = "# ages for K multiplier")
+  }
   wl("SD_add_to_LAA",comment="#_SD_add_to_LAA (set to 0.1 for SS2 V1.x compatibility)")
   wl("CV_Growth_Pattern",comment="#_CV_Growth_Pattern:  0 CV=f(LAA); 1 CV=F(A); 2 SD=F(LAA); 3 SD=F(A); 4 logSD=F(A)")
   wl("maturity_option",comment=

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -134,8 +134,8 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
   }
 
   # write a header
+  writeComment("#V3.24")
   writeComment("#C control file created using the SS_writectl function in the R package r4ss")
-  writeComment(paste("#C should work with SS version:",ctllist$SSversion))
   writeComment(paste("#C file write time:",Sys.time()))
   writeComment("#")
 

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -216,12 +216,34 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
   #writeComment("#_LO HI INIT PRIOR PR_type SD PHASE env-var use_dev dev_minyr dev_maxyr dev_stddev Block Block_Fxn")
   printdf("MG_parms")
 
+  # MG environmental linkage lines
   writeComment("#")
-  writeComment("#_Cond 0  #custom_MG-env_setup (0/1)")
-  writeComment("#_Cond -2 2 0 0 -1 99 -2 #_placeholder when no MG-environ parameters")
+  if(any(ctllist$MG_parms$env_var > 0)) {
+    wl("read_MG_custom_env_var")
+    if(ctllist$read_MG_custom_env_var == 1) {
+      printdf("MG_custom_env_var")
+    } else {
+      writeComment("#_Cond -2 2 0 0 -1 99 -2 #_placeholder when no MG-environ parameters")
+    }
+  } else {
+    writeComment("#_Cond 0  #custom_MG-env_setup (0/1)")
+    writeComment("#_Cond -2 2 0 0 -1 99 -2 #_placeholder when no MG-environ parameters")
+  }
   writeComment("#")
-  writeComment("#_Cond 0  #custom_MG-block_setup (0/1)")
-  writeComment("#_Cond -2 2 0 0 -1 99 -2 #_placeholder when no MG-block parameters")
+  
+  # MG block lines
+  if(!is.null(ctllist[["custom_MG_block"]])) {
+    wl("custom_MG_block")
+    if(ctllist[["custom_MG_block"]] == 1) {
+      printdf("MG_parms_blocks")
+    } else {
+      writeComment("#_Cond -2 2 0 0 -1 99 -2 #_placeholder when no MG-block parameters")
+    } 
+  } else {
+    writeComment("#_Cond 0  #custom_MG-block_setup (0/1)")
+    writeComment("#_Cond -2 2 0 0 -1 99 -2 #_placeholder when no MG-block parameters")
+  }
+
   writeComment("#_Cond No MG parm trends")
   writeComment("#")
   writeComment("#_seasonal_effects_on_biology_parms")

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -218,7 +218,7 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
 
   # MG environmental linkage lines
   writeComment("#")
-  if(any(ctllist$MG_parms$env_var > 0)) {
+  if(any(ctllist$MG_parms$env_var != 0)) {
     wl("read_MG_custom_env_var")
     if(ctllist$read_MG_custom_env_var == 1) {
       printdf("MG_custom_env_var")
@@ -230,7 +230,6 @@ SS_writectl_3.24 <- function(ctllist,outfile,overwrite=FALSE,verbose=TRUE,
     writeComment("#_Cond -2 2 0 0 -1 99 -2 #_placeholder when no MG-environ parameters")
   }
   writeComment("#")
-  
   # MG block lines
   if(!is.null(ctllist[["custom_MG_block"]])) {
     wl("custom_MG_block")

--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -1156,7 +1156,6 @@ SSplotComparisons <-
     if(!any(uncertainty)){
       show_uncertainty <- FALSE
     }
-    browser()
     # empty plot
     if(is.null(xlim)){
       xlim <- range(recdevs$Yr, na.rm=TRUE)


### PR DESCRIPTION
Includes fixes and improvements to `SS_readctl_3.24()` and `SS_writectl_3.24()`. Note that users should access these functions by calling `SS_readctl()` and `SS_writectl()`.

Fixes include:
- Ability to read and write the MG env var short parameter lines
- write all par lines for growth model option 3

Improvements include:
- `SS_writectl_3.24()` writes `#v3.24` at the top of the file
- style changes to code to make it more readable and consistent
- slight refactoring to remove an unused object `Age_K_count` in `SS_readctl_3.24`