### PR TITLE
Read and write custom reporting options in starter file

### DIFF
--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -70,6 +70,16 @@ SS_readstarter <-  function(file='starter.ss', verbose=TRUE){
   mylist$init_values_src <- allnums[i]; i <- i+1
   mylist$run_display_detail <- allnums[i]; i <- i+1
   mylist$detailed_age_structure <- allnums[i]; i <- i+1
+  if(mylist$detailed_age_structure == 3) {
+    mylist$custom_start <- allnums[i]; i <- i + 1
+    end_custom <- which(allnums == -999) 
+    end_custom <- end_custom[end_custom >= i] #return only vals after i
+    end_custom <- end_custom[1] # return first value after i.
+    if(end_custom > i) {
+      mylist$custom_add_rm <- allnums[i:(end_custom-1)]
+    }
+    i <- end_custom + 1
+  }
   mylist$checkup <- allnums[i]; i <- i+1
   mylist$parmtrace <- allnums[i]; i <- i+1
   mylist$cumreport <- allnums[i]; i <- i+1

--- a/R/SS_writestarter.R
+++ b/R/SS_writestarter.R
@@ -58,6 +58,21 @@ SS_writestarter <- function(mylist, dir=NULL, file="starter.ss",
     value = mylist[names(mylist)==name]
     writeLines(paste0(value," #_",name),con=zz)
   }
+  
+  # function to write a vector
+  wl.vector <- function(name,
+                        comment = NULL,
+                        collapse = NULL) {
+    value = mylist[names(mylist) == name][[1]]
+    if (is.null(collapse))
+      collapse <- " "
+    if (is.null(comment)) {
+      writeLines(paste(paste(value, collapse = collapse), " #_", name, sep = ""), con =
+                   zz)
+    }else{
+      writeLines(paste(paste(value, collapse = collapse), comment), con = zz)
+    }
+  }
 
   writeLines("#C starter file written by R function SS_writestarter")
   writeLines("#C rerun model to get more complete formatting in starter.ss_new")
@@ -73,6 +88,13 @@ SS_writestarter <- function(mylist, dir=NULL, file="starter.ss",
   wl("init_values_src")
   wl("run_display_detail")
   wl("detailed_age_structure")
+  if(mylist$detailed_age_structure == 3) {
+    writeLines(paste0("# custom report options: -100 to start with minimal; ",
+      "-101 to start with all; -number to remove, +number to add, -999 to end"))
+    wl("custom_start")
+    if(!is.null(mylist$custom_add_rm)) wl.vector("custom_add_rm")
+    writeLines("-999")
+  }
   wl("checkup")
   wl("parmtrace")
   wl("cumreport")

--- a/tests/testthat/test_simple.R
+++ b/tests/testthat/test_simple.R
@@ -272,3 +272,31 @@ test_that("SS_readforecast and SS_writeforecast both work for 3.30.13", {
     "Even though writeAll == TRUE, cannot write past list element Forecast")
   expect_true(file.exists(file.path(temp_path, "fore_0_read_short.ss")))
 })
+
+###############################################################################
+# testing read/write starter functions ----
+###############################################################################
+
+test_that("SS_readstater and SS_writestarter both work for 3.30.13", {
+  # read data file
+  start <- SS_readstarter(file = file.path(example_path,"simple_3.30.13/starter.ss"),
+                                           verbose = FALSE)
+  # write data file
+  SS_writestarter(start,
+              dir = temp_path, 
+              file = "teststarter_3.30.13.ss",
+              verbose = FALSE)
+  expect_true(file.exists(file.path(temp_path, "teststarter_3.30.13.ss")))
+})
+
+test_that("SS_readstater and SS_writestarter both work for 3.24", {
+  # read data file
+  start <- SS_readstarter(file = file.path(example_path,"simple_3.24/starter.ss"),
+                          verbose = FALSE)
+  # write data file
+  SS_writestarter(start,
+                  dir = temp_path, 
+                  file = "teststarter_3.24.ss",
+                  verbose = FALSE)
+  expect_true(file.exists(file.path(temp_path, "teststarter_3.24.ss")))
+})


### PR DESCRIPTION
This development is for a custom reporting feature (detailed output option = 3) to come in the 3.30.16 release of Stock Synthesis. It allows the setup in the starter file to be read in and written out. These changes were tested locally on models that use and don't use the custom reporting feature.