### PR TITLE
fix(SS_output): lenntune had non-numeric values of _ for fleet 3

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -1927,12 +1927,14 @@ SS_output <-
 
     # Length_Comp_Fit_Summary
     if (SS_versionNumeric < 3.30) {
-      # old way didn't have key word and had parantheses and other issues with column names
+      # old way didn't have key word and had parentheses and other issues with column names
       lenntune <- matchfun2("FIT_AGE_COMPS", -(nfleets + 2),
         "FIT_AGE_COMPS", -1,
         cols = 1:10, header = TRUE
       )
       names(lenntune)[10] <- "FleetName"
+      # convert underscores
+      lenntune[lenntune == "_"] <- NA
       # reorder columns (leaving out sample sizes perhaps to save space)
       lenntune <- lenntune[lenntune$N > 0, c(10, 1, 4:9)]
       # avoid NA warnings by removing #IND values


### PR DESCRIPTION
I am not sure why development is currently passing because I found the error
when running check() on development.

* Copied code from agentune that changed _ to NA so type.convert can
change all values to numeric ones for mathematical operations.
* I did not remove these rows of NA as is done in agentune.
* future development should work to include a function to process the tuning
information, this new internal function could be used to process each each tuning section rather than
have code that is duplicated for the two sections.
