### PR TITLE
fix: movement in ss_output

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -3115,15 +3115,13 @@ SS_output <-
     movement <- matchfun2("MOVEMENT", 1, substr1 = FALSE, header = TRUE)
     if (!is.null(movement)) {
       names(movement) <- c(
-        movement[1, 1:6],
-        paste("age", movement[1, -(1:6)], sep = "")
+        names(movement)[1:6],
+        paste("age", names(movement)[-(1:6)], sep = "")
       )
       movement <- df.rename(movement,
         oldnames = c("Gpattern"),
         newnames = c("GP")
       )
-
-      movement <- movement[-1, ]
       for (i in 1:ncol(movement)) {
         movement[, i] <- as.numeric(movement[, i])
       }


### PR DESCRIPTION
headers were being created from the first row when they are already being pulled in matchfun2. Thanks to Dan Fu for reporting this bug (https://vlab.ncep.noaa.gov/web/stock-synthesis/public-forums/-/message_boards/view_message/11095850)

@iantaylor-NOAA could you make sure this change looks ok and merge in if so?