### PR TITLE
Allow relative path to exe in run_SS_models, fix to check in SS_tune_comps

### DIFF
--- a/R/SS_tune_comps.R
+++ b/R/SS_tune_comps.R
@@ -127,10 +127,15 @@ SS_tune_comps <- function(replist = NULL, fleets = "all",
     verbose = FALSE
   )
   if (fleets[1] == "all") {
-    fleets <- 1:dat$Nfleets
+    fleets <- seq_len(dat$Nfleets)
   } else {
-    if (length(intersect(dat$Nfleets, 1:dat$Nfleets)) != length(fleets)) {
-      stop("Input 'fleets' should be 'all' or a vector of fleet numbers.")
+    if (!all(fleets %in% seq_len(dat$Nfleets))) {
+      fleets <- fleets[fleets %in% seq_len(dat$Nfleets)]
+      warning("Not all fleets are included in the model. Changing fleets to ",
+              "use only ones in the model: ", paste0(fleets, collapse = ", "))
+      if(length(fleets) == 0) {
+        stop("Please specify fleets used in the model")
+      }
     }
   }
   # add check that last_phase is less than max_phase in starter. If not,

--- a/R/run_SS_models.R
+++ b/R/run_SS_models.R
@@ -74,6 +74,15 @@ run_SS_models <- function(dirvec = NULL,
       exe <- tmp_exe
     }
   } else {
+    # check if exe is in PATH, to warn user this will be used by default
+    tmp_exe <- Sys.which(basename(exe))[[1]] # get 1st ss exe with name exe that is in your path
+    if(tmp_exe != "") {
+      warning("An binary named ", basename(exe), 
+              " was found in your PATH and will be", 
+              " used by default even though exe_in_path is FALSE. Please remove", 
+              " the exe in your PATH to avoid this behavior. This binary is", 
+              " located at ", normalizePath(tmp_exe), ".")
+    }
     # check if model is in the same dir as each folder of dir vec. If not
     # found in all folders, see if can find using the relative or absolute path.
     # If can't find, revert back to assuming the model is in each folder of the
@@ -86,9 +95,9 @@ run_SS_models <- function(dirvec = NULL,
         exe_exists <- TRUE
       }
       exe_exists
-    }, mod = model)
+    }, mod = exe)
     if(!all(unlist(all_exes_in_folder) == TRUE)) {
-      exists_abs_path <- file.info(normalizePath(model))$exe
+      exists_abs_path <- file.info(normalizePath(exe, mustWork = FALSE))$exe
       if(is.na(exists_abs_path) | (exists_abs_path) == "no" ) {
         exe_exists_abs_path <- FALSE
       } else {
@@ -96,7 +105,7 @@ run_SS_models <- function(dirvec = NULL,
       }
       if(exe_exists_abs_path) {
         message("Assuming path to the exe provided in model")
-        model <- (normalizePath(model))
+        exe <- (normalizePath(exe))
       } else {
         message("Assuming model is in each dirvec folder, but missing from ", 
                 "some folders")
@@ -125,7 +134,7 @@ run_SS_models <- function(dirvec = NULL,
         message("changing working directory to ",dir)
         setwd(dir) # change working directory
 
-        command <- paste(model, extras)
+        command <- paste(exe, extras)
         if(OS!="windows"){
           command <- paste0("./", command)
         }

--- a/R/run_SS_models.R
+++ b/R/run_SS_models.R
@@ -3,7 +3,13 @@
 #' Loops over a vector of directories and iteratively runs SS in each one
 #'
 #' @param dirvec List of directories containing the model files
-#' @param model Executable name
+#' @param model Executable name or path to executable (absolute path, or relative
+#'  to the working directory). First, if exe_in_path is
+#'  FALSE, The function will look an executable with the same name in each
+#'  element of dirvec. Then, if it is not found in each, the function will
+#'  assume that model is the path to the executable and there is only 1 copy of
+#'  the executable. Note that if there is an exe in your PATH with the same 
+#'  name, this will be used even if exe_in_path is FALSE.
 #' @param extras Additional commands to use when running SS. Default = "-nox"
 #' will reduce the amount of command-line output.
 #' @param systemcmd Should R call SS using "system" function instead of "shell".
@@ -23,9 +29,11 @@
 #' @examples
 #'
 #'   \dontrun{
-#' dirvec <- dir("c:/SS/models_to_run", full.names=TRUE)
-#' run_SS_models(dirvec=dirvec)
-#' 
+#' extdata_mods <- system.file("extdata", package = "r4ss")
+#' dirvec <- c(file.path(extdata_mods, "simple_3.30.12"), 
+#'             file.path(extdata_mods, "simple_3.30.13"))
+#' # if ss or ss.exe is available in both directories:
+#' run_SS_models(dirvec = dirvec)
 #'   }
 #'
 
@@ -54,11 +62,10 @@ run_SS_models <- function(dirvec = NULL,
   if(length(grep(".exe",tolower(model))) == 1){
     # if input 'model' includes .exe then assume it's Windows and just use the name
     exe <- model
-  }else{
+  } else {
     # if 'model' doesn't include .exe then append it (for Windows computers only)
     exe <- paste(model, ifelse(OS=="windows",".exe",""),sep="")
   }
-  
   if(exe_in_path == TRUE) {
     tmp_exe <- Sys.which(exe)[[1]] # get 1st ss exe with name exe that is in your path
     if(tmp_exe == ""){
@@ -66,10 +73,41 @@ run_SS_models <- function(dirvec = NULL,
     } else {
       exe <- tmp_exe
     }
+  } else {
+    # check if model is in the same dir as each folder of dir vec. If not
+    # found in all folders, see if can find using the relative or absolute path.
+    # If can't find, revert back to assuming the model is in each folder of the
+    # dirvec.
+    all_exes_in_folder <- lapply(dirvec, function(dir, mod) {
+      exists <- file.info(file.path(dir, mod))$exe
+      if(is.na(exists) | exists == "no" ) {
+        exe_exists <- FALSE
+      } else {
+        exe_exists <- TRUE
+      }
+      exe_exists
+    }, mod = model)
+    if(!all(unlist(all_exes_in_folder) == TRUE)) {
+      exists_abs_path <- file.info(normalizePath(model))$exe
+      if(is.na(exists_abs_path) | (exists_abs_path) == "no" ) {
+        exe_exists_abs_path <- FALSE
+      } else {
+        exe_exists_abs_path <- TRUE
+      }
+      if(exe_exists_abs_path) {
+        message("Assuming path to the exe provided in model")
+        model <- (normalizePath(model))
+      } else {
+        message("Assuming model is in each dirvec folder, but missing from ", 
+                "some folders")
+      }
+    } else {
+      message("Assuming model is in each dirvec folder.")
+    }
   }
 
   # loop over directories
-  for(idir in 1:length(dirvec)){
+  for(idir in seq_along(dirvec)){
     # directory where stuff will happen
     dir <- dirvec[idir]
     
@@ -78,13 +116,6 @@ run_SS_models <- function(dirvec = NULL,
       warning("not a directory:", dir)
       results[idir] <- "not a directory"
     }else{
-      # check whether exe is in directory (if not using exe in path)
-      if(all(file.info(dir(dir, full.names=TRUE))$exe=="no")){
-        if(exe_in_path == FALSE){
-          warning("Executable ",exe," not found in ",dir)
-          results[idir] <- "no executable"
-        }
-      }
       if(skipfinished & "Report.sso" %in% dir(dir)){
         # skip directories that have results in them
         message("Skipping ", dir, " since it contains a Report.sso file and skipfinished=TRUE")
@@ -115,12 +146,17 @@ run_SS_models <- function(dirvec = NULL,
                      con = 'console.output.txt')
           message("console output written to console.output.txt")
         }
-        results[idir] <- "ran model"
+        if(isTRUE(console.output > 0)) {
+          results[idir] <- "model run failed"
+        } else if (isTRUE(console.output == 0)){
+          results[idir] <- "ran model"
+        } else {
+          results[idir] <- "unknown run status"
+        }
         setwd(wd_orig) # needed when using relative paths
       } # end model run
     } # end code for exe present
   } # end loop over directories
-
   # return table of results
   return(data.frame(dir=dirvec, results=results))
 }

--- a/tests/testthat/test-tune_comps.R
+++ b/tests/testthat/test-tune_comps.R
@@ -14,6 +14,15 @@ runs_path <- file.path(tmp_path, "extdata")
 #clean up
 on.exit(unlink(tmp_path, recursive = TRUE))
 
+test_that("get_last_phase works", {
+  start <- r4ss::SS_readstarter(file.path(runs_path,  "simple_3.30.13", "starter.ss"), verbose = FALSE)
+  dat <- r4ss::SS_readdat(file.path(runs_path,  "simple_3.30.13", start$datfile), verbose = FALSE)
+  ctl <- r4ss::SS_readctl(file.path(runs_path,  "simple_3.30.13", start$ctlfile), use_datlist = TRUE,
+                          datlist = dat, verbose = FALSE)
+  last_phase <- get_last_phase(ctl)
+  expect_true(last_phase == 4) # based on last known value.
+})
+
 test_that(" ss tune comps works when just want to return the Francis table", {
   replist <- suppressWarnings(SS_output(dir = file.path(runs_path, "simple_3.30.13"), 
                                         verbose = FALSE, hidewarn = TRUE, printstats = FALSE))


### PR DESCRIPTION
This PR partially addresses #430 by allowing relative paths to the executable in `run_SS_models`. It also adds some additional checks on where the exe is located. Note, however, it is not perfect; The biggest issue I'm not sure how to fix is that if you wanted to use an exe called "ss.exe" in each model folder specified in dirvec, but ss.exe was also in the user's PATH (environmental variables) , the PATH version would be used by default even if `exe_in_path = FALSE`.  I have added a warning when this happens, but there may be a cleaner solution (for example, maybe we don't really need the `exe_in_path` argument at all?

This also includes a fix to a check on the `fleets` argument in `SS_tune_comps` that wasn't working properly.