### PR TITLE
Killoutput

### DIFF
--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -69,7 +69,7 @@ SS_readdat_3.30 <-
       stop("Error - There was no EOF marker (999) in the data file.")
     }
     if (is.null(section)) {
-      if (Nsections > 1) {
+      if (Nsections > 1 & verbose) {
         message(
           "The supplied data file has ", Nsections,
           ifelse(Nsections == 1, " section. ", " sections. "),

--- a/R/SS_tune_comps.R
+++ b/R/SS_tune_comps.R
@@ -283,13 +283,16 @@ SS_tune_comps <- function(replist = NULL, fleets = "all",
         skipfinished = FALSE, verbose = verbose,
         exe_in_path = exe_in_path, ...
       )
-      replist <- SS_output(
-        dir = dir, verbose = FALSE, printstats = FALSE,
-        hidewarn = TRUE
-      )
+      suppressWarnings(
+        replist <- SS_output(
+          dir = dir, verbose = FALSE, printstats = FALSE,
+          covar = !grepl("nohess", extras),
+          hidewarn = TRUE
+        )
+     )
     }
     if (niters_tuning == 0 | option == "none") {
-      # calculate the tuning table and regurn
+      # calculate the tuning table and rerun
       tuning_table <- get_tuning_table(
         replist = replist, fleets = fleets,
         option = option, digits = digits,
@@ -306,6 +309,7 @@ SS_tune_comps <- function(replist = NULL, fleets = "all",
         suppressWarnings(
           out <- SS_output(dir,
             verbose = FALSE, printstats = FALSE,
+            covar = !grepl("nohess", extras),
             hidewarn = TRUE
           )
         )
@@ -461,6 +465,7 @@ SS_tune_comps <- function(replist = NULL, fleets = "all",
       suppressWarnings(
         out <- SS_output(dir,
           verbose = FALSE, printstats = FALSE,
+          covar = !grepl("nohess", extras),
           hidewarn = TRUE
         )
       )

--- a/R/SS_tune_comps.R
+++ b/R/SS_tune_comps.R
@@ -215,7 +215,8 @@ SS_tune_comps <- function(replist = NULL, fleets = "all",
   # read in model files
   # get the r4ss files
   start <- SS_readstarter(file.path(dir, "starter.ss"), verbose = FALSE)
-  dat <- SS_readdat(file.path(dir, start[["datfile"]]), verbose = FALSE)
+  dat <- SS_readdat(file.path(dir, start[["datfile"]]),
+    verbose = FALSE, section = 1)
   ctl <- SS_readctl(file.path(dir, start[["ctlfile"]]),
     use_datlist = TRUE, datlist = dat,
     verbose = FALSE
@@ -325,7 +326,7 @@ SS_tune_comps <- function(replist = NULL, fleets = "all",
           verbose = FALSE
         )
         dat <- SS_readdat(file.path(dir, start[["datfile"]]),
-          verbose = FALSE
+          verbose = FALSE, section = 1
         )
         ctl <- SS_readctl(file.path(dir, start[["ctlfile"]]),
           use_datlist = TRUE, datlist = dat,

--- a/R/run_SS_models.R
+++ b/R/run_SS_models.R
@@ -138,7 +138,7 @@ run_SS_models <- function(dirvec = NULL,
         if (OS == "windows" & !systemcmd) {
           console.output <- shell(cmd = command, intern = intern)
         } else {
-          console.output <- system(command, intern = intern)
+          console.output <- system(command, intern = intern, show.output.on.console = verbose)
         }
         if (intern) {
           writeLines(c(


### PR DESCRIPTION
Working with ss3sim that uses SS_tune_comps to reweight data behind the scenes, I am trying to limit the output that is printed to the screen if verbose = FALSE. Which led to two things
1. SS_tune_comps() reads in report files with SS_output multiple times without setting covar = FALSE or TRUE. This is okay, but I put in a check to see if you for sure are not running with the hessian then do not try to have covar = TRUE. This essentially doesn't change anything. I did note that if you set covar = FALSE and you do have the hessian, that the results of Francis low and Francis hi will be different. Should we not be reporting these values if there is no hessian? Doesn't matter for weighting though.
2. show.output.on.console = FALSE stops admb output from being printed to the screen. I know that there are weird combinations here of arguments inside of system that either turn printing off or don't and I don't claim to know all of them, but this works for what I need :)