### PR TITLE
Fix subplot=11 of SSplotTimeSeries and improve label of time block parameters of SS_readctl_3.30 

### DIFF
--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1664,6 +1664,9 @@ get_tv_parlabs <- function(full_parms,
   par_num <- lapply(tmp_tv, function(x) which(x != 0))
   loop_pars <- unlist(par_num)
   loop_pars <- loop_pars[order(loop_pars)]
+  block_fxn <- full_parms[, "Block_Fxn"]
+  # block_method_label corresponds block method of 0, 1, 2, 3, 4
+  block_method_label <- c("mult_","add_","repl_","delta_","revertrw_")
   parlab <- vector() # a maybe faster approach is if we could initialize with the correct size.
   for (i in loop_pars) {
     tmp_parname <- rownames(full_parms)[i]
@@ -1676,12 +1679,13 @@ get_tv_parlabs <- function(full_parms,
       tmp_blk_design <- block_design[[n_blk]]
       # Get the start year for each block
       blk_start_yrs <- tmp_blk_design[seq(1, length(tmp_blk_design), by = 2)]
+      lbl <- block_method_label[block_fxn[i] + 1]
       parlab <- c(
         parlab,
         paste0(
           "# ",
           rep(tmp_parname, times = length(blk_start_yrs)),
-          "_BLK", n_blk, "add", blk_start_yrs
+          "_BLK", n_blk, lbl, blk_start_yrs
         )
       )
     }

--- a/R/SSplotTimeseries.R
+++ b/R/SSplotTimeseries.R
@@ -281,8 +281,8 @@ SSplotTimeseries <-
         if (subplot == 11) {
           # sum total recruitment across birth seasons
           for (y in ts[["Yr"]]) {
-            yvals[ts[["Yr"]] == y & ts[["Seas"]] == 1] <- sum(yvals[ts[["Yr"]] == y], na.rm = TRUE)
-            yvals[ts[["Yr"]] == y & ts[["Seas"]] > 1] <- 0
+            yvals[ts[["Yr"]] == y & ts[["Seas"]] == 1 & ts[["Area"]] ==1] <- sum(yvals[ts[["Yr"]] == y], na.rm = TRUE)
+            yvals[ts[["Yr"]] == y & (ts[["Seas"]] > 1 | ts[["Area"]] > 1)] <- 0
           }
         }
         if (subplot == 15) {


### PR DESCRIPTION
Subplot=11 (Total recruitment time series) in SSplotTimeSeries has a bug if there is multiple areas .  This commit fix this.

Also SS_readctl_3.30 is improved on the label(rownames) of time vary parameters for time block. Now it reflects block function (column 14 of parameter).  Previously "add" is always used regardless of block function used. 