### PR TITLE
fix(SSsummarize): DM parameters have a new name (DM_theta);

### DIFF
--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -95,7 +95,9 @@ SSsummarize <- function(biglist,
   for (imodel in 1:n) {
     stats <- biglist[[imodel]]
     listname <- names(biglist)[imodel]
-    message("imodel=", imodel, "/", n)
+    if (verbose) {
+      message("imodel=", imodel, "/", n)
+    }
 
     # gradient
     maxgrad <- c(maxgrad, stats[["maximum_gradient_component"]])
@@ -219,7 +221,9 @@ SSsummarize <- function(biglist,
       parsSD[parnames == parstemp[["Label"]][ipar], imodel] <- parstemp[["Parm_StDev"]][ipar]
       parphases[parnames == parstemp[["Label"]][ipar], imodel] <- parstemp[["Phase"]][ipar]
     }
-    message("  N active pars = ", sum(!is.na(parstemp[["Active_Cnt"]])))
+    if (verbose) {
+      message("  N active pars = ", sum(!is.na(parstemp[["Active_Cnt"]])))
+    }
 
     ## compile derived quantities
     quantstemp <- stats[["derived_quants"]]
@@ -288,7 +292,7 @@ SSsummarize <- function(biglist,
 
 
   ### format and process info from the models
-  names(pars) <- names(parsSD) <- modelnames
+  names(pars) <- names(parsSD) <- names(parphases) <- modelnames
   names(quants) <- names(quantsSD) <- modelnames
   names(likelihoods) <- names(likelambdas) <- modelnames
 
@@ -541,6 +545,24 @@ SSsummarize <- function(biglist,
     return(x2)
   }
 
+  # helper fxn b/c name of DM parameter changed
+  # todo: delete when these models no longer need to be maintained
+  copy.dm <- function(data, oldgrep = "EffN", newgrep = "theta") {
+    oldrows <- grep(oldgrep, data[, "Label"])
+    if (length(oldrows) == 0) {
+      return(data)
+    }
+    newrows <- grep(newgrep, data[, "Label"])
+    fix <- which(apply(
+      X = data[newrows, grep("model", colnames(data))],
+      MARGIN = 2, function(vector) all(is.na(vector))))
+    if (length(oldrows) != length(newrows) | length(fix) == 0) {
+      return(data)
+    }
+    data[newrows, fix] <- data[oldrows, fix]
+    return(data)
+  }
+
   # function to sort by year
   sort.fn <- function(x) {
     if (!is.null(x)) {
@@ -558,9 +580,9 @@ SSsummarize <- function(biglist,
   mylist[["nsexes"]] <- nsexes
   mylist[["startyrs"]] <- startyrs
   mylist[["endyrs"]] <- endyrs
-  mylist[["pars"]] <- pars
-  mylist[["parsSD"]] <- parsSD
-  mylist[["parphases"]] <- parphases
+  mylist[["pars"]] <- copy.dm(pars)
+  mylist[["parsSD"]] <- copy.dm(parsSD)
+  mylist[["parphases"]] <- copy.dm(parphases)
   mylist[["quants"]] <- quants
   mylist[["quantsSD"]] <- quantsSD
   mylist[["likelihoods"]] <- likelihoods


### PR DESCRIPTION
 new row in pars, parSD, and parphases

* write a helper function copy.dm, where the DM parameters that were named
EffN_mult are copied into the rows for the DM_theta parameter which will be in
newer models; nothing is changed in the EffN_mult line, this is to encourage people to
use the new naming rather than leaving their code as is with EffN.
* name parphases with model names as is done for the other "par" data frames;
I looked back in the code and this line had not been touched other than line endings
for over 10 years and I am guessing it is just that no one uses this table that
has led to the names staying V1 V2 ... instead of model1 model2.
* make a few if(verbose) checks to limit output to the screen.

pushing to branch to run automated tests prior to merging in, but I don't see
any problems in merging this into development