### PR TITLE
docs, init: add contributing info and code of conduct to r4ss

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,27 @@ remotes::install_github("r4ss/r4ss", build_vignettes = TRUE)
 
 See [NEWS.md](https://github.com/r4ss/r4ss/blob/master/NEWS.md) for a (not very complete) log of changes to r4ss, starting with r4ss v1.24.0 from 2014. The list of commits at <https://github.com/r4ss/r4ss/commits/master> provides a much more detailed list.
 
+## Contributing to r4ss
+
+Interested in contributing to r4ss? We recognize contributions come in many forms, including but not limited to code, reporting issues, creating examples and/or documentation.
+
+We strive to follow the [NMFS Fisheries Toolbox Contribution Guide](https://github.com/nmfs-fish-tools/Resources/blob/master/CONTRIBUTING.md). We also have included r4ss-specific code contribution information in the [Git workflow page of the r4ss wiki](https://github.com/r4ss/r4ss/wiki/Git-Workflow). Note that these are guidelines, not rules, and we are open to collaborations in other ways that may work better for you. Please feel free to reach out to us by opening an issue in this repository or by emailing the maintainer (call `maintainer("r4ss")` in R to view the current maintainer's name and email address). 
+
+Note that by contribuiting, you are expect to uphold the [code of conduct](#code-of-conduct).
 
 ## Reporting problems
 
 Please report any issues with this package by posting a new github issue at <https://github.com/r4ss/r4ss/issues>. You can also write to Ian.Taylor@noaa.gov.
+
+## Code of conduct
+
+This project and everyone participating in it is governed by the [NMFS Fisheries Toolbox Code of Conduct](https://github.com/nmfs-fish-tools/Resources/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [fisheries.toolbox@noaa.gov](mailto:fisheries.toolbox@noaa.gov). Note that the maintainers of r4ss do not have access to this email account, so unacceptable behavior of maintainers can also be reported here.
+
+The NFMS Fisheries Toolbox Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+


### PR DESCRIPTION
This pull request is to add a section on contributing in the readme and a code of conduct to the r4ss project (see the change to learn more about the contents of the contributing guide and the code of conduct). 

These are preliminary versions that can be changed. Please feel free to comment on this pull request or email nmfs.stock.synthesis@noaa.gov or the maintainer (which can be found by running `maintainer("r4ss")` in R) with your suggestions. Perhaps this can be left open at least a week for comments? I think changes could still be incorporated after that time, though.