### PR TITLE
Roxygen2md

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,3 +44,4 @@ URL: https://github.com/r4ss/r4ss
 BugReports: https://github.com/r4ss/r4ss/issues
 RoxygenNote: 7.1.1
 VignetteBuilder: knitr
+Roxygen: list(markdown = TRUE)

--- a/R/NegLogInt_Fn.R
+++ b/R/NegLogInt_Fn.R
@@ -8,12 +8,12 @@
 #' @param Input_SD_Group_Vec Vector where each element is the standard deviation
 #' for a group of random effects (e.g., a model with a single group of random
 #' effects will have Input_SD_Group_Vec be a vector of length one)
-#' @param CTL_linenum_List List (same length as \code{Input_SD_Group_Vec}),
+#' @param CTL_linenum_List List (same length as `Input_SD_Group_Vec`),
 #' where each
 #' element is a vector giving the line number(s) for the random effect standard
 #' deviation parameter or penalty in the CTL file (and where each line will
 #' correspond to a 7-parameter or 14-parameter line).
-#' @param ESTPAR_num_List List (same length as \code{Input_SD_Group_Vec}),
+#' @param ESTPAR_num_List List (same length as `Input_SD_Group_Vec`),
 #' where each
 #' element is a vector giving the parameter number for the random effect
 #' coefficients in that group of random effects. These "parameter numbers"
@@ -30,11 +30,11 @@
 #' @param Intern Logical flag saying whether to display all ss3 runtime output
 #' in the R terminal
 #' @param ReDoBiasRamp Logical flag saying whether to re-do the bias ramp
-#' (using \code{\link{SS_fitbiasramp}}) each time Stock Synthesis is run.
+#' (using [SS_fitbiasramp()]) each time Stock Synthesis is run.
 #' @param BiasRamp_linenum_Vec Vector giving the line numbers from the CTL file
 #' that contain the information about the bias ramp.
 #' @param CTL_linenum_Type Character vector (same length as
-#' \code{Input_SD_Group_Vec}),
+#' `Input_SD_Group_Vec`),
 #' where each element is either "Short_Param", "Long_Penalty", "Long_Penalty".
 #' Default is NULL, and if not explicitly specified the program will attempt to
 #' detect these automatically based on the length of relevant lines from the CTL
@@ -45,7 +45,7 @@
 #' This string is used for both calling the executable and also finding the
 #' output files like ss.par. For 3.30, it should always be "ss" since the
 #' output file names are hardwired in the TPL code.
-#' @seealso \code{\link{read.admbFit}}, \code{\link{getADMBHessian}}
+#' @seealso [read.admbFit()], [getADMBHessian()]
 #' @author James Thorson
 #' @export
 #' @references Thorson, J.T., Hicks, A.C., and Methot, R.D. 2014. Random

--- a/R/PinerPlot.R
+++ b/R/PinerPlot.R
@@ -6,25 +6,25 @@
 ##' profiles. He's surely not the first person to make such a plot
 ##' but the name seems to have stuck.
 ##' @param summaryoutput List created by the function
-##' \code{\link{SSsummarize}}.
+##' [SSsummarize()].
 ##' @param plot Plot to active plot device?
 ##' @param print Print to PNG files?
 ##' @param component Which likelihood component to plot. Default is "Length_like".
 ##' @param main Title for plot. Should match component.
 ##' @param models Optional subset of the models described in
-##' \code{summaryoutput}.  Either "all" or a vector of numbers indicating
+##' `summaryoutput`.  Either "all" or a vector of numbers indicating
 ##' columns in summary tables.
 ##' @param fleets Optional vector of fleet numbers to include.
 ##' @param fleetnames Optional character vector of names for each fleet.
 ##' @param profile.string Character string used to find parameter over which the
-##' profile was conducted. If \code{exact=FALSE}, this can be a substring of
+##' profile was conducted. If `exact=FALSE`, this can be a substring of
 ##' one of the SS parameter labels found in the Report.sso file.
 ##' For instance, the default input 'R0'
-##' matches the parameter 'SR_LN(R0)'. If \code{exact=TRUE}, then
+##' matches the parameter 'SR_LN(R0)'. If `exact=TRUE`, then
 ##' profile.string needs to be an exact match to the parameter label.
 ##' @param profile.label Label for x-axis describing the parameter over which
 ##' the profile was conducted.
-##' @param exact Should the \code{profile.string} have to match the parameter
+##' @param exact Should the `profile.string` have to match the parameter
 ##' label exactly, or is a substring OK.
 ##' @param ylab Label for y-axis. Default is "Change in -log-likelihood".
 ##' @param col Optional vector of colors for each line.
@@ -58,9 +58,9 @@
 ##' be the directory where the model was run.
 ##' @param add_cutoff Add dashed line at ~1.92 to indicate 95% confidence interval
 ##' based on common cutoff of half of chi-squared of p=.95 with 1 degree of
-##' freedom: \code{0.5*qchisq(p=cutoff_prob, df=1)}. The probability value
-##' can be adjusted using the \code{cutoff_prob} below.
-##' @param cutoff_prob Probability associated with \code{add_cutoff} above.
+##' freedom: `0.5*qchisq(p=cutoff_prob, df=1)`. The probability value
+##' can be adjusted using the `cutoff_prob` below.
+##' @param cutoff_prob Probability associated with `add_cutoff` above.
 ##' @param verbose Return updates of function progress to the R GUI? (Doesn't do
 ##' anything yet.)
 ##' @param fleetgroups Optional character vector, with length equal to

--- a/R/SSMethod.Cond.TA1.8.R
+++ b/R/SSMethod.Cond.TA1.8.R
@@ -4,13 +4,13 @@
 #' to do stage-2 weighting of conditional age at length composition data from a
 #' Stock Synthesis model.
 #'
-#' The function outputs a multiplier, \emph{w},
-#' (with bootstrap 95\% confidence intervals) so that
-#' \emph{N2i} = \emph{w} x \emph{N1i},
-#' where \emph{N1i} and \emph{N2i} are the stage-1 and stage-2 multinomial
-#' sample sizes for the \emph{i}th composition. Optionally makes a plot
+#' The function outputs a multiplier, *w*,
+#' (with bootstrap 95% confidence intervals) so that
+#' *N2i* = *w* x *N1i*,
+#' where *N1i* and *N2i* are the stage-1 and stage-2 multinomial
+#' sample sizes for the *i*th composition. Optionally makes a plot
 #' of observed and expected mean ages, with two alternative
-#' sets of confidence limits - based on \emph{N1i} (thin lines) and \emph{N2i}
+#' sets of confidence limits - based on *N1i* (thin lines) and *N2i*
 #' (thick lines) - for the observed values.
 #'
 #' This function formerly reported two versions of w differ according to whether
@@ -32,7 +32,7 @@
 #' in pldat - one row per group).
 #'   \item If the data are to be plotted they are further
 #' grouped by fleet, with one panel of the plot per fleet.
-#'   \item A single multiplier, \emph{w}, is calculated to apply to all the
+#'   \item A single multiplier, *w*, is calculated to apply to all the
 #' selected data.
 #' }
 #'
@@ -64,12 +64,12 @@
 #' @param add add to existing plot
 #' @author Chris Francis, Andre Punt, Ian Taylor
 #' @export
-#' @seealso \code{\link{SSMethod.TA1.8}}
+#' @seealso [SSMethod.TA1.8()]
 #' @references Francis, R.I.C.C. (2011). Data weighting in statistical
 #' fisheries stock assessment models. Can. J. Fish. Aquat. Sci. 68: 1124-1138.
 #'
 #' Punt, A.E. (2015). Some insights into data weighting in integrated stock assessments.
-#' Fish. Res. \url{http://dx.doi.org/10.1016/j.fishres.2015.12.006}
+#' Fish. Res. <http://dx.doi.org/10.1016/j.fishres.2015.12.006>
 #'
 SSMethod.Cond.TA1.8 <-
   function(fit, fleet, part = 0:2, seas = NULL,

--- a/R/SSMethod.TA1.8.R
+++ b/R/SSMethod.TA1.8.R
@@ -2,11 +2,11 @@
 #'
 #' Uses method TA1.8 (described in Appendix A of Francis 2011) to do
 #' stage-2 weighting of composition data from a Stock Synthesis model.
-#' Outputs a multiplier, \emph{w} (with bootstrap 95\% confidence interval),
-#' so that \emph{N2y} = \emph{w} x \emph{N1y}, where \emph{N1y} and
-#' \emph{N2y} are the stage-1 and stage-2
+#' Outputs a multiplier, *w* (with bootstrap 95% confidence interval),
+#' so that *N2y* = *w* x *N1y*, where *N1y* and
+#' *N2y* are the stage-1 and stage-2
 #' multinomial sample sizes for the data set in year y.  Optionally
-#' makes a plot of observed (with confidence limits, based on \emph{N1y})
+#' makes a plot of observed (with confidence limits, based on *N1y*)
 #' and expected mean lengths (or ages).
 #' \cr\cr
 #' CAUTIONARY/EXPLANATORY NOTE.
@@ -69,7 +69,7 @@
 #' @param add add to existing plot
 #' @author Chris Francis, Andre Punt, Ian Taylor
 #' @export
-#' @seealso \code{\link{SSMethod.Cond.TA1.8}}
+#' @seealso [SSMethod.Cond.TA1.8()]
 #' @references Francis, R.I.C.C. (2011). Data weighting in statistical
 #' fisheries stock assessment models. Canadian Journal of
 #' Fisheries and Aquatic Sciences 68: 1124-1138.

--- a/R/SS_ForeCatch.R
+++ b/R/SS_ForeCatch.R
@@ -18,7 +18,7 @@
 ##' @param dead TRUE/FALSE switch to choose dead catch instead of retained catch.
 ##' @param zeros Include entries with zero catch (TRUE/FALSE)
 ##'
-##' @seealso \code{\link{SS_readforecast}}, \code{\link{SS_readforecast}}
+##' @seealso [SS_readforecast()], [SS_readforecast()]
 ##' @author Ian G. Taylor
 ##' @examples
 ##'

--- a/R/SS_RunJitter.R
+++ b/R/SS_RunJitter.R
@@ -7,25 +7,25 @@
 #' @param mydir Directory where model files are located.
 #' @template model
 #' @param extras Additional command line arguments passed to the executable.
-#'   The default, \code{"-nohess"}, runs each jittered model without the hessian.
+#'   The default, `"-nohess"`, runs each jittered model without the hessian.
 #' @param Njitter Number of jitters, or a vector of jitter iterations.
-#'   If \code{length(Njitter) > 1} only the iterations specified will be ran,
-#'   else \code{1:Njitter} will be executed.
+#'   If `length(Njitter) > 1` only the iterations specified will be ran,
+#'   else `1:Njitter` will be executed.
 #' @param Intern Show command line info in R console or keep hidden. The default,
-#'   \code{TRUE}, keeps the executable hidden.
+#'   `TRUE`, keeps the executable hidden.
 #' @param systemcmd Option to switch between 'shell' and 'system'. The default,
-#'   \code{FALSE}, facilitates using the shell command on Windows.
+#'   `FALSE`, facilitates using the shell command on Windows.
 #' @param printlikes A logical value specifying if the likelihood values should
 #'   be printed to the console.
 #' @template verbose
 #' @param jitter_fraction The value, typically 0.1, used to define a uniform
 #'   distribution in cumulative normal space to generate new initial parameter values.
-#'   The default of \code{NULL} forces the user to specify the jitter_fraction
+#'   The default of `NULL` forces the user to specify the jitter_fraction
 #'   in the starter file, and this value must be greater than zero and
 #'   will not be overwritten.
 #' @param init_values_src Either zero or one, specifying if the initial values to
 #'   jitter should be read from the control file or from the par file, respectively.
-#'   The default is \code{NULL}, which will leave the starter file unchanged.
+#'   The default is `NULL`, which will leave the starter file unchanged.
 #' @author James T. Thorson, Kelli F. Johnson, Ian G. Taylor
 #' @return A vector of likelihoods for each jitter iteration.
 #' @export

--- a/R/SS_changepars.R
+++ b/R/SS_changepars.R
@@ -3,8 +3,8 @@
 #' Loops over a subset of control file to change parameter lines.
 #' Current initial value, lower and upper bounds, and phase can be modified,
 #' but function could be expanded to control other columns.
-#' Depends on \code{\link{SS_parlines}}.
-#' Used by \code{\link{SS_profile}} and the \pkg{ss3sim} package.
+#' Depends on [SS_parlines()].
+#' Used by [SS_profile()] and the \pkg{ss3sim} package.
 #'
 #'
 #' @param dir Directory with control file to change.
@@ -12,64 +12,64 @@
 #' @param newctlfile Name of new control file to be written.
 #'   Default="control_modified.ss".
 #' @param linenums Line numbers of control file to be modified. Either this or
-#'   the \code{strings} argument are needed. Default=NULL.
+#'   the `strings` argument are needed. Default=NULL.
 #' @param strings Strings (with optional partial matching) indicating which
-#'   parameters to be modified. This is an alternative to \code{linenums}.
-#'   \code{strings} correspond to the commented parameter names included in
-#'   \code{control.ss_new}, or whatever is written as comment at the end
+#'   parameters to be modified. This is an alternative to `linenums`.
+#'   `strings` correspond to the commented parameter names included in
+#'   `control.ss_new`, or whatever is written as comment at the end
 #'   of the 14 number parameter lines. Default=NULL.
 #' @param newvals Vector of new parameter values. Default=NULL.
-#'   The vector can contain \code{NA} values, which will assign the original
+#'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remainder parameters, where
 #'   the vector of values needs to be in the same order as either
-#'   \code{linenums} or \code{strings}.
+#'   `linenums` or `strings`.
 #' @param repeat.vals If multiple parameter lines match criteria, repeat the
-#'   \code{newvals} input for each line.
+#'   `newvals` input for each line.
 #' @param estimate Optional vector or single value of TRUE/FALSE for which
 #'   parameters are to be estimated. Changes sign of phase to be positive or
-#'   negative. Default \code{NULL} causes no change to phase.
+#'   negative. Default `NULL` causes no change to phase.
 #' @param newlos Vector of new lower bounds. Default=NULL.
-#'   The vector can contain \code{NA} values, which will assign the original
+#'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remainder parameters, where
 #'   the vector of values needs to be in the same order as either
-#'   \code{linenums} or \code{strings}.
+#'   `linenums` or `strings`.
 #' @param newhis Vector of new high bounds. Must be the same length as newhis
 #'   Default=NULL.
-#'   The vector can contain \code{NA} values, which will assign the original
+#'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remainder parameters, where
 #'   the vector of values needs to be in the same order as either
-#'   \code{linenums} or \code{strings}.
+#'   `linenums` or `strings`.
 #' @param newprior Vector of new prior values.
 #'   Default=NULL.
-#'   The vector can contain \code{NA} values, which will assign the original
+#'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remainder parameters, where
 #'   the vector of values needs to be in the same order as either
-#'   \code{linenums} or \code{strings}.
+#'   `linenums` or `strings`.
 #' @param newprsd Vector of new prior sd values.
 #'   Default=NULL.
-#'   The vector can contain \code{NA} values, which will assign the original
+#'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remainder parameters, where
 #'   the vector of values needs to be in the same order as either
-#'   \code{linenums} or \code{strings}.
+#'   `linenums` or `strings`.
 #' @param newprtype Vector of new prior type.
 #'   Default=NULL.
-#'   The vector can contain \code{NA} values, which will assign the original
+#'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remainder parameters, where
 #'   the vector of values needs to be in the same order as either
-#'   \code{linenums} or \code{strings}.
+#'   `linenums` or `strings`.
 #' @param newphs Vector of new phases. Can be a single value, which will be
 #'   repeated for each parameter, the same length as newvals, where each
-#'   value corresponds to a single parameter, or \code{NULL}, where the
+#'   value corresponds to a single parameter, or `NULL`, where the
 #'   phases will not be changed. If one wants to strictly turn parameters
 #'   on or off and not change the phase in which they are estimated use
-#'   \code{estimate = TRUE} or \code{estimate = FALSE}, respectively.
-#'   The vector can contain \code{NA} values, which will assign the original
+#'   `estimate = TRUE` or `estimate = FALSE`, respectively.
+#'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remaining parameters, where
 #'   the vector of values needs to be in the same order as either
-#'   \code{linenums} or \code{strings}.
+#'   `linenums` or `strings`.
 #' @param verbose More detailed output to command line. Default=TRUE.
 #' @author Ian Taylor, Christine Stawitz, Chantel Wetzel
-#' @seealso \code{\link{SS_parlines}}, \code{\link{SS_profile}}
+#' @seealso [SS_parlines()], [SS_profile()]
 #' @export
 #' @examples
 #'

--- a/R/SS_doRetro.R
+++ b/R/SS_doRetro.R
@@ -6,9 +6,9 @@
 #'
 #'
 #' @param masterdir Directory where everything takes place.
-#' @param oldsubdir Subdirectory within \code{masterdir} with existing model
+#' @param oldsubdir Subdirectory within `masterdir` with existing model
 #' files.
-#' @param newsubdir Subdirectory within \code{masterdir} where retrospectives
+#' @param newsubdir Subdirectory within `masterdir` where retrospectives
 #' will be run. Default is 'retrospectives'.
 #' @param subdirstart First part of the pattern of names for the directories in
 #' which the models will actually be run.
@@ -32,7 +32,7 @@
 #' simplistic and probably won't work in most cases. Default=FALSE.
 #' @author Ian Taylor, Jim Thorson
 #' @export
-#' @seealso \code{\link{SSgetoutput}}
+#' @seealso [SSgetoutput()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/SS_fitbiasramp.R
+++ b/R/SS_fitbiasramp.R
@@ -1,7 +1,7 @@
 #' Estimate bias adjustment for recruitment deviates
 #'
 #' Uses standard error of estimated recruitment deviates to estimate the 5
-#' controls (\href{https://doi.org/10.1139/f2011-092}{Methot and Taylor, 2011})
+#' controls ([Methot and Taylor, 2011](https://doi.org/10.1139/f2011-092))
 #' for bias adjustment in Stock Synthesis.
 #'
 #' @details
@@ -9,7 +9,7 @@
 #' the likelihood that the estimated recruitmente events, which are
 #' log-normally distributed, are mean unbiased and comparable to results from
 #' Markov chain Mone Carlo estimation routines
-#' (\href{https://doi.org/10.1139/f2011-092}{Methot and Taylor, 2011}).
+#' ([Methot and Taylor, 2011](https://doi.org/10.1139/f2011-092)).
 #' Options to account for the fact that data typically do not equally represent
 #' all modelled time periods are as follows:
 #' \enumerate{
@@ -31,7 +31,7 @@
 #' minimization. Default=NULL.
 #' @param method A method to apply to the 'optim' function. See ?optim for
 #' options. Default="BFGS". By default, optim is not used, and the optimization
-#' is based on the input \code{altmethod}.
+#' is based on the input `altmethod`.
 #' @param twoplots Make a two-panel plot showing devs as well as transformed
 #' uncertainty, or just the second panel in the set?  Default=TRUE.
 #' @param transform An experimental option to treat the transform the 5
@@ -58,7 +58,7 @@
 #' @template cex.main
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_output}}
+#' @seealso [SS_output()]
 #' @template methot2011cjfas
 #'
 SS_fitbiasramp <-

--- a/R/SS_html.R
+++ b/R/SS_html.R
@@ -1,14 +1,14 @@
 #' Create HTML files to view figures in browser.
 #'
 #' Writes a set of HTML files with tabbed navigation between them.  Depends on
-#' \code{\link{SS_plots}} with settings in place to write figures to PNG files.
+#' [SS_plots()] with settings in place to write figures to PNG files.
 #' Should open main file in default browser automatically.
 #'
 #'
 #' @template replist
 #' @param plotdir Directory where PNG files are located.
 #' @param plotInfoTable CSV file with info on PNG files. By default, the
-#' \code{plotdir} directory will be searched for files with name beginning
+#' `plotdir` directory will be searched for files with name beginning
 #' 'plotInfoTable*'
 #' @param title Title for HTML page.
 #' @param width Width of plots (in pixels).
@@ -24,7 +24,7 @@
 #' for improvement.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 #'
 SS_html <- function(replist = NULL,
                     plotdir = NULL,

--- a/R/SS_makedatlist.R
+++ b/R/SS_makedatlist.R
@@ -1,7 +1,7 @@
 #' make a list for SS data
 #'
-#' create a list similar to those built by \code{\link{SS_readdat}} which can
-#' be written to a Stock Synthesis data file using \code{\link{SS_writedat}}.
+#' create a list similar to those built by [SS_readdat()] which can
+#' be written to a Stock Synthesis data file using [SS_writedat()].
 #' In hindsight, this function doesn't seem very useful and I haven't taken
 #' time to describe the arguments below.
 #'
@@ -60,7 +60,7 @@
 #' @param morphcomp_data Morph composition data. NOT IMPLEMENTED YET.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_readdat}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readdat()], [SS_writedat()]
 SS_makedatlist <-
   function(styr = 1971,
            endyr = 2001,

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -13,7 +13,7 @@
 #' This can also either be an absolute path or relative to the working
 #' directory.
 #' @param dir.mcmc Optional directory containing MCMC output. This can either be
-#' relative to \code{dir}, such that \code{file.path(dir, dir.mcmc)}
+#' relative to `dir`, such that `file.path(dir, dir.mcmc)`
 #' will end up in the right place, or an absolute path.
 #' @param repfile Name of the big report file (could be renamed by user).
 #' @param compfile Name of the composition report file.
@@ -24,8 +24,8 @@
 #' @param ncols The maximum number of columns in files being read in.  If this
 #' value is too big the function runs more slowly, too small and errors will
 #' occur.  A warning will be output to the R command line if the value is too
-#' small. It should be bigger than the maximum age + 10 and the number of years
-#' + 10. The default value is \code{NULL}, which finds the optimum width.
+#' small. It should be bigger than the maximum age + 10 and the number of
+#' years + 10. The default value is `NULL`, which finds the optimum width.
 #' @param forecast Read the forecast-report file?
 #' @param warn Read the Warning.sso file?
 #' @param covar Read covar.sso to get variance information and identify bad
@@ -51,7 +51,7 @@
 #' should probably be created at some point in the future.
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}
+#' @seealso [SS_plots()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/SS_parlines.R
+++ b/R/SS_parlines.R
@@ -25,8 +25,8 @@
 #' @param active Should only active parameters (those with positive phase) be
 #' output? Default=FALSE.
 #' @author Ian Taylor
-#' @seealso \code{\link{SS_changepars}}, \code{\link{SS_readctl}},
-#' \code{\link{SS_readctl_3.24}}
+#' @seealso [SS_changepars()], [SS_readctl()],
+#' [SS_readctl_3.24()]
 #' @export
 #' @examples
 #'

--- a/R/SS_plots.R
+++ b/R/SS_plots.R
@@ -42,11 +42,11 @@
 #' }
 #'
 #' @param print Deprecated input for backward compatibility, now replaced by
-#' \code{png = TRUE/FALSE}.
+#' `png = TRUE/FALSE`.
 #' @param pdf Send plots to PDF file instead of R GUI?
 #' @param png Send plots to PNG files instead of R GUI?
-#' @param html Run \code{\link{SS_html}} on completion? By default has same
-#' value as \code{png}.
+#' @param html Run [SS_html()] on completion? By default has same
+#' value as `png`.
 #' @param printfolder The sub-directory under 'dir' (see below) in which the
 #' PNG files will be located.  The default sub-directory is "plots".
 #' The directory will be created if it doesn\'t exist.
@@ -55,7 +55,7 @@
 #' @param dir The directory in which a PDF file (if requested) will be created
 #' and within which the printfolder sub-directory (see above) will be created
 #' if png=TRUE. By default it will be the same directory that the report file
-#' was read from by the \code{SS_output} function. Alternatives to the default
+#' was read from by the `SS_output` function. Alternatives to the default
 #' can be either relative (to the working directory) or absolute paths.
 #' The function will attempt to create the directory it doesn't exist, but it
 #' does not do so recursively.
@@ -142,10 +142,10 @@
 #' age-at-length plots (TRUE/FALSE, still in development)
 #' @param showlegend Display legends in various plots? Default=T.
 #' @param pwidth Width of plots printed to files in units of
-#' \code{punits}. Default recently changed from 7 to 6.5.
+#' `punits`. Default recently changed from 7 to 6.5.
 #' @param pheight Height width of plots printed to files in units of
-#' \code{punits}. Default recently changed from 7 to 5.0
-#' @param punits Units for \code{pwidth} and \code{pheight}. Can be "px"
+#' `punits`. Default recently changed from 7 to 5.0
+#' @param punits Units for `pwidth` and `pheight`. Can be "px"
 #' (pixels), "in" (inches), "cm" or "mm". Default="in".
 #' @param ptsize Point size for plotted text in plots printed to files (see
 #' help("png") in R for details). Default recently changed from 12 to 10.
@@ -202,7 +202,7 @@
 #' @param showprior Show prior distribution as black line in the parameter
 #' distribution plots?
 #' @param showpost Show posterior distribution as bar graph in parameter
-#' distribution plots (requires MCMC results to be available in \code{replist})?
+#' distribution plots (requires MCMC results to be available in `replist`)?
 #' @param showinit Show initial value as red triangle in the parameter
 #' distribution plots?
 #' @param showdev Include devs in the parameter distribution plots?
@@ -211,14 +211,14 @@
 #' @param \dots Additional arguments that will be passed to some subfunctions.
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_output}}, \code{\link{SSplotBiology}},
-#' \code{\link{SSplotCatch}}, \code{\link{SSplotComps}},
-#' \code{\link{SSplotDiscard}}, \code{\link{SSplotIndices}},
-#' \code{\link{SSplotMnwt}}, \code{\link{SSplotNumbers}},
-#' \code{\link{SSplotRecdevs}}, \code{\link{SSplotSelex}},
-#' \code{\link{SSplotSpawnrecruit}}, \code{\link{SSplotSPR}},
-#' \code{\link{SSplotTags}}, \code{\link{SSplotTimeseries}},
-#' \code{\link{SSplotYield}}
+#' @seealso [SS_output()], [SSplotBiology()],
+#' [SSplotCatch()], [SSplotComps()],
+#' [SSplotDiscard()], [SSplotIndices()],
+#' [SSplotMnwt()], [SSplotNumbers()],
+#' [SSplotRecdevs()], [SSplotSelex()],
+#' [SSplotSpawnrecruit()], [SSplotSPR()],
+#' [SSplotTags()], [SSplotTimeseries()],
+#' [SSplotYield()]
 #' @references Walters, Hilborn, and Christensen, 2008, Surplus production
 #' dynamics in declining and recovering fish populations. Can. J. Fish. Aquat.
 #' Sci. 65: 2536-2551.

--- a/R/SS_profile.R
+++ b/R/SS_profile.R
@@ -8,15 +8,15 @@
 #' @param newctlfile Destination for new control files (must match entry in
 #' starter file). Default = "control_modified.ss".
 #' @param linenum Line number of parameter to be changed.  Can be used instead
-#' of \code{string} or left as NULL.
+#' of `string` or left as NULL.
 #' @param string String partially matching name of parameter to be changed. Can
-#' be used instead of \code{linenum} or left as NULL.
+#' be used instead of `linenum` or left as NULL.
 #' @param usepar Use PAR file from previous profile step for starting values?
 #' @param globalpar Use global par file ("parfile_original_backup.sso", which is
-#' automatically copied from original \code{parfile}) for all runs instead
+#' automatically copied from original `parfile`) for all runs instead
 #' of the par file from each successive run
 #' @param parfile Name of par file to use (for 3.30 models, this needs to
-#' remain 'ss.par'). When \code{globalpar=TRUE}, the backup copy of this
+#' remain 'ss.par'). When `globalpar=TRUE`, the backup copy of this
 #' is used for all runs.
 #' @param parlinenum Line number in par file to change.
 #' @param parstring String in par file preceding line number to change.
@@ -51,14 +51,14 @@
 #' values.
 #'
 #' Also, someday this function will be improved to work directly with the
-#' plotting function \code{\link{SSplotProfile}}, but they don't yet work well
-#' together. Thus, even if \code{\link{SS_profile}} is used, the output should
-#' be read using \code{\link{SSgetoutput}} or by multiple calls to
-#' \code{\link{SS_output}} before sending to \code{\link{SSplotProfile}}.
+#' plotting function [SSplotProfile()], but they don't yet work well
+#' together. Thus, even if [SS_profile()] is used, the output should
+#' be read using [SSgetoutput()] or by multiple calls to
+#' [SS_output()] before sending to [SSplotProfile()].
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SSplotProfile}}, \code{\link{SSgetoutput}},
-#' \code{\link{SS_changepars}}, \code{\link{SS_parlines}}
+#' @seealso [SSplotProfile()], [SSgetoutput()],
+#' [SS_changepars()], [SS_parlines()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/SS_read_summary.R
+++ b/R/SS_read_summary.R
@@ -5,13 +5,13 @@
 #'
 #' @param file Filename either with full path or relative to working directory.
 #' @template verbose
-#' @return Output will be a list with four elements, \code{header},
-#' \code{likelihoods}, \code{parameters}, and \code{derived_quants}.
+#' @return Output will be a list with four elements, `header`,
+#' `likelihoods`, `parameters`, and `derived_quants`.
 #' Each is a data frame with rownames indicating the quantity shown in each row.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_output}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_readdat}}, \code{\link{SS_readstarter}}
+#' @seealso [SS_output()], [SS_readforecast()],
+#' [SS_readdat()], [SS_readstarter()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -73,7 +73,7 @@
 #' `r ls("package:r4ss", pattern = "SS_readctl_")`.
 #' The returned list structure can be written back to the disk using
 #' [r4ss::SS_writectl].\cr
-#' See the following for other \code{SS_read} functions:
+#' See the following for other `SS_read` functions:
 #' `r ls("package:r4ss", pattern = "SS_read[a-z]+$")`.\cr
 #' @examples
 #' # Read in the 'simple' example SS model stored in r4ss

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -46,11 +46,11 @@
 #' @author Yukio Takeuchi, Neil Klaer, Iago Mosqueira, and Kathryn Doering
 
 #' @export
-#' @seealso \code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-#' \code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.30}}
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readctl()], [SS_readdat()]
+#' [SS_readdat_3.24()],[SS_readdat_3.30()]
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readctl_3.24 <- function(file,
                             verbose = TRUE,
                             echoall = FALSE,

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -43,16 +43,16 @@
 #' @param use_datlist LOGICAL if TRUE, use datlist to derive parameters which can not be
 #'        determined from control file
 #' @param datlist list or character. If list, should be a list produced from
-#'   \code{\link{SS_writedat}}. If character, should be the file name of an
+#'   [SS_writedat()]. If character, should be the file name of an
 #'   SS data file.
 #' @author Neil Klaer, Yukio Takeuchi, Watal M. Iwasaki, and Kathryn Doering
 #' @export
-#' @seealso \code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-#' \code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.30}}
-#' \code{\link{SS_readctl_3.24}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readctl()], [SS_readdat()]
+#' [SS_readdat_3.24()],[SS_readdat_3.30()]
+#' [SS_readctl_3.24()],
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readctl_3.30 <- function(file, verbose = TRUE, echoall = FALSE, version = "3.30",
                             ## Parameters that are not defined in control file
                             nseas = 4,
@@ -1713,7 +1713,7 @@ get_tv_parlabs <- function(full_parms,
 #' This functionality used to be in SS_readctl_3.30, but ware removed to avoid
 #'  confusion.
 #' @param Variance_adjustment_list The Variance_adjustments_list element
-#'  in the control file r4ss list output generated from \link{SS_readctl}.
+#'  in the control file r4ss list output generated from [SS_readctl].
 #'  Defaults to NULL, which can be the case if no variance adjustments were
 #'  included in the model.
 #' @param Nfleets Number of fleets in the model
@@ -1755,7 +1755,7 @@ translate_3.30_to_3.24_var_adjust <- function(Variance_adjustment_list = NULL,
 #' Use 3.30 q options to create the 3.24 q setup
 #'
 #' @param Q_options The Q options list element in the 3.30
-#'  control file r4ss list output generated from \link{SS_readctl}.
+#'  control file r4ss list output generated from [SS_readctl].
 #' @param Nfleets Number of fleets in the model
 #' @param fleetnames Name of the fleets. Defaults to fleet numbers, in the order
 #' @return A dataframe containing the 3.24 Q setup.

--- a/R/SS_readdat.R
+++ b/R/SS_readdat.R
@@ -24,12 +24,12 @@
 #' @author Ian G. Taylor, Allan C. Hicks, Neil L. Klaer, Kelli F. Johnson,
 #' Chantel R. Wetzel
 #' @export
-#' @seealso \code{\link{SS_readdat_2.00}}, \code{\link{SS_readdat_3.00}},
-#' \code{\link{SS_readdat_3.24}}, \code{\link{SS_readdat_3.30}},
-#' \code{\link{SS_readctl}}, \code{\link{SS_readctl_3.24}}
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readdat_2.00()], [SS_readdat_3.00()],
+#' [SS_readdat_3.24()], [SS_readdat_3.30()],
+#' [SS_readctl()], [SS_readctl_3.24()]
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 
 SS_readdat <- function(file, version = NULL, verbose = TRUE, echoall = FALSE, section = NULL) {
 

--- a/R/SS_readdat_2.00.R
+++ b/R/SS_readdat_2.00.R
@@ -17,10 +17,10 @@
 #' will read input data, (equivalent to section=1). ## needs to be added
 #' @author Ian G. Taylor, Yukio Takeuchi, Z. Teresa A'mar, Neil L. Klaer
 #' @export
-#' @seealso \code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readdat()], [SS_readdat_3.30()]
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readdat_2.00 <- function(file, verbose = TRUE, echoall = FALSE, section = NULL) {
   # function to read Stock Synthesis data files
 

--- a/R/SS_readdat_3.00.R
+++ b/R/SS_readdat_3.00.R
@@ -17,10 +17,10 @@
 #' will read input data, (equivalent to section=1).
 #' @author Ian G. Taylor, Yukio Takeuchi, Z. Teresa A'mar
 #' @export
-#' @seealso \code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readdat()], [SS_readdat_3.30()]
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readdat_3.00 <- function(file, verbose = TRUE, echoall = FALSE, section = NULL) {
   # function to read Stock Synthesis data files
 

--- a/R/SS_readdat_3.24.R
+++ b/R/SS_readdat_3.24.R
@@ -18,10 +18,10 @@
 #' @author Ian G. Taylor, Yukio Takeuchi, Z. Teresa A'mar, Kelli F. Johnson,
 #' Chantel R. Wetzel
 #' @export
-#' @seealso \code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readdat()], [SS_readdat_3.30()]
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NULL) {
   # function to read Stock Synthesis data files
 

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -19,10 +19,10 @@
 #' Kelli F. Johnson, Chantel R. Wetzel
 #' @export
 #' @importFrom utils type.convert
-#' @seealso \code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readdat()], [SS_readdat_3.30()]
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readdat_3.30 <-
   function(file, verbose = TRUE, echoall = FALSE, section = NULL) {
     if (verbose) {

--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -14,9 +14,9 @@
 #' @param verbose Should there be verbose output while running the file?
 #' @author Ian Taylor + Nathan Vaughan
 #' @export
-#' @seealso \code{\link{SS_readstarter}}, \code{\link{SS_readdat}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}},
+#' @seealso [SS_readstarter()], [SS_readdat()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()],
 
 SS_readforecast <- function(file = "forecast.ss", Nfleets = NULL, Nareas = NULL, nseas = NULL,
                             version = "3.30", readAll = FALSE, verbose = TRUE) {

--- a/R/SS_readpar_3.24.R
+++ b/R/SS_readpar_3.24.R
@@ -5,21 +5,21 @@
 #'
 #' @param parfile Filename either with full path or relative to working directory.
 #' @param datsource list or character. If list, should be a list produced
-#' from \code{\link{SS_writedat}}. If character, should be the full file location of an
+#' from [SS_writedat()]. If character, should be the full file location of an
 #' SS data file.
 #' @param ctlsource list or character. If list, should be a list produced
-#' from \code{\link{SS_writectl}}. If character, should be the full file location of an
+#' from [SS_writectl()]. If character, should be the full file location of an
 #' SS control file.
 #' @param verbose Should there be verbose output while running the file?
 #' Default=TRUE.
 #' @author Nathan R. Vaughan
 #' @export
-#' @seealso \code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-#' \code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.24}}
-#' \code{\link{SS_readctl_3.24}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readctl()], [SS_readdat()]
+#' [SS_readdat_3.24()],[SS_readdat_3.24()]
+#' [SS_readctl_3.24()],
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readpar_3.24 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
   if (is.character(datsource)) {
     datlist <- SS_readdat(file = datsource, version = "3.24", verbose = FALSE)

--- a/R/SS_readpar_3.30.R
+++ b/R/SS_readpar_3.30.R
@@ -5,22 +5,22 @@
 #'
 #' @param parfile Filename either with full path or relative to working directory.
 #' @param datsource list or character. If list, should be a list produced
-#' from \code{\link{SS_writedat}}. If character, should be the full file location of an
+#' from [SS_writedat()]. If character, should be the full file location of an
 #' SS data file.
 #' @param ctlsource list or character. If list, should be a list produced
-#' from \code{\link{SS_writectl}}. If character, should be the full file location of an
+#' from [SS_writectl()]. If character, should be the full file location of an
 #' SS control file.
 #' @param verbose Should there be verbose output while running the file?
 #' Default=TRUE.
 #' @author Nathan R. Vaughan
 #' @export
-#' @seealso \code{\link{SS_readctl}},
-#' \code{\link{SS_readdat}},
-#' \code{\link{SS_readstarter}},
-#' \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}},
-#' \code{\link{SS_writedat}}
+#' @seealso [SS_readctl()],
+#' [SS_readdat()],
+#' [SS_readstarter()],
+#' [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()],
+#' [SS_writedat()]
 SS_readpar_3.30 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
   if (is.character(datsource)) {
     datlist <- SS_readdat(file = datsource, version = "3.30", verbose = FALSE)

--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -7,9 +7,9 @@
 #' @param verbose Should there be verbose output while running the file?
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_readforecast}}, \code{\link{SS_readdat}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readforecast()], [SS_readdat()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   if (verbose) {
     message("running SS_readstarter")

--- a/R/SS_splitdat.R
+++ b/R/SS_splitdat.R
@@ -3,9 +3,9 @@
 #' A function to split apart bootstrap data files created in data.ss_new.  To
 #' get bootstraps, the input "N bootstrap file to produce" in starter.ss needs
 #' to be 3 or greater. The function can either create a file for just the
-#' input data (if \code{inputs=TRUE}), a file for just the MLE values
-#' (if \code{MLE = TRUE}), or separate files for each of the bootstraps
-#' (if \code{inputs=FALSE} and \code{MLE=FALSE}).
+#' input data (if `inputs=TRUE`), a file for just the MLE values
+#' (if `MLE = TRUE`), or separate files for each of the bootstraps
+#' (if `inputs=FALSE` and `MLE=FALSE`).
 #'
 #'
 #' @param inpath Directory containing the input file. By default the working
@@ -16,7 +16,7 @@
 #' Default="Data.SS_New".
 #' @param outpattern File name of output data file. Default="BootData".
 #' @param number Append bootstrap number to the file name chosen in
-#' \code{outpattern}? Default=F.
+#' `outpattern`? Default=F.
 #' @param verbose Provide richer command line info of function progress?
 #' Default=TRUE.
 #' @param fillblank Replace blank lines with "#". Helps with running on linux.

--- a/R/SS_tune_comps.R
+++ b/R/SS_tune_comps.R
@@ -81,13 +81,13 @@
 #' @param ... Additional arguments to pass to [run_SS_models].
 #'
 #' @return Returns a table that can be copied into the control file.
-#' If \code{write=TRUE} then will write the values to a file
+#' If `write=TRUE` then will write the values to a file
 #' (currently hardwired to go in the directory where the model was run
 #' and called "suggested_tunings.ss").
 #'
 #' @author Ian G. Taylor, Kathryn Doering
 #' @export
-#' @seealso \code{\link{SSMethod.TA1.8}}
+#' @seealso [SSMethod.TA1.8()]
 #' @references Francis, R.I.C.C. (2011). Data weighting in statistical
 #' fisheries stock assessment models. Can. J. Fish. Aquat. Sci. 68: 1124-1138.
 #' @examples
@@ -696,7 +696,7 @@ get_tuning_table <- function(replist, fleets,
 
 #' Get the highest phase used in the control file
 #'
-#' @param ctl A control file list read in using \code{r4ss::SS_readctl}.
+#' @param ctl A control file list read in using `r4ss::SS_readctl`.
 #' @author Kathryn Doering
 get_last_phase <- function(ctl) {
   # read all phases in ctl

--- a/R/SS_varadjust.R
+++ b/R/SS_varadjust.R
@@ -21,7 +21,7 @@
 #' @param verbose TRUE/FALSE switch for amount of detail produced by function.
 #' Default=TRUE.
 #' @author Ian G. Taylor, Gwladys I. Lambert
-#' @seealso \code{\link{SS_tune_comps}}, \code{\link{SS_parlines}}, \code{\link{SS_changepars}}
+#' @seealso [SS_tune_comps()], [SS_parlines()], [SS_changepars()]
 #' @export
 #' @examples
 #'

--- a/R/SS_writectl.R
+++ b/R/SS_writectl.R
@@ -1,25 +1,25 @@
 #' Srite Stock Synthesis control file
 #'
 #' Write Stock Synthesis control file from list object in R which was probably
-#' created using \code{\link{SS_readctl}}. This function is a
+#' created using [SS_readctl()]. This function is a
 #' wrapper which calls either SS_writectl_3.24 or SS_writectl_3.30
 #' (and potentially additional functions in the future).
 #'
-#' @param ctllist List object created by \code{\link{SS_readdat}}.
+#' @param ctllist List object created by [SS_readdat()].
 #' @param outfile Filename for where to write new control file.
 #' @param version SS version number. Currently only "3.24" or "3.30" are supported,
 #' either as character or numeric values (noting that numeric 3.30 = 3.3).
 #' Defaults to NULL, which means that the function will attempt to determine the
-#' version from \code{ctllist}.
+#' version from `ctllist`.
 #' @param overwrite Should existing files be overwritten? Defaults to FALSE.
 #' @param verbose Should there be verbose output while running the file?
 #' Defaults to TRUE.
 #' @author Ian G. Taylor, Yukio Takeuchi, Gwladys I. Lambert, Kathryn Doering
 #' @export
-#' @seealso \code{\link{SS_writedat_3.24}}, \code{\link{SS_writedat_3.30}},
-#' \code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-#' \code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+#' @seealso [SS_writedat_3.24()], [SS_writedat_3.30()],
+#' [SS_readdat()], [SS_makedatlist()],
+#' [SS_readstarter()], [SS_writestarter()],
+#' [SS_readforecast()], [SS_writeforecast()]
 SS_writectl <- function(ctllist, outfile, version = NULL, overwrite = FALSE,
                         verbose = TRUE) {
   # function to write Stock Synthesis data files

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -1,10 +1,10 @@
 #' write control file
 #'
 #' write Stock Synthesis control file from list object in R which was probably
-#' created using \code{\link{SS_readctl}}
+#' created using [SS_readctl()]
 #'
 #'
-#' @param ctllist  List object created by \code{\link{SS_readctl}}.
+#' @param ctllist  List object created by [SS_readctl()].
 #' @param outfile Filename for where to write new data file.
 #' @param overwrite Should existing files be overwritten? Default=FALSE.
 #' @param verbose Should there be verbose output while running the file?
@@ -17,7 +17,7 @@
 #'  to disable them. This information is not explicitly available in control file, too.
 #' @author Yukio Takeuchi
 #' @export
-#' @seealso \code{\link{SS_readctl}}, \code{\link{SS_readctl_3.24}},\code{\link{SS_readstarter}},
+#' @seealso [SS_readctl()], [SS_readctl_3.24()],[SS_readstarter()],
 # ' \code{\link{SS_readforecast}},
 # ' \code{\link{SS_writestarter}}, \code{\link{SS_writeforecast}},
 # ' \code{\link{SS_writedat}}

--- a/R/SS_writectl_3.30.R
+++ b/R/SS_writectl_3.30.R
@@ -1,19 +1,19 @@
 #' write control file for SS version 3.30
 #'
 #' write Stock Synthesis control file from list object in R which was created
-#'   using \code{\link{SS_readctl}}.This function is designed to be called
-#'   using \code{\link{SS_writectl}} and should not be called directly.
+#'   using [SS_readctl()].This function is designed to be called
+#'   using [SS_writectl()] and should not be called directly.
 #'
-#' @param ctllist  List object created by \code{\link{SS_readctl}}.
+#' @param ctllist  List object created by [SS_readctl()].
 #' @param outfile Filename for where to write new data file.
 #' @param overwrite Should existing files be overwritten? Default=FALSE.
 #' @param verbose Should there be verbose output while running the file?
 #' @author Kathryn Doering, Yukio Takeuchi, Neil Klaer, Watal M. Iwasaki
 #' @export
-#' @seealso \code{\link{SS_readctl}}, \code{\link{SS_readctl_3.30}},\code{\link{SS_readstarter}},
-#' \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}}, \code{\link{SS_writeforecast}},
-#' \code{\link{SS_writedat}}
+#' @seealso [SS_readctl()], [SS_readctl_3.30()],[SS_readstarter()],
+#' [SS_readforecast()],
+#' [SS_writestarter()], [SS_writeforecast()],
+#' [SS_writedat()]
 #'
 SS_writectl_3.30 <- function(ctllist, outfile, overwrite = FALSE, verbose) {
   if (verbose) message("Running SS_writectl_3.30\n")

--- a/R/SS_writedat.R
+++ b/R/SS_writedat.R
@@ -1,15 +1,15 @@
 #' write Stock Synthesis data file
 #'
 #' Write Stock Synthesis data file from list object in R which was probably
-#' created using \code{\link{SS_readdat}}. This function is a
+#' created using [SS_readdat()]. This function is a
 #' wrapper which calls either SS_writedat_3.24 or SS_writedat_3.30
 #' (and potentially additional functions in the future). This setup allows those
 #' functions to be cleaner (if somewhat redundant) than a single function that
 #' attempts to do everything.
 #'
 #'
-#' @param datlist List object created by \code{\link{SS_readdat}}
-#' (or by \code{\link{SS_readdat_3.24}} or \code{\link{SS_readdat_3.24}})
+#' @param datlist List object created by [SS_readdat()]
+#' (or by [SS_readdat_3.24()] or [SS_readdat_3.24()])
 #' @param outfile Filename for where to write new data file.
 #' @param version SS version number. Currently only "3.24" or "3.30" are supported,
 #' either as character or numeric values (noting that numeric 3.30 = 3.3).
@@ -19,10 +19,10 @@
 #' @param verbose Should there be verbose output while running the file?
 #' @author Ian G. Taylor, Yukio Takeuchi, Gwladys I. Lambert
 #' @export
-#' @seealso \code{\link{SS_writedat_3.24}}, \code{\link{SS_writedat_3.30}},
-#' \code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-#' \code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+#' @seealso [SS_writedat_3.24()], [SS_writedat_3.30()],
+#' [SS_readdat()], [SS_makedatlist()],
+#' [SS_readstarter()], [SS_writestarter()],
+#' [SS_readforecast()], [SS_writeforecast()]
 #'
 #'
 SS_writedat <- function(datlist,

--- a/R/SS_writedat_3.24.R
+++ b/R/SS_writedat_3.24.R
@@ -1,11 +1,11 @@
 #' write data file for SS version 3.24
 #'
 #' Write Stock Synthesis data file from list object in R which was probably
-#' created using \code{\link{SS_readdat}} (which would have called on
-#' \code{\link{SS_readdat_3.24}}).
+#' created using [SS_readdat()] (which would have called on
+#' [SS_readdat_3.24()]).
 #'
 #'
-#' @param datlist List object created by \code{\link{SS_readdat}}.
+#' @param datlist List object created by [SS_readdat()].
 #' @param outfile Filename for where to write new data file.
 #' @param overwrite Should existing files be overwritten? Default=FALSE.
 #' @param faster Speed up writing by writing length and age comps without aligning
@@ -14,10 +14,10 @@
 #' @author Ian G. Taylor, Yukio Takeuchi, Gwladys I. Lambert, Kelli F. Johnson,
 #' Chantel R. Wetzel
 #' @export
-#' @seealso \code{\link{SS_writedat}}, \code{\link{SS_writedat_3.30}},
-#' \code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-#' \code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+#' @seealso [SS_writedat()], [SS_writedat_3.30()],
+#' [SS_readdat()], [SS_makedatlist()],
+#' [SS_readstarter()], [SS_writestarter()],
+#' [SS_readforecast()], [SS_writeforecast()]
 #'
 SS_writedat_3.24 <- function(datlist,
                              outfile,

--- a/R/SS_writedat_3.30.R
+++ b/R/SS_writedat_3.30.R
@@ -1,11 +1,11 @@
 #' write data file for SS version 3.30
 #'
 #' Write Stock Synthesis data file from list object in R which was probably
-#' created using \code{\link{SS_readdat}} (which would have called on
-#' \code{\link{SS_readdat_3.30}}).
+#' created using [SS_readdat()] (which would have called on
+#' [SS_readdat_3.30()]).
 #'
 #'
-#' @param datlist List object created by \code{\link{SS_readdat}}.
+#' @param datlist List object created by [SS_readdat()].
 #' @param outfile Filename for where to write new data file.
 #' @param overwrite Should existing files be overwritten? Default=FALSE.
 #' @param faster Speed up writing by writing length and age comps without aligning
@@ -15,10 +15,10 @@
 #' Chantel R. Wetzel
 #' @export
 #' @importFrom stats reshape
-#' @seealso \code{\link{SS_writedat}}, \code{\link{SS_writedat_3.24}},
-#' \code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-#' \code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+#' @seealso [SS_writedat()], [SS_writedat_3.24()],
+#' [SS_readdat()], [SS_makedatlist()],
+#' [SS_readstarter()], [SS_writestarter()],
+#' [SS_readforecast()], [SS_writeforecast()]
 #'
 SS_writedat_3.30 <- function(datlist,
                              outfile,

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -1,10 +1,10 @@
 #' write forecast file
 #'
 #' write Stock Synthesis forecast file from list object in R which was probably
-#' created using \code{\link{SS_readforecast}}
+#' created using [SS_readforecast()]
 #'
 #'
-#' @param mylist List object created by \code{\link{SS_readforecast}}.
+#' @param mylist List object created by [SS_readforecast()].
 #' @param dir Directory for new forecast file. Default=NULL (working
 #' directory).
 #' @param file Filename for new forecast file. Default="forecast.ss".
@@ -16,9 +16,9 @@
 #' Default=TRUE.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_readdat}},
-#' \code{\link{SS_writestarter}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readstarter()], [SS_readforecast()],
+#' [SS_readdat()],
+#' [SS_writestarter()], [SS_writedat()]
 SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
                              writeAll = FALSE, overwrite = FALSE, verbose = TRUE) {
   # function to write Stock Synthesis forecast files

--- a/R/SS_writepar_3.24.R
+++ b/R/SS_writepar_3.24.R
@@ -3,18 +3,18 @@
 #' Write Stock Synthesis (version 3.24) parameter file from list object in R to file.
 #'
 #'
-#' @param parlist  List object created by \code{\link{SS_readpar_3.24}}.
+#' @param parlist  List object created by [SS_readpar_3.24()].
 #' @param outfile Filename for where to write new parameter file.
 #' @param overwrite Should existing files be overwritten? Default=TRUE.
 #' @param verbose Should there be verbose output while running the file?
 #' @author Nathan R. Vaughan
 #' @export
-#' @seealso \code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-#' \code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.24}}
-#' \code{\link{SS_readctl_3.24}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readctl()], [SS_readdat()]
+#' [SS_readdat_3.24()],[SS_readdat_3.24()]
+#' [SS_readctl_3.24()],
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_writepar_3.24 <- function(parlist, outfile, overwrite = TRUE, verbose = FALSE) {
 
   # function to write Stock Synthesis parameter files

--- a/R/SS_writepar_3.30.R
+++ b/R/SS_writepar_3.30.R
@@ -3,18 +3,18 @@
 #' Write Stock Synthesis (version 3.30) parameter file from list object in R to file.
 #'
 #'
-#' @param parlist  List object created by \code{\link{SS_readpar_3.30}}.
+#' @param parlist  List object created by [SS_readpar_3.30()].
 #' @param outfile Filename for where to write new parameter file.
 #' @param overwrite Should existing files be overwritten? Default=TRUE.
 #' @param verbose Should there be verbose output while running the file?
 #' @author Nathan R. Vaughan
 #' @export
-#' @seealso \code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-#' \code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.30}}
-#' \code{\link{SS_readctl_3.24}},
-#' \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readctl()], [SS_readdat()]
+#' [SS_readdat_3.24()],[SS_readdat_3.30()]
+#' [SS_readctl_3.24()],
+#' [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_writepar_3.30 <- function(parlist, outfile, overwrite = TRUE, verbose = FALSE) {
 
   # function to write Stock Synthesis parameter files

--- a/R/SS_writestarter.R
+++ b/R/SS_writestarter.R
@@ -1,10 +1,10 @@
 #' write starter file
 #'
 #' write Stock Synthesis starter file from list object in R which was probably
-#' created using \code{\link{SS_readstarter}}
+#' created using [SS_readstarter()]
 #'
 #'
-#' @param mylist List object created by \code{\link{SS_readstarter}}.
+#' @param mylist List object created by [SS_readstarter()].
 #' @param dir Directory for new starter file. Default=NULL (working directory).
 #' @param file Filename for new starter file. Default="starter.ss".
 #' @param overwrite Should existing files be overwritten? Default=FALSE.
@@ -13,9 +13,9 @@
 #' @param warn Print warning if overwriting file?
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-#' \code{\link{SS_writestarter}},
-#' \code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+#' @seealso [SS_readstarter()], [SS_readforecast()],
+#' [SS_writestarter()],
+#' [SS_writeforecast()], [SS_writedat()]
 SS_writestarter <- function(mylist, dir = NULL, file = "starter.ss",
                             overwrite = FALSE, verbose = TRUE, warn = TRUE) {
   if (verbose) cat("running SS_writestarter\n")

--- a/R/SS_writewtatage.R
+++ b/R/SS_writewtatage.R
@@ -1,19 +1,19 @@
 #' Write weight-at-age file
 #'
 #' Write Stock Synthesis weight-at-age file from R object that was probably
-#' created using \code{\link{SS_readwtatage}}
+#' created using [SS_readwtatage()]
 #'
-#' @param mylist Object created by \code{\link{SS_readwtatage}}.
+#' @param mylist Object created by [SS_readwtatage()].
 #' @template dir
 #' @param file Filename for new weight-at-age file, which
-#' will be appended to \code{dir} to create a full file path.
+#' will be appended to `dir` to create a full file path.
 #' Default="wtatage.ss".
 #' @template overwrite
 #' @template verbose
 #' @template warn
 #' @author Kelli Faye Johnson
 #' @export
-#' @seealso \code{\link{SS_readwtatage}}
+#' @seealso [SS_readwtatage()]
 #'
 SS_writewtatage <- function(mylist, dir = NULL, file = "wtatage.ss",
                             overwrite = FALSE, verbose = TRUE, warn = TRUE) {

--- a/R/SSbiologytables.R
+++ b/R/SSbiologytables.R
@@ -1,5 +1,5 @@
 #' A function to create a table of biology for assessment reporting:
-#' length, weight, \% mature, fecundity, and selectivity
+#' length, weight, % mature, fecundity, and selectivity
 #'
 #' Takes the object created by SS_output to create table for reporting
 #' for West Coast groundfish.  Works with Stock Synthesis versions 3.30.12
@@ -14,7 +14,7 @@
 #' @param dir The directory in which a PDF file (if requested) will be created
 #' and within which the printfolder sub-directory (see above) will be created
 #' if png=TRUE. By default it will be the same directory that the report file
-#' was read from by the \code{SS_output} function. Alternatives to the default
+#' was read from by the `SS_output` function. Alternatives to the default
 #' can be either relative (to the working directory) or absolute paths.
 #' The function will attempt to create the directory it doesn't exist, but it
 #' does not do so recursively.

--- a/R/SSbootstrap.R
+++ b/R/SSbootstrap.R
@@ -10,7 +10,7 @@
 #' @author Ian Taylor
 #' @export
 #' @references
-#' \url{http://www.pcouncil.org/wp-content/uploads/2006_hake_assessment_FINAL_ENTIRE.pdf}
+#' <http://www.pcouncil.org/wp-content/uploads/2006_hake_assessment_FINAL_ENTIRE.pdf>
 #' (A description is on page 41 and Figures 55-56 (pg 139-140) show some
 #' results.)
 SSbootstrap <- function() {

--- a/R/SSgetMCMC.R
+++ b/R/SSgetMCMC.R
@@ -17,18 +17,18 @@
 #' @param csv2 Second CSV file for nuisance quantities.
 #' @param keystrings Vector of strings that partially match parameter names to
 #' write to the file csv1. This file intended to feed into
-#' \code{\link{mcmc.out}}.
+#' [mcmc.out()].
 #' @param nuisancestrings Vector of strings that partially match derived
 #' quantity names to write to the file csv2. This file intended to feed into
-#' \code{\link{mcmc.nuisance}}.
+#' [mcmc.nuisance()].
 #' @param burnin Optional burn-in value to apply on top of the option in the
 #' starter file.
 #' @param thin Optional thinning value to apply on top of the option in the
-#' starter file and in the \code{-mcsave} runtime command.
+#' starter file and in the `-mcsave` runtime command.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{mcmc.out}}, \code{\link{mcmc.nuisance}},
-#' \code{\link{SSplotPars}}
+#' @seealso [mcmc.out()], [mcmc.nuisance()],
+#' [SSplotPars()]
 SSgetMCMC <-
   function(dir = NULL,
            verbose = TRUE,

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -1,6 +1,6 @@
 #' Get output from multiple Stock Synthesis models.
 #'
-#' Apply the function \code{\link{SS_output}} multiple times and save output as
+#' Apply the function [SS_output()] multiple times and save output as
 #' individual objects or a list of lists.
 #'
 #'
@@ -17,7 +17,7 @@
 #' @param verbose Print various messages to the command line as the function
 #' runs? Default=TRUE.
 #' @param ncols Maximum number of columns in Report.sso (same input as for
-#' \code{\link{SS_output}}).  Default=210.
+#' [SS_output()]).  Default=210.
 #' @param listlists Save output from each model as a element of a list (i.e.
 #' make a list of lists). Default = TRUE.
 #' @param underscore Add an underscore '_' between any file names and any keys
@@ -26,7 +26,7 @@
 #' filenaming convention based on iteration and date stamp.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_output}} \code{\link{SSsummarize}}
+#' @seealso [SS_output()] [SSsummarize()]
 SSgetoutput <-
   function(keyvec = NULL, dirvec = NULL, getcovar = TRUE, getcomp = TRUE, forecast = TRUE,
            verbose = TRUE, ncols = 210, listlists = TRUE, underscore = FALSE,

--- a/R/SSmohnsrho.R
+++ b/R/SSmohnsrho.R
@@ -7,7 +7,7 @@
 ##' (2) and (3) are based on all years between the reference and the retrospective run.
 ##'
 ##'
-##' @param summaryoutput List created by \code{SSsummarize}. The expected order for the
+##' @param summaryoutput List created by `SSsummarize`. The expected order for the
 ##' models are the full reference model, the retro -1, retro -2, and so forth.
 ##' @param endyrvec Single year or vector of years representing the
 ##' final year of values to show for each model.

--- a/R/SSplotAgeMatrix.R
+++ b/R/SSplotAgeMatrix.R
@@ -37,7 +37,7 @@
 #' be the directory where the model was run.
 #' @author Ian G. Taylor
 #' @export
-#' @seealso \code{\link{SSplotNumbers}}
+#' @seealso [SSplotNumbers()]
 
 
 SSplotAgeMatrix <- function(replist, option = 1, slices = NULL,

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -41,7 +41,7 @@
 #' @param seas which season to plot (values other than 1 only work in
 #' seasonal models but but maybe not fully implemented)
 #' @param morphs Which morphs to plot (if more than 1 per sex)? By default this
-#' will be replist[["mainmorphs"]]
+#' will be `replist[["mainmorphs"]]`
 #' @param forecast Include forecast years in plots of time-varying biology?
 #' @param minyr optional input for minimum year to show in plots
 #' @param maxyr optional input for maximum year to show in plots
@@ -70,7 +70,7 @@
 #' @param verbose Return updates of function progress to the R GUI?
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotBiology <-
   function(replist, plot = TRUE, print = FALSE, add = FALSE,
            subplots = 1:32, seas = 1,

--- a/R/SSplotCatch.R
+++ b/R/SSplotCatch.R
@@ -50,7 +50,7 @@
 #' @param verbose Report progress to R console?
 #' @author Ian Taylor, Ian Stewart
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotCatch <-
   function(replist, subplots = 1:16, add = FALSE, areas = 1,
            plot = TRUE, print = FALSE,

--- a/R/SSplotCohortCatch.R
+++ b/R/SSplotCohortCatch.R
@@ -15,14 +15,14 @@
 #' @param cohortfrac What fraction of the cohorts to include in plot. If value
 #' < 1 is used, then cohorts are filtered to only include those with the
 #' highest maximum cumulative catch. Value will be overridden by
-#' \code{cohortvec}.
+#' `cohortvec`.
 #' @param cohortvec Optional vector of birth years for cohorts to include in
-#' plot. Value overrides \code{cohortfrac}.
+#' plot. Value overrides `cohortfrac`.
 #' @param cohortlabfrac What fraction of the cohorts to label in plot. By
-#' default, top 10\% of cohorts are labeled. Value will be overridden by
-#' \code{cohortlabvec}.
+#' default, top 10% of cohorts are labeled. Value will be overridden by
+#' `cohortlabvec`.
 #' @param cohortlabvec Optional vector of birth years for cohorts to label in
-#' plot. Value overrides \code{cohortlabfrac}.
+#' plot. Value overrides `cohortlabfrac`.
 #' @param lwd Line width
 #' @param plotdir Directory where PNG or PDF files will be written. By default
 #' it will be the directory where the model was run.
@@ -38,7 +38,7 @@
 #' @param verbose Report progress to R console?
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotCohortCatch <-
   function(replist, subplots = 1:2, add = FALSE,
            plot = TRUE, print = FALSE,

--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -2,10 +2,10 @@
 #'
 #' Creates a user-chosen set of plots comparing model output from a summary of
 #' multiple models, where the collection was created using the
-#' \code{SSsummarize} function.
+#' `SSsummarize` function.
 #'
 #'
-#' @param summaryoutput List created by \code{SSsummarize}
+#' @param summaryoutput List created by `SSsummarize`
 #' @param subplots Vector of subplots to be created
 #' Numbering of subplots is as follows:
 #' \itemize{
@@ -29,13 +29,13 @@
 #' }
 #' @param plot Plot to active plot device?
 #' @param print Send plots to PNG files in directory specified by
-#' \code{plotdir}?
-#' @param png Has same result as \code{print}, included for consistency with
-#' \code{SS_plots}.
+#' `plotdir`?
+#' @param png Has same result as `print`, included for consistency with
+#' `SS_plots`.
 #' @param pdf Write output to PDF file? Can't be used in conjunction with
-#' \code{png} or \code{print}.
+#' `png` or `print`.
 #' @param models Optional subset of the models described in
-#' \code{summaryoutput}.  Either "all" or a vector of numbers indicating
+#' `summaryoutput`.  Either "all" or a vector of numbers indicating
 #' columns in summary tables.
 #' @param endyrvec Optional single year or vector of years representing the
 #' final year of values to show for each model. By default it is set to the
@@ -59,31 +59,31 @@
 #' @param indexQlabel Add catchability to legend in plot of index fits
 #' (TRUE/FALSE)?
 #' @param indexQdigits Number of significant digits for catchability in legend
-#' (if \code{indexQlabel=TRUE})
+#' (if `indexQlabel=TRUE`)
 #' @param indexSEvec Optional replacement for the SE values in
-#' summaryoutput[["indices"]] to deal with the issue of differing uncertainty by
+#' `summaryoutput[["indices"]]` to deal with the issue of differing uncertainty by
 #' models described above.
 #' @param indexPlotEach TRUE plots the observed index for each model with
 #' colors, or FALSE just plots observed once in black dots.
 #' @param labels Vector of labels for plots (titles and axis labels)
 #' @param col Optional vector of colors to be used for lines. Input NULL
-#' makes use of \code{rich.colors.short} function.
+#' makes use of `rich.colors.short` function.
 #' @param shadecol Optional vector of colors to be used for shading uncertainty
 #' intervals. The default (NULL) is to use the same colors provided by
-#' \code{col} (either the default or a user-chosen input) and make them
-#' more transparent by applying the \code{shadealpha} input as an alpha
-#' transparency value (using the \code{adjustcolor()} function)
+#' `col` (either the default or a user-chosen input) and make them
+#' more transparent by applying the `shadealpha` input as an alpha
+#' transparency value (using the `adjustcolor()` function)
 #' @param pch Optional vector of plot character values
 #' @param lty Optional vector of line types
 #' @param lwd Optional vector of line widths
 #' @param spacepoints Number of years between points shown on top of lines (for
 #' long timeseries, points every year get mashed together)
 #' @param staggerpoints Number of years to stagger the first point (if
-#' \code{spacepoints > 1}) for each line (so that adjacent lines have points in
+#' `spacepoints > 1`) for each line (so that adjacent lines have points in
 #' different years)
 #' @param initpoint Year value for first point to be added to lines.
 #' Points added to plots are those that satisfy
-#' (Yr-initpoint)\%\%spacepoints == (staggerpoints*iline)\%\%spacepoints
+#' (Yr-initpoint)%%spacepoints == (staggerpoints*iline)%%spacepoints
 #' @param tickEndYr TRUE/FALSE switch to turn on/off extra axis mark at final
 #' year in timeseries plots.
 #' @param shadeForecast TRUE/FALSE switch to turn on off shading of years beyond
@@ -99,7 +99,7 @@
 #' TRUE/FALSE value, or a vector of TRUE/FALSE values for each model,
 #' or a set of integers corresponding to the choice of models.
 #' @param shadealpha Transparency adjustment used to make default shadecol
-#' values (implemented as \code{adjustcolor(col=col, alpha.f=shadealpha)})
+#' values (implemented as `adjustcolor(col=col, alpha.f=shadealpha)`)
 #' @param legend Add a legend?
 #' @param legendlabels Optional vector of labels to include in legend. Default
 #' is 'model1','model2',etc.
@@ -127,11 +127,11 @@
 #' @param filenameprefix Additional text to append to PNG or PDF file names.
 #' It will be separated from default name by an underscore.
 #' @param densitynames Vector of names (or subset of names) of parameters or
-#' derived quantities contained in summaryoutput[["pars"]][["Label"]] or
-#' summaryoutput[["quants"]][["Label"]] for which to make density plots
+#' derived quantities contained in `summaryoutput[["pars"]][["Label"]]` or
+#' `summaryoutput[["quants"]][["Label"]]` for which to make density plots
 #' @param densityxlabs Optional vector of x-axis labels to use in the density
 #' plots (must be equal in length to the printed vector of quantities that
-#' match the \code{densitynames} input)
+#' match the `densitynames` input)
 #' @param rescale TRUE/FALSE control of automatic rescaling of units into
 #' thousands, millions, or billions
 #' @param densityscalex Scalar for upper x-limit in density plots (values below
@@ -143,10 +143,10 @@
 #' @param densityadjust Multiplier on bandwidth of kernel in density function
 #' used for smoothing MCMC posteriors. See 'adjust' in ?density for details.
 #' @param densitysymbols Add symbols along lines in density plots. Quantiles
-#' are \code{c(0.025,0.1,0.25,0.5,0.75,0.9,0.975)}.
-#' @param densitytails Shade tails outside of 95\% interval darker in
+#' are `c(0.025,0.1,0.25,0.5,0.75,0.9,0.975)`.
+#' @param densitytails Shade tails outside of 95% interval darker in
 #' density plots?
-#' @param densitymiddle Shade middle inside of 95\% interval darker in
+#' @param densitymiddle Shade middle inside of 95% interval darker in
 #' density plots?
 #' @param densitylwd Line width for density plots
 #' @param fix0 Always include 0 in the density plots?
@@ -154,7 +154,7 @@
 #' @param add Allows single plot to be added to existing figure. This needs to
 #' be combined with specific 'subplots' input to make sure only one thing gets
 #' added.
-#' @param par list of graphics parameter values passed to the \code{par}
+#' @param par list of graphics parameter values passed to the `par`
 #' function
 #' @param verbose Report progress to R GUI?
 #' @param mcmcVec Vector of TRUE/FALSE values (or single value) indicating
@@ -165,8 +165,8 @@
 #' useful to turn off. Defaults to TRUE.
 #' @author Ian G. Taylor, John R. Wallace
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SSsummarize}},
-#' \code{\link{SS_output}}, \code{\link{SSgetoutput}}
+#' @seealso [SS_plots()], [SSsummarize()],
+#' [SS_output()], [SSgetoutput()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -1,13 +1,13 @@
 #' Plot composition data and fits.
 #'
 #' Plot composition data and fits from Stock Synthesis output.  Multi-figure
-#' plots depend on \code{make_multifig}.
+#' plots depend on `make_multifig`.
 #'
 #'
 #' @template replist
 #' @param subplots vector controlling which subplots to create
 #' @param kind indicator of type of plot can be "LEN", "SIZE", "AGE", "cond",
-#' "GSTAGE", "L[at]A", or "W[at]A".
+#' "GSTAGE", "L@A", or "W@A".
 #' @param sizemethod if kind = "SIZE" then this switch chooses which of the
 #' generalized size bin methods will be plotted.
 #' @param aalyear Years to plot multi-panel conditional age-at-length fits for
@@ -65,10 +65,10 @@
 #' @param blue What color to use for males in bubble plots (default is slightly
 #' transparent blue)
 #' @param pwidth default width of plots printed to files in units of
-#' \code{punits}. Default=7.
+#' `punits`. Default=7.
 #' @param pheight default height width of plots printed to files in units of
-#' \code{punits}. Default=7.
-#' @param punits units for \code{pwidth} and \code{pheight}. Can be "px"
+#' `punits`. Default=7.
+#' @param punits units for `pwidth` and `pheight`. Can be "px"
 #' (pixels), "in" (inches), "cm" or "mm". Default="in".
 #' @param ptsize point size for plotted text in plots printed to files (see
 #' help("png") in R for details). Default=12.
@@ -117,10 +117,10 @@
 #' posterior distributions in which the median and mean differ.
 #' @param mainTitle Logical indicating if a title for the plot should be produced
 #' @param \dots additional arguments that will be passed to
-#' the \code{par} command in the \code{\link{make_multifig}} function.
+#' the `par` command in the [make_multifig()] function.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{make_multifig}}
+#' @seealso [SS_plots()], [make_multifig()]
 SSplotComps <-
   function(replist, subplots = c(1:21, 24), # subplots=1:13,
            kind = "LEN", sizemethod = 1, aalyear = -1, aalbin = -1, plot = TRUE, print = FALSE,

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -49,8 +49,8 @@
 #' @param mainTitle TRUE/FALSE switch to turn on/off the title on the plot.
 #' @author Ian Taylor, Chantel Wetzel, Cole Monnahan
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}},
-#' \code{\link{SS_readdat}}
+#' @seealso [SS_plots()], [SS_output()],
+#' [SS_readdat()]
 SSplotData <- function(replist,
                        plot = TRUE, print = FALSE,
                        plotdir = "default",

--- a/R/SSplotDiscard.R
+++ b/R/SSplotDiscard.R
@@ -5,8 +5,8 @@
 #'
 #' @template replist
 #' @param subplots Vector of which plots to make (1 = data only, 2 = with fit).
-#' If \code{plotdat = FALSE} then subplot 1 is not created, regardless of
-#' choice of \code{subplots}.
+#' If `plotdat = FALSE` then subplot 1 is not created, regardless of
+#' choice of `subplots`.
 #' @param plot Plot to active plot device?
 #' @param print Print to PNG files?
 #' @param plotdir Directory where PNG files will be written. by default it will
@@ -14,7 +14,7 @@
 #' @param fleets Optional vector to subset fleets for which plots will be made
 #' @param fleetnames Optional replacement for fleenames used in data file
 #' @param datplot Make data-only plot of discards? This can override the choice
-#' of \code{subplots}.
+#' of `subplots`.
 #' @param labels Vector of labels for plots (titles and axis labels)
 #' @param yhi Maximum y-value which will always be included in the plot
 #' (all data included regardless). Default = 1 so that discard fractions are always
@@ -33,7 +33,7 @@
 #' @param verbose Report progress to R GUI?
 #' @author Ian G. Taylor, Ian J. Stewart, Robbie L. Emmet
 #' @export
-#' @seealso \code{\link{SS_plots}}
+#' @seealso [SS_plots()]
 SSplotDiscard <-
   function(replist, subplots = 1:2,
            plot = TRUE, print = FALSE,

--- a/R/SSplotIndices.R
+++ b/R/SSplotIndices.R
@@ -72,10 +72,10 @@
 #' the total uncertainty which may result from estimating a parameter for
 #' extra standard deviations
 #' @param verbose report progress to R GUI?
-#' @param \dots Extra arguments to pass to calls to \code{plot}
+#' @param \dots Extra arguments to pass to calls to `plot`
 #' @author Ian Stewart, Ian Taylor, James Thorson
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotIndices <-
   function(replist, subplots = c(1:10, 12),
            plot = TRUE, print = FALSE,

--- a/R/SSplotMCMC_ExtraSelex.R
+++ b/R/SSplotMCMC_ExtraSelex.R
@@ -6,7 +6,7 @@
 #'
 #' @param post A data frame containing either derived_posteriors.sso or a good
 #' subset of it. This can be an element of the list created by the the
-#' \code{\link{SSgetMCMC}} function.
+#' [SSgetMCMC()] function.
 #' @param add TRUE/FALSE option to add results to an existing plot.
 #' @param nsexes Number of sexes in the model (should match model values but is
 #' only used in the title).

--- a/R/SSplotMnwt.R
+++ b/R/SSplotMnwt.R
@@ -7,8 +7,8 @@
 #' @template replist
 #' @param ymax Optional input to override default ymax value.
 #' @param subplots Vector of which plots to make (1 = data only, 2 = with fit).
-#' If \code{plotdat = FALSE} then subplot 1 is not created, regardless of
-#' choice of \code{subplots}.
+#' If `plotdat = FALSE` then subplot 1 is not created, regardless of
+#' choice of `subplots`.
 #' @param plot plot to active plot device?
 #' @param print print to PNG files?
 #' @param plotdir directory where PNG files will be written. by default it will
@@ -16,7 +16,7 @@
 #' @param fleets optional vector to subset fleets for which plots will be made
 #' @param fleetnames optional replacement for fleenames used in data file
 #' @param datplot Make data-only plot of discards? This can override the choice
-#' of \code{subplots}.
+#' of `subplots`.
 #' @param labels vector of labels for plots (titles and axis labels)
 #' @param col1 first color to use in plot (for expected values)
 #' @param col2 second color to use in plot (for observations and intervals)
@@ -29,7 +29,7 @@
 #' @param verbose report progress to R GUI?
 #' @author Ian Taylor, Ian Stewart
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotMnwt <-
   function(replist, subplots = 1:2, ymax = NULL,
            plot = TRUE, print = FALSE,

--- a/R/SSplotMovementMap.R
+++ b/R/SSplotMovementMap.R
@@ -10,12 +10,12 @@
 #' @param polygonlist a list of data frames, each with two columns representing
 #' the longitude and latitude values of the colored polygons. The order of
 #' elements in the list should match the numbering of areas in the SS model.
-#' @param colvec vector of colors for each polygon (if \code{replist} is
+#' @param colvec vector of colors for each polygon (if `replist` is
 #' provided)
 #' @param land color of landmasses in the map
 #' @param xytable data frame of latitude and longitude values which will be
 #' connected by the arrows representing movement rates. The order should match
-#' the order of areas in \code{polygonlist} and in the SS model. Not necessary
+#' the order of areas in `polygonlist` and in the SS model. Not necessary
 #' if no arrows are shown on the map.
 #' @param moveage age for which movement rates will be represented
 #' @param moveseas season for which movement rates will be represented
@@ -31,7 +31,7 @@
 #' Langley
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_output}}, \code{\link{SSplotMovementRates}}
+#' @seealso [SS_output()], [SSplotMovementRates()]
 SSplotMovementMap <-
   function(replist = NULL, xlim, ylim,
            polygonlist, colvec, land = "grey", xytable = NULL,

--- a/R/SSplotMovementRates.R
+++ b/R/SSplotMovementRates.R
@@ -12,7 +12,7 @@
 #' @param plotdir where to put the plots (uses model directory by default)
 #' @param colvec vector of colors for each movement rate in the plot
 #' @param ylim optional input for y range of the plot. By default plot ranges
-#' from 0 to 10\% above highest movement rate (not including fish staying in an
+#' from 0 to 10% above highest movement rate (not including fish staying in an
 #' area).
 #' @param legend add a legend designating which color goes with which pair of
 #' areas?
@@ -28,7 +28,7 @@
 #' @param verbose Print information on function progress.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_output}}, \code{\link{SSplotMovementRates}},
+#' @seealso [SS_output()], [SSplotMovementRates()],
 #' @examples
 #'
 #' \dontrun{

--- a/R/SSplotNumbers.R
+++ b/R/SSplotNumbers.R
@@ -39,7 +39,7 @@
 #' @param verbose report progress to R GUI?
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_output}}, \code{\link{SS_plots}}
+#' @seealso [SS_output()], [SS_plots()]
 SSplotNumbers <-
   function(replist, subplots = 1:10,
            plot = TRUE, print = FALSE,

--- a/R/SSplotPars.R
+++ b/R/SSplotPars.R
@@ -6,7 +6,7 @@
 #'
 #' @template replist
 #' @param plotdir A path to the folder where the plots will be saved. The default
-#' is \code{NULL}, which leads to the plots being created in the folder that
+#' is `NULL`, which leads to the plots being created in the folder that
 #' contains the results.
 #' @param xlab Label on horizontal axis.
 #' @param ylab Label on vertical axis.
@@ -14,14 +14,14 @@
 #' lines?
 #' @param showprior Show prior distribution as black line?
 #' @param showpost Show posterior distribution as bar graph if MCMC results
-#' are available in \code{replist}?
+#' are available in `replist`?
 #' @param showinit Show initial value as red triangle?
 #' @param showdev Include devs in the plot?
 #' @param add Add to existing plot?
 #' @param showlegend Show the legend?
 #' @param fitrange Fit range tightly around MLE & posterior distributions,
 #' instead of full parameter range?
-#' @param xaxs Parameter input for x-axis. See \code{?par} for more info.
+#' @param xaxs Parameter input for x-axis. See `?par` for more info.
 #' @param xlim Optional x-axis limits to be applied to all plots.
 #' Otherwise, limits are based on the model results.
 #' @param ylim Optional y-axis limits to be applied to all plots.
@@ -38,10 +38,10 @@
 #' @param plot Plot to active plot device?
 #' @param print Print to PNG files?
 #' @param pwidth Default width of plots printed to files in units of
-#' \code{punits}. Default=7.
+#' `punits`. Default=7.
 #' @param pheight Default height width of plots printed to files in units of
-#' \code{punits}. Default=7.
-#' @param punits Units for \code{pwidth} and \code{pheight}. Can be "px"
+#' `punits`. Default=7.
+#' @param punits Units for `pwidth` and `pheight`. Can be "px"
 #' (pixels), "in" (inches), "cm" or "mm". Default="in".
 #' @param ptsize Point size for plotted text in plots printed to files (see
 #' help("png") in R for details). Default=12.

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -5,29 +5,29 @@
 #' total.
 #'
 #'
-#' @param summaryoutput List created by the function \code{\link{SSsummarize}}.
+#' @param summaryoutput List created by the function [SSsummarize()].
 #' @param plot Plot to active plot device?
 #' @param print Print to PNG files?
 #' @param models Optional subset of the models described in
-#' \code{summaryoutput}.  Either "all" or a vector of numbers indicating
+#' `summaryoutput`.  Either "all" or a vector of numbers indicating
 #' columns in summary tables.
 #' @param profile.string Character string used to find parameter over which the
-#' profile was conducted. If \code{exact=FALSE}, this can be a substring of
+#' profile was conducted. If `exact=FALSE`, this can be a substring of
 #' one of the SS parameter labels found in the Report.sso file.
 #' For instance, the default input 'steep'
-#' matches the parameter 'SR_BH_steep'. If \code{exact=TRUE}, then
+#' matches the parameter 'SR_BH_steep'. If `exact=TRUE`, then
 #' profile.string needs to be an exact match to the parameter label.
 #' @param profile.label Label for x-axis describing the parameter over which
 #' the profile was conducted.
-#' @param exact Should the \code{profile.string} have to match the parameter
+#' @param exact Should the `profile.string` have to match the parameter
 #' label exactly, or is a substring OK.
 #' @param ylab Label for y-axis. Default is "Change in -log-likelihood".
 #' @param components Vector of likelihood components that may be included in
 #' plot. List is further refined by any components that are not present in
 #' model or have little change over range of profile (based on limit
-#' \code{minfraction}). Hopefully this doesn't need to be changed.
+#' `minfraction`). Hopefully this doesn't need to be changed.
 #' @param component.labels Vector of labels for use in the legend that matches
-#' the vector in \code{components}.
+#' the vector in `components`.
 #' @param minfraction Minimum change in likelihood (over range considered) as a
 #' fraction of change in total likelihood for a component to be included in the
 #' figure.
@@ -46,7 +46,7 @@
 #' likelihood.
 #' @param xlim Range for x-axis. Change in likelihood is calculated relative to
 #' values within this range.
-#' @param ymax Maximum y-value. Default is 10\% greater than largest value
+#' @param ymax Maximum y-value. Default is 10% greater than largest value
 #' plotted.
 #' @param xaxs The style of axis interval calculation to be used for the x-axis
 #' (see ?par for more info)
@@ -65,21 +65,21 @@
 #' be the directory where the model was run.
 #' @param add_cutoff Add dashed line at ~1.92 to indicate 95% confidence interval
 #' based on common cutoff of half of chi-squared of p=.95 with 1 degree of
-#' freedom: \code{0.5*qchisq(p=cutoff_prob, df=1)}. The probability value
-#' can be adjusted using the \code{cutoff_prob} below.
-#' @param cutoff_prob Probability associated with \code{add_cutoff} above.
+#' freedom: `0.5*qchisq(p=cutoff_prob, df=1)`. The probability value
+#' can be adjusted using the `cutoff_prob` below.
+#' @param cutoff_prob Probability associated with `add_cutoff` above.
 #' @param verbose Return updates of function progress to the R GUI? (Doesn't do
 #' anything yet.)
-#' @param \dots Additional arguments passed to the \code{plot} command.
-#' @note Someday the function \code{\link{SS_profile}} will be improved and
+#' @param \dots Additional arguments passed to the `plot` command.
+#' @note Someday the function [SS_profile()] will be improved and
 #' made to work directly with this plotting function, but they don't yet work
-#' well together. Thus, even if \code{\link{SS_profile}} is used, the output
-#' should be read using \code{\link{SSgetoutput}} or by multiple calls to
-#' \code{\link{SS_output}}.
+#' well together. Thus, even if [SS_profile()] is used, the output
+#' should be read using [SSgetoutput()] or by multiple calls to
+#' [SS_output()].
 #' @author Ian Taylor, Ian Stewart
 #' @export
-#' @seealso \code{\link{SSsummarize}}, \code{\link{SS_profile}},
-#' \code{\link{SS_output}}, \code{\link{SSgetoutput}}
+#' @seealso [SSsummarize()], [SS_profile()],
+#' [SS_output()], [SSgetoutput()]
 SSplotProfile <-
   function(summaryoutput,
            plot = TRUE, print = FALSE,

--- a/R/SSplotRecdevs.R
+++ b/R/SSplotRecdevs.R
@@ -30,7 +30,7 @@
 #' @param verbose report progress to R GUI?
 #' @author Ian Taylor, Ian Stewart
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_fitbiasramp}}
+#' @seealso [SS_plots()], [SS_fitbiasramp()]
 SSplotRecdevs <-
   function(replist, subplots = 1:3, plot = TRUE, print = FALSE, add = FALSE,
            uncertainty = TRUE, minyr = -Inf, maxyr = Inf, forecastplot = FALSE,

--- a/R/SSplotRecdist.R
+++ b/R/SSplotRecdist.R
@@ -26,7 +26,7 @@
 #' @param verbose report progress to R GUI?
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SSplotRecdevs}}
+#' @seealso [SS_plots()], [SSplotRecdevs()]
 SSplotRecdist <-
   function(replist, plot = TRUE, print = FALSE,
            areanames = NULL,

--- a/R/SSplotRetroRecruits.R
+++ b/R/SSplotRetroRecruits.R
@@ -3,7 +3,7 @@
 #' Inspired by Jim Ianelli and named by Sean Cox, the squid plot is a way to
 #' examine retrospective patterns in estimation of recruitment deviations.
 #'
-#' @param retroSummary List object created by \code{\link{SSsummarize}} that
+#' @param retroSummary List object created by [SSsummarize()] that
 #' summarizes the results of a set of retrospective analysis models.ss
 #' @param endyrvec Vector of years representing the final year of values to
 #' show for each model.
@@ -20,14 +20,14 @@
 #' to 0.
 #' @param labelyears Label cohorts with text at the end of each line?
 #' @param legend Add a legend showing which color goes with which line (as
-#' alternative to \code{labelyears}).
+#' alternative to `labelyears`).
 #' @param leg.ncols Number of columns for the legend.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SSsummarize}}
+#' @seealso [SSsummarize()]
 #' @references Ianelli et al. (2011) Assessment of the walleye pollock stock in
 #' the Eastern Bering Sea.
-#' \url{http://www.afsc.noaa.gov/REFM/docs/2011/EBSpollock.pdf}. (Figure 1.31,
+#' <http://www.afsc.noaa.gov/REFM/docs/2011/EBSpollock.pdf>. (Figure 1.31,
 #' which is on an absolute, rather than log scale.)
 #' @examples
 #'

--- a/R/SSplotSPR.R
+++ b/R/SSplotSPR.R
@@ -29,7 +29,7 @@
 #' @param verbose report progress to R GUI?
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotSPR <-
   function(replist, add = FALSE, plot = TRUE, print = FALSE,
            uncertainty = TRUE,

--- a/R/SSplotSelex.R
+++ b/R/SSplotSelex.R
@@ -23,8 +23,8 @@
 #' @param sexes Optional vector to subset genders for which to make plots
 #' (1=females, 2=males)
 #' @param selexlines Vector to select which lines get plotted. values are 1.
-#' Selectivity, 2. Retention, 3. Discard mortality, 4. Keep = Sel*Ret, 5. Dead
-#' = Sel*(Ret+(1-Ret)*Mort).
+#' Selectivity, 2. Retention, 3. Discard mortality, 4. Keep = Sel\*Ret, 5. Dead
+#' = Sel\*(Ret+(1-Ret)\*Mort).
 #' @param subplot Vector controlling which subplots to create
 #' @param skipAgeSelex10 Exclude plots for age selectivity type 10 (selectivity
 #' = 1.0 for all ages beginning at age 1)?
@@ -32,7 +32,7 @@
 #' @param spacepoints number of years between points shown on top of lines (for
 #' long timeseries, points every year get mashed together)
 #' @param staggerpoints number of years to stagger the first point (if
-#' \code{spacepoints > 1}) for each line (so that adjacent lines have points in
+#' `spacepoints > 1`) for each line (so that adjacent lines have points in
 #' different years)
 #' @param legendloc location of legend. See ?legend for more info.
 #' @param plot Plot to active plot device?
@@ -53,7 +53,7 @@
 #' @param verbose report progress to R GUI?
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotSelex <-
   function(replist, infotable = NULL,
            fleets = "all", fleetnames = "default",

--- a/R/SSplotSelex.R
+++ b/R/SSplotSelex.R
@@ -23,8 +23,7 @@
 #' @param sexes Optional vector to subset genders for which to make plots
 #' (1=females, 2=males)
 #' @param selexlines Vector to select which lines get plotted. values are 1.
-#' Selectivity, 2. Retention, 3. Discard mortality, 4. Keep = Sel\*Ret, 5. Dead
-#' = Sel\*(Ret+(1-Ret)\*Mort).
+#' Selectivity, 2. Retention, 3. Discard mortality, 4. Keep.
 #' @param subplot Vector controlling which subplots to create
 #' @param skipAgeSelex10 Exclude plots for age selectivity type 10 (selectivity
 #' = 1.0 for all ages beginning at age 1)?

--- a/R/SSplotSexRatio.R
+++ b/R/SSplotSexRatio.R
@@ -1,14 +1,14 @@
 #' Plot sex-ratio data and fits for two sex models
 #'
 #' Plot sex-ratio data and fits from Stock Synthesis output.  Multi-figure
-#' plots depend on \code{make_multifig}. The confidence intervals around the
+#' plots depend on `make_multifig`. The confidence intervals around the
 #' observed points are based on a Jeffreys interval calculated from
 #' the adjusted input sample size (with a floor of 1).
 #'
 #'
 #' @template replist
 #' @param kind indicator of type of plot can be "LEN", "SIZE", "AGE", "cond",
-#' "GSTAGE", "L[at]A", or "W[at]A".
+#' "GSTAGE", "L@A", or "W@A".
 #' @param sexratio.option code to choose among (1) female:male ratio or
 #' (2) fraction females out of the total
 #' @param CI confidence interval for uncertainty
@@ -25,10 +25,10 @@
 #' @param axis1 position of bottom axis values
 #' @param axis2 position of left size axis values
 #' @param pwidth default width of plots printed to files in units of
-#' \code{punits}. Default=7.
+#' `punits`. Default=7.
 #' @param pheight default height width of plots printed to files in units of
-#' \code{punits}. Default=7.
-#' @param punits units for \code{pwidth} and \code{pheight}. Can be "px"
+#' `punits`. Default=7.
+#' @param punits units for `pwidth` and `pheight`. Can be "px"
 #' (pixels), "in" (inches), "cm" or "mm". Default="in".
 #' @param ptsize point size for plotted text in plots printed to files (see
 #' help("png") in R for details). Default=12.
@@ -51,7 +51,7 @@
 #' @param \dots additional arguments that will be passed to the plotting.
 #' @author Cole Monnahan, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{make_multifig_sexratio}}
+#' @seealso [SS_plots()], [make_multifig_sexratio()]
 #' @references Brown, L.; Cai, T. Tony; DasGupta, A. (2001).
 #' Interval Estimation for a Binomial Proportion. Statistical Science.
 #' 16(2): 101-133. http://www.jstor.org/stable/2676784.

--- a/R/SSplotSpawnrecruit.R
+++ b/R/SSplotSpawnrecruit.R
@@ -26,12 +26,12 @@
 #' @param verbose report progress to R GUI?
 #' @param colvec vector of length 4 with colors for 3 lines and 1 set of points
 #' (where the 4th value for the points is the color of the circle around the
-#' background color provided by \code{ptcol}
+#' background color provided by `ptcol`
 #' @param ltyvec vector of length 4 with line types for the 3 lines and 1 set
 #' of points, where the points are disconnected (lty=NA) by default
 #' @param ptcol vector or single value for the color of the points, "default"
 #' will by replaced by a vector of colors of length equal to
-#' nrow(replist[["recruit"]])
+#' `nrow(replist[["recruit"]])`
 #' @param legend add a legend to the figure?
 #' @param legendloc location of legend. By default it is chosen as the first
 #' value in the set of "topleft", "topright", "bottomright" that results in no
@@ -55,7 +55,7 @@
 #' @param forecast include forecast years in the curve?
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotSpawnrecruit <-
   function(replist, subplot = 1:3, add = FALSE, plot = TRUE, print = FALSE,
            xlim = NULL, ylim = NULL,

--- a/R/SSplotSummaryF.R
+++ b/R/SSplotSummaryF.R
@@ -12,7 +12,7 @@
 #' @param plotdir Directory where PNG files will be written. By default it will
 #' be the directory where the model was run.
 #' @param verbose Verbose output to R console?
-#' @param uncertainty Show 95\% uncertainty intervals around point estimates?
+#' @param uncertainty Show 95% uncertainty intervals around point estimates?
 #' @param add add to existing plot
 #' @param pwidth width of plot
 #' @param pheight height of plot
@@ -21,7 +21,7 @@
 #' @param ptsize point size for PNG file
 #' @author Allan Hicks
 #' @export
-#' @seealso \code{\link{SSplotTimeseries}}, ~~~
+#' @seealso [SSplotTimeseries()], ~~~
 SSplotSummaryF <- function(replist, yrs = "all", Ftgt = NA, ylab = "Summary Fishing Mortality",
                            plot = TRUE, print = FALSE, plotdir = "default", verbose = TRUE,
                            uncertainty = TRUE,

--- a/R/SSplotTags.R
+++ b/R/SSplotTags.R
@@ -22,10 +22,10 @@
 #' @param minnbubble minimum number of years below which blank years will be
 #' added to bubble plots to avoid cropping
 #' @param pwidth default width of plots printed to files in units of
-#' \code{punits}. Default=7.
+#' `punits`. Default=7.
 #' @param pheight default height width of plots printed to files in units of
-#' \code{punits}. Default=7.
-#' @param punits units for \code{pwidth} and \code{pheight}. Can be "px"
+#' `punits`. Default=7.
+#' @param punits units for `pwidth` and `pheight`. Can be "px"
 #' (pixels), "in" (inches), "cm" or "mm". Default="in".
 #' @param ptsize point size for plotted text in plots printed to files (see
 #' help("png") in R for details). Default=12.
@@ -42,7 +42,7 @@
 #' @author Andre E. Punt, Ian G. Taylor, Ashleigh J. Novak
 #' @import ggplot2
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotTags <-
   function(replist = replist, subplots = 1:10, latency = NULL, taggroups = NULL,
            rows = 1, cols = 1,

--- a/R/SSplotTimeseries.R
+++ b/R/SSplotTimeseries.R
@@ -53,7 +53,7 @@
 #' @param cex.main character expansion for plot titles
 #' @author Ian Taylor, Ian Stewart
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 SSplotTimeseries <-
   function(replist, subplot, add = FALSE, areas = "all",
            areacols = "default", areanames = "default",

--- a/R/SSplotYield.R
+++ b/R/SSplotYield.R
@@ -33,7 +33,7 @@
 #' @param verbose report progress to R GUI?
 #' @author Ian Stewart, Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}}, \code{\link{SS_output}}
+#' @seealso [SS_plots()], [SS_output()]
 #' @references Walters, Hilborn, and Christensen, 2008, Surplus production
 #' dynamics in declining and recovering fish populations.  Can. J. Fish. Aquat.
 #' Sci. 65: 2536-2551

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -1,13 +1,13 @@
 #' Summarize the output from multiple Stock Synthesis models.
 #'
 #' Summarize various quantities from the model output collected by
-#' \code{\link{SSgetoutput}} and return them in a list of tables and vectors.
+#' [SSgetoutput()] and return them in a list of tables and vectors.
 #'
 #'
 #' @param biglist A list of lists, one for each model. The individual lists can
-#' be created by \code{\link{SS_output}} or the list of lists can be
-#' created by \code{\link{SSgetoutput}} (which iteratively calls
-#' \code{\link{SS_output}}).
+#' be created by [SS_output()] or the list of lists can be
+#' created by [SSgetoutput()] (which iteratively calls
+#' [SS_output()]).
 #' @param sizeselfactor A string or vector of strings indicating which elements
 #' of the selectivity at length output to summarize. Default=c("Lsel").
 #' @param ageselfactor A string or vector of strings indicating which elements
@@ -28,7 +28,7 @@
 #' @template verbose
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SSgetoutput}}
+#' @seealso [SSgetoutput()]
 SSsummarize <- function(biglist,
                         sizeselfactor = "Lsel",
                         ageselfactor = "Asel",

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -22,9 +22,9 @@
 #' @param SpawnOutputUnits Optional single value or vector of "biomass" or
 #' "numbers" giving units of spawning for each model.
 #' @param lowerCI Quantile for lower bound on calculated intervals. Default =
-#' 0.025 for 95\% intervals.
+#' 0.025 for 95% intervals.
 #' @param upperCI Quantile for upper bound on calculated intervals. Default =
-#' 0.975 for 95\% intervals.
+#' 0.975 for 95% intervals.
 #' @template verbose
 #' @author Ian Taylor
 #' @export

--- a/R/SStableComparisons.R
+++ b/R/SStableComparisons.R
@@ -2,18 +2,18 @@
 #'
 #' Creates a table comparing key quantities from multiple models, which is a
 #' reduction of the full information in various parts of the list created using
-#' the \code{SSsummarize} function.
+#' the `SSsummarize` function.
 #'
 #'
-#' @param summaryoutput list created by \code{SSsummarize}
+#' @param summaryoutput list created by `SSsummarize`
 #' @param models optional subset of the models described in
-#' \code{summaryoutput}.  Either "all" or a vector of numbers indicating
+#' `summaryoutput`.  Either "all" or a vector of numbers indicating
 #' columns in summary tables.
 #' @param likenames Labels for likelihood values to include, should match
-#' substring of labels in \code{summaryoutput[["likelihoods"]]}.
+#' substring of labels in `summaryoutput[["likelihoods"]]`.
 #' @param names Labels for parameters or derived quantities to include, should
-#' match substring of labels in \code{summaryoutput[["pars"]]} or
-#' \code{summaryoutput[["quants"]]}.
+#' match substring of labels in `summaryoutput[["pars"]]` or
+#' `summaryoutput[["quants"]]`.
 #' @param digits Optional vector of the number of decimal digits to use in
 #' reporting each quantity.
 #' @param modelnames optional vector of labels to use as column names. Default
@@ -25,8 +25,8 @@
 #' @param mcmc summarize MCMC output in table?
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SSsummarize}}, \code{\link{SSplotComparisons}},
-#' \code{\link{SS_output}}
+#' @seealso [SSsummarize()], [SSplotComparisons()],
+#' [SS_output()]
 SStableComparisons <- function(summaryoutput,
                                models = "all",
                                likenames = c(

--- a/R/TSCplot.R
+++ b/R/TSCplot.R
@@ -1,15 +1,15 @@
 #' Create a plot for the TSC report
 #'
 #' Creates a plot of catch and spawning biomass from the output of
-#' \code{\link{SS_output}} for the NOAA TSC report.
+#' [SS_output()] for the NOAA TSC report.
 #'
 #' It creates a plot on the current graphics device, in a pdf file, or as a png
 #' image of the figure used in the TSC report produced by the NWFSC.  It
-#' expects the SS results read in by \code{\link{SS_output}}.  If MCMC results
+#' expects the SS results read in by [SS_output()].  If MCMC results
 #' are to be plotted, a 'mcmc' list element should be added using the
-#' \code{\link{SSgetMCMC}} function. See the examples below.
+#' [SSgetMCMC()] function. See the examples below.
 #'
-#' @param SSout The output from \code{\link{SS_output}}
+#' @param SSout The output from [SS_output()]
 #' @param yrs The vector of years to plot
 #' @param ylimBar y-axis limits for catch barplot
 #' @param ylimDepl y-axis limits for depletion line
@@ -17,7 +17,7 @@
 #' @param cexBarLabels character expansion for the labels underneath the bars
 #' (years)
 #' @param cex.axis character expansion for the axis labels
-#' @param space space between bars (see space argument of \code{barplot})
+#' @param space space between bars (see space argument of `barplot`)
 #' @param pchDepl character type for points on the depletion line
 #' @param colDepl color of the points on the depletion line
 #' @param lwdDepl width of the depletion line
@@ -28,7 +28,7 @@
 #' numbers help tidy up the plot when plotting many years.
 #' @param ht Height of the plot in inches
 #' @param wd Width of the plot in inches
-#' @param labelLines line argument for \code{mtext} to move the axis labels
+#' @param labelLines line argument for `mtext` to move the axis labels
 #' @param makePDF filename for a pdf file. If NULL it does not make a pdf.  Can
 #' specify a pdf filename or a png filename. Not both at the same time.
 #' @param makePNG filename for a png image. If NULL it does not make a png.
@@ -39,7 +39,7 @@
 #' and total dead catch.
 #' @author Allan Hicks
 #' @export
-#' @seealso \code{\link{SS_output}} \code{\link{SSgetMCMC}}
+#' @seealso [SS_output()] [SSgetMCMC()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/bubble3.R
+++ b/R/bubble3.R
@@ -1,6 +1,6 @@
 #' Create a bubble plot.
 #'
-#' Bubble plot based on function vaguely based on \code{bubble} by Edzer
+#' Bubble plot based on function vaguely based on `bubble` by Edzer
 #' Pebesma in gstat package. By default, positive values have closed bubbles
 #' and negative values have open bubbles.
 #'
@@ -8,12 +8,12 @@
 #' @param x Vector of x-values.
 #' @param y Vector of y-values.
 #' @param z Vector of bubble sizes, where positive sizes will be plotted as
-#' closed bubbles and negative as open unless \code{allopen==TRUE}.
+#' closed bubbles and negative as open unless `allopen==TRUE`.
 #' @param col Color for bubbles. Should be either a single value or vector
 #' of length equal to x, y, and z vectors.
 #' @param cexZ1 Character expansion (cex) value for a proportion of 1.0.
 #' @param maxsize Size of largest bubble. Preferred option is now an expansion
-#' factor for a bubble with z=1 (see \code{cexZ1} above).
+#' factor for a bubble with z=1 (see `cexZ1` above).
 #' @param do.sqrt Should size be based on the area? (Diameter proportional to
 #' sqrt(z)). Default=TRUE.
 #' @param bg.open background color for open bubbles (border will equal 'col')

--- a/R/check_model.R
+++ b/R/check_model.R
@@ -1,13 +1,13 @@
-#' Check input argument \code{model}
+#' Check input argument `model`
 #'
-#' Check that the executable name provided in \code{model},
-#' an input argument to numerous \code{r4ss} functions,
+#' Check that the executable name provided in `model`,
+#' an input argument to numerous `r4ss` functions,
 #' does not contain the extension and is available.
 #'
 #' @template model
-#' @param mydir The directory where \code{model} is located.
+#' @param mydir The directory where `model` is located.
 #' @author Kelli Faye Johnson
-#' @return A cleaned \code{model} name based on the input argument.
+#' @return A cleaned `model` name based on the input argument.
 
 check_model <- function(model, mydir = getwd()) {
   modelnoexe <- gsub("\\.exe$", "", model)

--- a/R/file_increment.R
+++ b/R/file_increment.R
@@ -1,17 +1,17 @@
 #' Rename Stock Synthesis files by adding integer value
 #'
-#' Rename files found with \code{pattern} by adding \code{i} to their
+#' Rename files found with `pattern` by adding `i` to their
 #' name before the extension.
 #'
 #' @details
-#' The \code{.par} file, which is the only file extension searched for
-#' with the default entry that does not end in \code{.sso}, is
-#' modified differently.\code{_i.sso} is added to the file name.
+#' The `.par` file, which is the only file extension searched for
+#' with the default entry that does not end in `.sso`, is
+#' modified differently.`_i.sso` is added to the file name.
 #' @param i An integer value to append to the file name before the
-#' \code{.sso} extension.
+#' `.sso` extension.
 #' @template verbose
 #' @param pattern A character value specifying the file names to search
-#' for in \code{getwd()}.
+#' for in `getwd()`.
 #' @author Kelli Faye Johnson
 #' @returns Invisibly returns a vector of logical values specifying
 #' whether or not the file was successfully renamed.

--- a/R/getADMBHessian.R
+++ b/R/getADMBHessian.R
@@ -9,9 +9,9 @@
 ##' @return A list with elements num.pars, hes, hybrid_bounded_flag, and scale.
 ##' @author Cole Monnahan
 ##' @export
-##' @seealso \code{\link{read.admbFit}}, \code{\link{NegLogInt_Fn}}
+##' @seealso [read.admbFit()], [NegLogInt_Fn()]
 ##' @note Explanation of the methods (in PDF form) published here:
-##' \url{https://github.com/admb-project/admb-examples/blob/master/admb-tricks/covariance-calculations/ADMB_Covariance_Calculations.pdf}
+##' <https://github.com/admb-project/admb-examples/blob/master/admb-tricks/covariance-calculations/ADMB_Covariance_Calculations.pdf>
 getADMBHessian <- function(File, FileName) {
   ## This function reads in all of the information contained in the
   ## admodel.hes file. Some of this is needed for relaxing the

--- a/R/get_SIS_info.R
+++ b/R/get_SIS_info.R
@@ -1,7 +1,7 @@
 #' Gather information for the NOAA Species Information System (SIS)
 #'
 #' Processes model results contained in the list created by
-#' \code{\link{SS_output}} in a format that is more convenient for submission
+#' [SS_output()] in a format that is more convenient for submission
 #' to SIS. Currently the results are returned invisibly as a list of two tables
 #' and written to a CSV file from which results could be copied into SIS.
 #' In the future some more direct link could be explored to avoid the manual
@@ -10,17 +10,17 @@
 #' @param model Output from SS_output
 #' @param dir Directory where the file will be written
 #' @param writecsv Write results to a CSV file (where the name will have the
-#' format "[species]_2019_SIS_info.csv" where \code{species}
+#' format "\[stock\]_2019_SIS_info.csv" where `stock`
 #' is an additional input
 #' @param stock String to prepend id info to filename for CSV file
 #' @param final_year Year of assessment and reference points
-#' (typically will be model[["endyr"]] + 1)
+#' (typically will be `model[["endyr"]] + 1`)
 #' @param data_year Last year of of timeseries data
 #' @param sciencecenter Origin of assessment report
 #' @param Mgt_Council Council jurisdiction. Currently the only option oustside of the default is Gulf of Mexico (`"GM"`)
 #' @author Ian G. Taylor, Andi Stephens
 #' @export
-#' @seealso \code{\link{SS_output}}
+#' @seealso [SS_output()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/get_ncol.R
+++ b/R/get_ncol.R
@@ -1,7 +1,7 @@
-#' Calculate the number of columns in \code{Report.sso}
+#' Calculate the number of columns in `Report.sso`
 #'
 #' The number of columns is important for the optimization of
-#' \code{\link{SS_output}}. Using a \code{while} loop, this function
+#' [SS_output()]. Using a `while` loop, this function
 #' finds the optimum width for reading in data as a table and
 #' decreases the need for users to pre-specify a width when reading
 #' in files.
@@ -13,9 +13,9 @@
 #' before beginning to read data.
 #' @noRd
 #' @return
-#' An integer value specifying the number of columns in \code{file}.
+#' An integer value specifying the number of columns in `file`.
 #' @author Kelli Faye Johnson
-#' @seealso \code{\link{SS_output}}
+#' @seealso [SS_output()]
 #'
 get_ncol <- function(file, skip = 0, nrows = -1) {
   numcol <- list("yes")

--- a/R/make_multifig.R
+++ b/R/make_multifig.R
@@ -25,7 +25,7 @@
 #' @param cols number or cols to return to as default for next plots to come or
 #' for single plots
 #' @param fixdims fix the dimensions at maxrows by maxcols or resize based on
-#' number of elements in \code{yr} input.
+#' number of elements in `yr` input.
 #' @param main title of plot
 #' @param cex.main character expansion for title
 #' @param xlab x-axis label
@@ -104,10 +104,10 @@
 #' passed to this function via the ... argument.
 #' @param multifig_oma vector of outer margins. Can be input to SS_plots and will be
 #' passed to this function via the ... argument.
-#' @param \dots additional arguments passed to \code{par}.
+#' @param \dots additional arguments passed to `par`.
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{SS_plots}},\code{\link{SSplotComps}}
+#' @seealso [SS_plots()],[SSplotComps()]
 make_multifig <-
   function(ptsx, ptsy, yr, linesx = 0, linesy = 0, ptsSD = 0,
            sampsize = 0, effN = 0,

--- a/R/make_multifig_sexratio.R
+++ b/R/make_multifig_sexratio.R
@@ -1,11 +1,11 @@
 #' Create multi-figure sex ratio plots.
 #'
-#' Modified version of \code{\link{make_multifig}} for multi-figure
+#' Modified version of [make_multifig()] for multi-figure
 #' plots of sex ratio data with crude confidence intervals (+/i 1 se) and
 #' fits from Stock Synthesis output.
 #'
-#' @param dbase element of list created by \code{\link{SS_output}} passed from
-#' \code{\link{SSplotSexRatio}}
+#' @param dbase element of list created by [SS_output()] passed from
+#' [SSplotSexRatio()]
 #' @param sexratio.option code to choose among (1) female:male ratio or
 #' (2) fraction females out of the total (the default)
 #' @param CI confidence interval for uncertainty
@@ -17,7 +17,7 @@
 #' @param cols number or cols to return to as default for next plots to come or
 #' for single plots
 #' @param fixdims fix the dimensions at maxrows by maxcols or resize based on
-#' number of elements in \code{yr} input.
+#' number of elements in `yr` input.
 #' @param main title of plot
 #' @param cex.main character expansion for title
 #' @param xlab x-axis label
@@ -57,20 +57,20 @@
 #' @param multifig_oma vector of outer margins. Can be input to SS_plots and will be
 #' passed to this function via the ... argument.
 #' @param \dots additional arguments (NOT YET IMPLEMENTED).
-#' @author Cole Monnahan. Adapted from \code{\link{make_multifig}}.
+#' @author Cole Monnahan. Adapted from [make_multifig()].
 #' @export
 #' @details The SE of the sex ratio is crude and calculated as
 #' follows. First, assume a multinomial which as MLEs of proportions. Then
 #' use the delta method of the ratio F/M, using the MLE as the expected
 #' values and analytical variances and covariance between F and M. After
-#' some algebra this calculation reduces to: SE(F/M)= sqrt((f/m)^2*(
-#' (1-f)/(f*N) + (1-m)/(m*N) +2/N )). Confidence intervals created from
+#' some algebra this calculation reduces to: `SE(F/M)= sqrt((f/m)^2*(
+#' (1-f)/(f*N) + (1-m)/(m*N) +2/N ))`. Confidence intervals created from
 #' these should be considered very crude and would not necessarily be
 #' appropriate for future alternative compositional likelihoods.
 #'
 #' This function was derived from make_multifig and hence has a lot of
 #' overlap in functionality and arguments.
-#' @seealso \code{\link{SS_plots}},\code{\link{SSplotSexRatio}}
+#' @seealso [SS_plots()],[SSplotSexRatio()]
 make_multifig_sexratio <-
   function(dbase, sexratio.option = 2, CI = 0.75,
            sampsizeround = 1, maxrows = 6, maxcols = 6,

--- a/R/mcmc.nuisance.R
+++ b/R/mcmc.nuisance.R
@@ -1,7 +1,7 @@
 #' Summarize nuisance MCMC output
 #'
 #' Summarize nuisance MCMC output (used in combination with
-#' \code{\link{mcmc.out}} for key parameters).
+#' [mcmc.out()] for key parameters).
 #'
 #'
 #' @param directory Directory where all results are located, one level above
@@ -11,24 +11,24 @@
 #' @templateVar file_t posteriors
 #' @param file2 Optional second file containing posterior samples for nuisance
 #' parameters. This could be derived_posteriors.sso.
-#' @param bothfiles TRUE/FALSE indicator on whether to read \code{file2} in
-#' addition to \code{file1}.
+#' @param bothfiles TRUE/FALSE indicator on whether to read `file2` in
+#' addition to `file1`.
 #' @param printstats Return all the statistics for a closer look.
 #' @param burn Optional burn-in value to apply on top of the option in the
-#' starter file and \code{\link{SSgetMCMC}}.
+#' starter file and [SSgetMCMC()].
 #' @param header Data file with header?
 #' @param thin Optional thinning value to apply on top of the option in the
-#' starter file, in the \code{mcsave} runtime command, and in
-#' \code{\link{SSgetMCMC}}.
+#' starter file, in the `mcsave` runtime command, and in
+#' [SSgetMCMC()].
 #' @param trace Plot trace for param # (to help sort out problem parameters).
 #' @param labelstrings Vector of strings that partially match the labels of the
 #' parameters you want to consider.
 #' @param columnnumbers Vector of column numbers indicating the columns you
 #' want to consider.
-#' @param sep Separator for data file passed to the \code{read.table} function.
+#' @param sep Separator for data file passed to the `read.table` function.
 #' @author Ian Stewart
 #' @export
-#' @seealso \code{\link{mcmc.out}}, \code{\link{SSgetMCMC}}
+#' @seealso [mcmc.out()], [SSgetMCMC()]
 mcmc.nuisance <- function(
                           directory = "c:/mydirectory/", # directory to use
                           run = "mymodel/", # folder with ADMB run files

--- a/R/mcmc.out.R
+++ b/R/mcmc.out.R
@@ -12,14 +12,14 @@
 #' @param namefile The (optional) file name of the dimension and names of
 #' posteriors.
 #' @param names Read in names file (T) or use generic naming (F).
-#' @param headernames Use the names in the header of \code{file}?
+#' @param headernames Use the names in the header of `file`?
 #' @param numparams The number of parameters to analyze.
 #' @param closeall By default close all open devices.
 #' @param burn Optional burn-in value to apply on top of the option in the
-#' starter file and \code{\link{SSgetMCMC}}.
+#' starter file and [SSgetMCMC()].
 #' @param thin Optional thinning value to apply on top of the option in the
-#' starter file, in the \code{-mcsave} runtime command, and in
-#' \code{\link{SSgetMCMC}}.
+#' starter file, in the `-mcsave` runtime command, and in
+#' [SSgetMCMC()].
 #' @param scatter Can add a scatter-plot of all params at end, default is none.
 #' @param surface Add a surface plot of 2-way correlations.
 #' @param surf1 The first parameter for the surface plot.
@@ -27,13 +27,13 @@
 #' @param stats Print stats if desired.
 #' @param plots Show plots or not.
 #' @param header Data file with header?
-#' @param sep Separator for data file passed to the \code{read.table} function.
+#' @param sep Separator for data file passed to the `read.table` function.
 #' @param print Send to screen unless asked to print.
 #' @param new Logical whether or not to open a new plot window before plotting
-#' @param colNames Specific names of the \code{file} to extract and work with. \code{NULL} keeps all columns
+#' @param colNames Specific names of the `file` to extract and work with. `NULL` keeps all columns
 #' @author Ian Stewart, Allan Hicks (modifications)
 #' @export
-#' @seealso \code{\link{mcmc.nuisance}}, \code{\link{SSgetMCMC}}
+#' @seealso [mcmc.nuisance()], [SSgetMCMC()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/plotCI.R
+++ b/R/plotCI.R
@@ -12,7 +12,7 @@
 #' @param ylo Lower limit of y range.
 #' @param yhi Upper limit of y range.
 #' @param \dots Additional inputs that will be passed to the function
-#' \code{plot(x,y,ylim=ylim,...)}
+#' `plot(x,y,ylim=ylim,...)`
 #' @param sfrac Fraction of width of plot to be used for bar ends.
 #' @param ymax Additional input for Upper limit of y range.
 #' @param add Add points and intervals to existing plot? Default=FALSE.

--- a/R/populate_multiple_folders.R
+++ b/R/populate_multiple_folders.R
@@ -20,7 +20,7 @@
 #' successfully populated with the model input files and/or executables
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{copy_SS_inputs}}
+#' @seealso [copy_SS_inputs()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/r4ss-package.R
+++ b/R/r4ss-package.R
@@ -8,7 +8,7 @@
 #'
 #' \tabular{ll}{ Package: \tab r4ss\cr Type: \tab Package\cr Version: \tab
 #' 1.41.0\cr Date: \tab 2021-01-11\cr License: \tab GPL-3\cr LazyLoad: \tab
-#' yes\cr URL: \tab \url{https://github.com/r4ss/}\cr }
+#' yes\cr URL: \tab <https://github.com/r4ss/>\cr }
 #' Should be compatible with Stock Synthesis versions 3.24 through 3.30
 #' (specifically version 3.30.16.02, from September 2020).
 #'
@@ -25,8 +25,8 @@
 #' Nathan Vaughan, LaTreese S. Denson, and Ashleigh J. Novak
 #'
 #' Package maintainer: Ian G. Taylor <Ian.Taylor@@noaa.gov>
-#' @references r4ss on GitHub: \url{https://github.com/r4ss}
-#' \cr Download Stock Synthesis: \url{https://vlab.ncep.noaa.gov/web/stock-synthesis/home}
+#' @references r4ss on GitHub: <https://github.com/r4ss>
+#' \cr Download Stock Synthesis: <https://vlab.ncep.noaa.gov/web/stock-synthesis/home>
 #' @import coda
 #' @import kableExtra
 #' @importFrom corpcor pseudoinverse

--- a/R/read.admbFit.R
+++ b/R/read.admbFit.R
@@ -8,7 +8,7 @@
 ##' have format file.par and file.cor.
 ##' @return List of various things from these files.
 ##' @author James Thorson
-##' @seealso \code{\link{getADMBHessian}}, \code{\link{NegLogInt_Fn}}
+##' @seealso [getADMBHessian()], [NegLogInt_Fn()]
 ##' @export
 read.admbFit <- function(file) {
   ret <- list()

--- a/R/rm_dollar_sign.R
+++ b/R/rm_dollar_sign.R
@@ -3,12 +3,13 @@
 #' The dollar sign is convienent to write, but allows for partial matching,
 #' which we don't often want. This function takes a file and changes all dollar
 #' signs to double brackets with names in quotations instead. Note that this
-#' function will incorrectly convert text that includesnames in backticks that
-#' include a dollar sign (for example, test$`my$name` will not convert correctly).
-#' Note also that if a dollar sign is within a text string, it will also not 
-#' convert correctly (for example, "See test$name" would become 
-#' "See test[["name"]]", which is not parsable R code. Luckily, this is easily 
-#' discoverable by loading or sourcing the function.)
+#' function will incorrectly convert text enclosed in backticks that includes a dollar sign. 
+#' Note also that if a dollar sign is within a text 
+#' string enclosed with quotation marks, it will also not  convert correctly 
+#' (for example, "See test$name" would become 
+#' "See test[["name"]]", which is not parsable R code due to 2 sets of quotation 
+#' marks.) Luckily, this last issue is easily discoverable by attempting to load or source 
+#' the function because an error will be produced.
 #' @template file
 #' @param out_file The name or path of a new file to write to. This is by
 #'  default the same as the original file. Set to NULL to avoid writing a new
@@ -16,14 +17,14 @@
 #' @param allow_recursive Should dollar sign references of list in list be
 #'  replaced? If this is FALSE, then only the first reference will be replaced.
 #'  For example, `F$first$second` would become `F[["first"]]$second` when
-#'  alow_recursive is FALSE, but would become `F[["first"]][["second"]]` if TRUE.
+#'  allow_recursive is FALSE, but would become `F[["first"]][["second"]]` if TRUE.
 #' @param max_loops How many times should dollar signs be looked for
 #'  recursively, if allow_recursive is TRUE? Defaults to 5. This is meant to
 #'  prevent an infinite loop in case the function does not work properly.
 #' @return A character vector of the modified text. As a side effect, produces
-#'  a text file out_file that was written out from R using writeLines().
+#'  a text file (name specified in out_file) written out from R using writeLines().
 #' @author Kathryn Doering
-#' #' @example
+#' @examples 
 #' test_text <- c("x$my_name <- y$test"
 #'                  "x[['my_name']]",
 #'                  "no_replace_here <- 44",

--- a/R/rm_dollar_sign.R
+++ b/R/rm_dollar_sign.R
@@ -15,8 +15,8 @@
 #'  file.
 #' @param allow_recursive Should dollar sign references of list in list be
 #'  replaced? If this is FALSE, then only the first reference will be replaced.
-#'  For example, F$first$second would become F[["first"]]$second when
-#'  alow_recursive is FALSE, but would become F[["first"]][["second"]] if TRUE.
+#'  For example, `F$first$second` would become `F[["first"]]$second` when
+#'  alow_recursive is FALSE, but would become `F[["first"]][["second"]]` if TRUE.
 #' @param max_loops How many times should dollar signs be looked for
 #'  recursively, if allow_recursive is TRUE? Defaults to 5. This is meant to
 #'  prevent an infinite loop in case the function does not work properly.

--- a/R/rm_dollar_sign.R
+++ b/R/rm_dollar_sign.R
@@ -7,7 +7,7 @@
 #' Note also that if a dollar sign is within a text 
 #' string enclosed with quotation marks, it will also not  convert correctly 
 #' (for example, "See test$name" would become 
-#' "See test[["name"]]", which is not parsable R code due to 2 sets of quotation 
+#' "See test\[\["name"\]\]", which is not parsable R code due to 2 sets of quotation 
 #' marks.) Luckily, this last issue is easily discoverable by attempting to load or source 
 #' the function because an error will be produced.
 #' @template file

--- a/R/rm_dollar_sign.R
+++ b/R/rm_dollar_sign.R
@@ -25,7 +25,7 @@
 #'  a text file (name specified in out_file) written out from R using writeLines().
 #' @author Kathryn Doering
 #' @examples 
-#' test_text <- c("x$my_name <- y$test"
+#' test_text <- c("x$my_name <- y$test",
 #'                  "x[['my_name']]",
 #'                  "no_replace_here <- 44",
 #'                  "x$names<-new_assign;x$`22`",
@@ -37,12 +37,11 @@
 #'                  "x$`bad$name` <- 55",
 #'                  "x$`other_$badname`")
 #' writeLines(test_text, "test_rm_dollar_sign.txt")
-#' on.exit(file.remove("test_rm_dollar_sign.txt"), add = TRUE)
-#'
-#'  new_text <- rm_dollar_sign(
+#'  new_text <- r4ss:::rm_dollar_sign(
 #'    file = "test_rm_dollar_sign.txt",
 #'    out_file = NULL)
 #'    new_text
+#' file.remove("test_rm_dollar_sign.txt")
 
 rm_dollar_sign <- function(file,
                            out_file = file,

--- a/R/run_SS_models.R
+++ b/R/run_SS_models.R
@@ -24,8 +24,8 @@
 #' had errors like missing executable or Report.sso already present
 #' @author Ian Taylor
 #' @export
-#' @seealso \code{\link{copy_SS_inputs}},
-#' \code{\link{populate_multiple_folders}}
+#' @seealso [copy_SS_inputs()],
+#' [populate_multiple_folders()]
 #' @examples
 #'
 #' \dontrun{

--- a/R/stackpoly.R
+++ b/R/stackpoly.R
@@ -6,7 +6,7 @@
 #'
 #' @param x A numeric data frame or matrix with the 'x' values. If 'y' is NULL,
 #' these will become the 'y' values and the 'x' positions will be the integers
-#' from 1 to dim(x)[1].
+#' from 1 to `dim(x)[1]`.
 #' @param y The 'y' values.
 #' @param main The title for the plot.
 #' @param xlab x axis labels for the plot.
@@ -25,7 +25,7 @@
 #' @param \dots Additional arguments passed to 'plot'.
 #' @author Jim Lemon, Ian Taylor
 #' @export
-#' @references \url{https://cran.r-project.org/package=plotrix}
+#' @references <https://cran.r-project.org/package=plotrix>
 stackpoly <- function(x, y, main = "", xlab = "", ylab = "", xat = NA,
                       xaxlab = NA, xlim = NA, ylim = NA, lty = 1, border = NA,
                       col = NA, axis4 = F, x.hash = NULL, density = 20, ...)

--- a/R/write.fwf.R
+++ b/R/write.fwf.R
@@ -1,6 +1,6 @@
 #' Write object in fixed width format
 #'
-#' \code{write.fwf} writes object in *f*ixed *w*idth *f*ormat.
+#' `write.fwf` writes object in *f*ixed *w*idth *f*ormat.
 #'
 #' Note: This function is copied from the gdata package version 2.18.0 on CRAN
 #' under the GPL-2 license.
@@ -16,52 +16,52 @@
 #' #' While *F*ixed *w*idth *f*ormat is no longer widely used, it remains common
 #' in some disciplines.
 #'
-#' Output is similar to \code{print(x)} or \code{format(x)}. Formatting is done
-#' completely by \code{\link{format}} on a column basis. Columns in the output
+#' Output is similar to `print(x)` or `format(x)`. Formatting is done
+#' completely by [format()] on a column basis. Columns in the output
 #' are by default separated with a space i.e. empty column with a width of one
-#' character, but that can be changed with \code{sep} argument as passed to
-#' \code{\link{write.table}} via \dots{}.
+#' character, but that can be changed with `sep` argument as passed to
+#' [write.table()] via \dots{}.
 #'
-#' As mentioned formatting is done completely by \code{\link{format}}.
-#' Arguments can be passed to \code{format} via \code{\dots{}} to further
-#' modify the output. However, note that the returned \code{formatInfo} might
-#' not properly account for this, since \code{\link{format.info}} (which is
+#' As mentioned formatting is done completely by [format()].
+#' Arguments can be passed to `format` via \code{\dots{}} to further
+#' modify the output. However, note that the returned `formatInfo` might
+#' not properly account for this, since [format.info()] (which is
 #' used to collect information about formatting) lacks the arguments of
-#' \code{\link{format}}.
+#' [format()].
 #'
-#' \code{quote} can be used to quote fields in the output. Since all columns of
-#' \code{x} are converted to character (via \code{\link{format}}) during the
+#' `quote` can be used to quote fields in the output. Since all columns of
+#' `x` are converted to character (via [format()]) during the
 #' output, all columns will be quoted! If quotes are used,
-#' \code{\link{read.table}} can be easily used to read the data back into .
-#' Check examples. Do read the details about \code{quoteInfo} argument.
+#' [read.table()] can be easily used to read the data back into .
+#' Check examples. Do read the details about `quoteInfo` argument.
 #'
 #' Use only *true* character, i.e., avoid use of tabs, i.e., "\\t", or similar
-#' separators via argument \code{sep}. Width of the separator is taken as the
-#' number of characters evaluated via \code{\link{nchar}(sep)}.
+#' separators via argument `sep`. Width of the separator is taken as the
+#' number of characters evaluated via `[nchar](sep)`.
 #'
-#' Use argument \code{na} to convert missing/unknown values. Only single value
-#' can be specified. Use \code{gdata::NAToUnknown} prior to export if you need
+#' Use argument `na` to convert missing/unknown values. Only single value
+#' can be specified. Use `gdata::NAToUnknown` prior to export if you need
 #' greater flexibility.
 #'
-#' If \code{rowCol} is not \code{NULL} and \code{rownames=TRUE}, rownames will
-#' also have column name with \code{rowCol} value. This is mainly for
+#' If `rowCol` is not `NULL` and `rownames=TRUE`, rownames will
+#' also have column name with `rowCol` value. This is mainly for
 #' flexibility with tools outside . Note that (at least in 2.4.0) it is not
-#' "easy" to import data back to with \code{\link{read.fwf}} if you also export
-#' rownames. This is the reason, that default is \code{rownames=FALSE}.
+#' "easy" to import data back to with [read.fwf()] if you also export
+#' rownames. This is the reason, that default is `rownames=FALSE`.
 #'
 #' Information about format of output will be returned if
-#' \code{formatInfo=TRUE}. Returned value is described in value section. This
-#' information is gathered by \code{\link{format.info}} and care was taken to
+#' `formatInfo=TRUE`. Returned value is described in value section. This
+#' information is gathered by [format.info()] and care was taken to
 #' handle numeric properly. If output contains rownames, values account for
-#' this. Additionally, if \code{rowCol} is not \code{NULL} returned values
+#' this. Additionally, if `rowCol` is not `NULL` returned values
 #' contain also information about format of rownames.
 #'
-#' If \code{quote=TRUE}, the output is of course wider due to quotes. Return
-#' value (with \code{formatInfo=TRUE}) can account for this in two ways;
-#' controlled with argument \code{quoteInfo}. However, note that there is no
-#' way to properly read the data back to if \code{quote=TRUE & quoteInfo=FALSE}
-#' arguments were used for export. \code{quoteInfo} applies only when
-#' \code{quote=TRUE}. Assume that there is a file with quoted data as shown
+#' If `quote=TRUE`, the output is of course wider due to quotes. Return
+#' value (with `formatInfo=TRUE`) can account for this in two ways;
+#' controlled with argument `quoteInfo`. However, note that there is no
+#' way to properly read the data back to if `quote=TRUE & quoteInfo=FALSE`
+#' arguments were used for export. `quoteInfo` applies only when
+#' `quote=TRUE`. Assume that there is a file with quoted data as shown
 #' bellow (column numbers in first three lines are only for demonstration of
 #' the values in the output).
 #'
@@ -69,17 +69,17 @@
 #' width with quoteInfo=TRUE 1 12345 1234 # for width with quoteInfo=FALSE "a"
 #' "hsgdh" " 9" " " " bb" " 123" }
 #'
-#' With \code{quoteInfo=TRUE} \code{write.fwf} will return
+#' With `quoteInfo=TRUE` `write.fwf` will return
 #'
 #' \preformatted{ colname position width V1 1 3 V2 5 7 V3 13 6 }
 #'
-#' or (with \code{quoteInfo=FALSE})
+#' or (with `quoteInfo=FALSE`)
 #'
 #' \preformatted{ colname position width V1 2 1 V2 6 5 V3 14 4 }
 #'
-#' Argument \code{width} can be used to increase the width of the columns in
+#' Argument `width` can be used to increase the width of the columns in
 #' the output. This argument is passed to the width argument of
-#' \code{\link{format}} function. Values in \code{width} are recycled if there
+#' [format()] function. Values in `width` are recycled if there
 #' is less values than the number of columns. If the specified width is to
 #' short in comparison to the "width" of the data in particular column, error
 #' is issued.
@@ -87,19 +87,19 @@
 #' @param x data.frame or matrix, the object to be written
 #' @template file
 #' @templateVar file_t write.table
-#' @param append logical, append to existing data in \code{file}
+#' @param append logical, append to existing data in `file`
 #' @param quote logical, quote data in output
-#' @param na character, the string to use for missing values i.e. \code{NA} in
+#' @param na character, the string to use for missing values i.e. `NA` in
 #' the output
 #' @param sep character, separator between columns in output
 #' @param rownames logical, print row names
 #' @param colnames logical, print column names
 #' @param rowCol character, rownames column name
 #' @param justify character, alignment of character columns; see
-#' \code{\link{format}}
+#' [format()]
 #' @param formatInfo logical, return information on number of levels, widths
 #' and format
-#' @param quoteInfo logical, should \code{formatInfo} account for quotes
+#' @param quoteInfo logical, should `formatInfo` account for quotes
 #' @param width numeric, width of the columns in the output
 #' @param eol the character(s) to print at the end of each line (row).  For
 #' example, 'eol="\\r\\n"' will produce Windows' line endings on a Unix-alike OS,
@@ -111,11 +111,11 @@
 #' the initial letter.
 #' @param scientific logical, if TRUE, allow numeric values to be formatted
 #' using scientific notation.
-#' @param \dots further arguments to \code{\link{format.info}} and
-#' \code{\link{format}}
+#' @param \dots further arguments to [format.info()] and
+#' [format()]
 #' @return
 #'
-#' Besides its effect to write/export data \code{write.fwf} can provide
+#' Besides its effect to write/export data `write.fwf` can provide
 #' information on format and width. A data.frame is returned with the following
 #' columns: \item{colname}{name of the column} \item{nlevels}{number of unique
 #' values (unused levels of factors are dropped), 0 for numeric column}
@@ -123,7 +123,7 @@
 #' the column} \item{digits}{number of digits after the decimal point}
 #' \item{exp}{width of exponent in exponential representation; 0 means there is
 #' no exponential representation, while 1 represents exponent of length one
-#' i.e. \code{1e+6} and 2 \code{1e+06} or \code{1e+16}}
+#' i.e. `1e+6` and 2 `1e+06` or `1e+16`}
 #' @author Gregor Gorjanc
 #' @keywords print file
 #' @examples

--- a/man-roxygen/intern.R
+++ b/man-roxygen/intern.R
@@ -1,0 +1,2 @@
+#' @param show_in_console Show output in the R console? If FALSE,
+#' then it is saved to a file.

--- a/man/NegLogInt_Fn.Rd
+++ b/man/NegLogInt_Fn.Rd
@@ -56,7 +56,7 @@ round of optimization from a ".par" file (I recommend TRUE)}
 in the R terminal}
 
 \item{ReDoBiasRamp}{Logical flag saying whether to re-do the bias ramp
-(using \code{\link{SS_fitbiasramp}}) each time Stock Synthesis is run.}
+(using \code{\link[=SS_fitbiasramp]{SS_fitbiasramp()}}) each time Stock Synthesis is run.}
 
 \item{BiasRamp_linenum_Vec}{Vector giving the line numbers from the CTL file
 that contain the information about the bias ramp.}
@@ -106,7 +106,7 @@ effect estimation of time-varying factors in Stock Synthesis. ICES J. Mar.
 Sci.
 }
 \seealso{
-\code{\link{read.admbFit}}, \code{\link{getADMBHessian}}
+\code{\link[=read.admbFit]{read.admbFit()}}, \code{\link[=getADMBHessian]{getADMBHessian()}}
 }
 \author{
 James Thorson

--- a/man/PinerPlot.Rd
+++ b/man/PinerPlot.Rd
@@ -49,7 +49,7 @@ PinerPlot(
 }
 \arguments{
 \item{summaryoutput}{List created by the function
-\code{\link{SSsummarize}}.}
+\code{\link[=SSsummarize]{SSsummarize()}}.}
 
 \item{plot}{Plot to active plot device?}
 
@@ -103,7 +103,7 @@ likelihood.}
 \item{xlim}{Range for x-axis. Change in likelihood is calculated relative to
 values within this range.}
 
-\item{ymax}{Maximum y-value. Default is 10\% greater than largest value
+\item{ymax}{Maximum y-value. Default is 10\\% greater than largest value
 plotted.}
 
 \item{xaxs}{The style of axis interval calculation to be used for the x-axis
@@ -134,7 +134,7 @@ The default is \code{res = 300}.}
 \item{plotdir}{Directory where PNG files will be written. by default it will
 be the directory where the model was run.}
 
-\item{add_cutoff}{Add dashed line at ~1.92 to indicate 95% confidence interval
+\item{add_cutoff}{Add dashed line at ~1.92 to indicate 95\% confidence interval
 based on common cutoff of half of chi-squared of p=.95 with 1 degree of
 freedom: \code{0.5*qchisq(p=cutoff_prob, df=1)}. The probability value
 can be adjusted using the \code{cutoff_prob} below.}

--- a/man/SSMethod.Cond.TA1.8.Rd
+++ b/man/SSMethod.Cond.TA1.8.Rd
@@ -86,15 +86,15 @@ very difficult to be sure that what this function does is appropriate for all
 combinations of options. The following notes (for version A) might help anyone
 wanting to check or correct the code.
 \enumerate{
-  \item The code first removes un-needed rows
+\item The code first removes un-needed rows
 from database condbase.
-  \item The remaining rows of the database are grouped
+\item The remaining rows of the database are grouped
 (indexed by vector indx) and relevant statistics (e.g., observed and expected
 mean age), and ancillary data, are calculated for each group (these are stored
 in pldat - one row per group).
-  \item If the data are to be plotted they are further
+\item If the data are to be plotted they are further
 grouped by fleet, with one panel of the plot per fleet.
-  \item A single multiplier, \emph{w}, is calculated to apply to all the
+\item A single multiplier, \emph{w}, is calculated to apply to all the
 selected data.
 }
 }
@@ -106,7 +106,7 @@ Punt, A.E. (2015). Some insights into data weighting in integrated stock assessm
 Fish. Res. \url{http://dx.doi.org/10.1016/j.fishres.2015.12.006}
 }
 \seealso{
-\code{\link{SSMethod.TA1.8}}
+\code{\link[=SSMethod.TA1.8]{SSMethod.TA1.8()}}
 }
 \author{
 Chris Francis, Andre Punt, Ian Taylor

--- a/man/SSMethod.TA1.8.Rd
+++ b/man/SSMethod.TA1.8.Rd
@@ -97,17 +97,17 @@ difficult to be sure that what this function does is
 appropriate for all combinations of options.  The following
 notes might help anyone wanting to check or correct the code.
 \enumerate{
-  \item The code first takes the appropriate database (lendbase, sizedbase,
-        agedbase, or condbase) and removes un-needed rows.
-  \item The remaining rows of the database are grouped into individual
-        comps (indexed by vector indx) and relevant statistics (e.g.,
-        observed and expected mean length or age), and ancillary data,
-        are calculated for each comp (these are stored in pldat - one row
-        per comp).
-        If the data are to be plotted, the comps are grouped, with each
-        group corresponding to a panel in the plot, and groups are indexed
-        by plindx.
-  \item A single multiplier is calculated to apply to all the comps.
+\item The code first takes the appropriate database (lendbase, sizedbase,
+agedbase, or condbase) and removes un-needed rows.
+\item The remaining rows of the database are grouped into individual
+comps (indexed by vector indx) and relevant statistics (e.g.,
+observed and expected mean length or age), and ancillary data,
+are calculated for each comp (these are stored in pldat - one row
+per comp).
+If the data are to be plotted, the comps are grouped, with each
+group corresponding to a panel in the plot, and groups are indexed
+by plindx.
+\item A single multiplier is calculated to apply to all the comps.
 }
 }
 \examples{
@@ -137,7 +137,7 @@ fisheries stock assessment models. Canadian Journal of
 Fisheries and Aquatic Sciences 68: 1124-1138.
 }
 \seealso{
-\code{\link{SSMethod.Cond.TA1.8}}
+\code{\link[=SSMethod.Cond.TA1.8]{SSMethod.Cond.TA1.8()}}
 }
 \author{
 Chris Francis, Andre Punt, Ian Taylor

--- a/man/SS_ForeCatch.Rd
+++ b/man/SS_ForeCatch.Rd
@@ -70,7 +70,7 @@ This is a common task for US west coast groundfish but might be useful elsewhere
 
 }
 \seealso{
-\code{\link{SS_readforecast}}, \code{\link{SS_readforecast}}
+\code{\link[=SS_readforecast]{SS_readforecast()}}, \code{\link[=SS_readforecast]{SS_readforecast()}}
 }
 \author{
 Ian G. Taylor

--- a/man/SS_changepars.Rd
+++ b/man/SS_changepars.Rd
@@ -103,8 +103,8 @@ the vector of values needs to be in the same order as either
 Loops over a subset of control file to change parameter lines.
 Current initial value, lower and upper bounds, and phase can be modified,
 but function could be expanded to control other columns.
-Depends on \code{\link{SS_parlines}}.
-Used by \code{\link{SS_profile}} and the \pkg{ss3sim} package.
+Depends on \code{\link[=SS_parlines]{SS_parlines()}}.
+Used by \code{\link[=SS_profile]{SS_profile()}} and the \pkg{ss3sim} package.
 }
 \examples{
 
@@ -132,7 +132,7 @@ SS_changepars(
 }
 }
 \seealso{
-\code{\link{SS_parlines}}, \code{\link{SS_profile}}
+\code{\link[=SS_parlines]{SS_parlines()}}, \code{\link[=SS_profile]{SS_profile()}}
 }
 \author{
 Ian Taylor, Christine Stawitz, Chantel Wetzel

--- a/man/SS_doRetro.Rd
+++ b/man/SS_doRetro.Rd
@@ -77,7 +77,7 @@ SSplotComparisons(retroSummary, endyrvec = endyrvec, legendlabels = paste("Data"
 
 }
 \seealso{
-\code{\link{SSgetoutput}}
+\code{\link[=SSgetoutput]{SSgetoutput()}}
 }
 \author{
 Ian Taylor, Jim Thorson

--- a/man/SS_fitbiasramp.Rd
+++ b/man/SS_fitbiasramp.Rd
@@ -100,26 +100,26 @@ Markov chain Mone Carlo estimation routines
 Options to account for the fact that data typically do not equally represent
 all modelled time periods are as follows:
 \enumerate{
-  \item{fix the bias adjustment parameters at best-guess values informed by a previous
+\item{fix the bias adjustment parameters at best-guess values informed by a previous
 assessment or model run;}
-  \item{fix values based on data availability, such that the start of the ramp aligns
+\item{fix values based on data availability, such that the start of the ramp aligns
 with the availability of composition data, the ramp down begins the last year
 those data are informative about recruitment, and the adjustment level is
 informed by life history;}
-  \item{set the adjustment level to 1.0 for all years to mimic how it was handled
+\item{set the adjustment level to 1.0 for all years to mimic how it was handled
 it Stock Synthesis prior to 2009; or}
-   \item{set the adjustment level to 0.0 for all years, but this last option is
+\item{set the adjustment level to 0.0 for all years, but this last option is
 not recommended because it will lead to biased results.}
 }
 }
 \references{
-Methot, R.D. and Taylor, I.G., 2011. 
+Methot, R.D. and Taylor, I.G., 2011.
 Adjusting for bias due to variability of estimated recruitments in fishery assessment models.
 Can. J. Fish. Aquat. Sci., 68:1744-1760.
 \href{https://doi.org/10.1139/f2011-092}{10.1139/f2011-092}.
 }
 \seealso{
-\code{\link{SS_output}}
+\code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_html.Rd
+++ b/man/SS_html.Rd
@@ -40,7 +40,7 @@ runs. Only do this if you know what you're doing.}
 }
 \description{
 Writes a set of HTML files with tabbed navigation between them.  Depends on
-\code{\link{SS_plots}} with settings in place to write figures to PNG files.
+\code{\link[=SS_plots]{SS_plots()}} with settings in place to write figures to PNG files.
 Should open main file in default browser automatically.
 }
 \note{
@@ -51,7 +51,7 @@ directory. Please provide feedback on any bugs, annoyances, or suggestions
 for improvement.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_makeHTMLdiagnostictable.Rd
+++ b/man/SS_makeHTMLdiagnostictable.Rd
@@ -21,7 +21,7 @@ a three-element vector; the first element is the name of the html table file, th
 Creates html tables that show diagnostic outputs, including status checks, gradients, and correlations.
 }
 \seealso{
-[SS_plots()], [SS_output()], [SS_html()]
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}, \code{\link[=SS_html]{SS_html()}}
 }
 \author{
 Christine Stawitz

--- a/man/SS_makedatlist.Rd
+++ b/man/SS_makedatlist.Rd
@@ -145,13 +145,13 @@ have genders combined.}
 \item{morphcomp_data}{Morph composition data. NOT IMPLEMENTED YET.}
 }
 \description{
-create a list similar to those built by \code{\link{SS_readdat}} which can
-be written to a Stock Synthesis data file using \code{\link{SS_writedat}}.
+create a list similar to those built by \code{\link[=SS_readdat]{SS_readdat()}} which can
+be written to a Stock Synthesis data file using \code{\link[=SS_writedat]{SS_writedat()}}.
 In hindsight, this function doesn't seem very useful and I haven't taken
 time to describe the arguments below.
 }
 \seealso{
-\code{\link{SS_readdat}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_output.Rd
+++ b/man/SS_output.Rd
@@ -55,8 +55,8 @@ will end up in the right place, or an absolute path.}
 \item{ncols}{The maximum number of columns in files being read in.  If this
 value is too big the function runs more slowly, too small and errors will
 occur.  A warning will be output to the R command line if the value is too
-small. It should be bigger than the maximum age + 10 and the number of years
-+ 10. The default value is \code{NULL}, which finds the optimum width.}
+small. It should be bigger than the maximum age + 10 and the number of
+years + 10. The default value is \code{NULL}, which finds the optimum width.}
 
 \item{forecast}{Read the forecast-report file?}
 
@@ -121,7 +121,7 @@ myreplist <- SS_output(dir = "c:/SS/Simple/", dir.mcmc = "mcmc")
 
 }
 \seealso{
-\code{\link{SS_plots}}
+\code{\link[=SS_plots]{SS_plots()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SS_parlines.Rd
+++ b/man/SS_parlines.Rd
@@ -59,8 +59,8 @@ head(parlines)
 
 }
 \seealso{
-\code{\link{SS_changepars}}, \code{\link{SS_readctl}},
-\code{\link{SS_readctl_3.24}}
+\code{\link[=SS_changepars]{SS_changepars()}}, \code{\link[=SS_readctl]{SS_readctl()}},
+\code{\link[=SS_readctl_3.24]{SS_readctl_3.24()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_plots.Rd
+++ b/man/SS_plots.Rd
@@ -102,32 +102,32 @@ not available in the model run will automatically be skipped, whether called
 or not.
 Current grouping of plots is as follows:
 \enumerate{
-  \item Biology
-  \item Selectivity and retention
-  \item Timeseries
-  \item Recruitment deviations
-  \item Recruitment bias adjustment
-  \item Spawner-recruit
-  \item Catch
-  \item SPR
-  \item Discards
-  \item Mean weight
-  \item Indices
-  \item Numbers at age
-  \item Length comp data
-  \item Age comp data
-  \item Conditional age-at-length data
-  \item Length comp fits
-  \item Age comp fits
-  \item Conditional age-at-length fits
-  \item Francis and Punt conditional age-at-length comp fits
-  \item Mean length-at-age and mean weight-at-age
-  \item Tags
-  \item Yield
-  \item Movement
-  \item Data range
-  \item Parameter distributions
-  \item Diagnostic tables
+\item Biology
+\item Selectivity and retention
+\item Timeseries
+\item Recruitment deviations
+\item Recruitment bias adjustment
+\item Spawner-recruit
+\item Catch
+\item SPR
+\item Discards
+\item Mean weight
+\item Indices
+\item Numbers at age
+\item Length comp data
+\item Age comp data
+\item Conditional age-at-length data
+\item Length comp fits
+\item Age comp fits
+\item Conditional age-at-length fits
+\item Francis and Punt conditional age-at-length comp fits
+\item Mean length-at-age and mean weight-at-age
+\item Tags
+\item Yield
+\item Movement
+\item Data range
+\item Parameter distributions
+\item Diagnostic tables
 }}
 
 \item{print}{Deprecated input for backward compatibility, now replaced by
@@ -137,7 +137,7 @@ Current grouping of plots is as follows:
 
 \item{png}{Send plots to PNG files instead of R GUI?}
 
-\item{html}{Run \code{\link{SS_html}} on completion? By default has same
+\item{html}{Run \code{\link[=SS_html]{SS_html()}} on completion? By default has same
 value as \code{png}.}
 
 \item{printfolder}{The sub-directory under 'dir' (see below) in which the
@@ -210,7 +210,7 @@ with only a single observed fish in it. Default=0.4.}
 
 \item{sprtarg}{Specify the F/SPR proxy target. Default=0.4.}
 
-\item{btarg}{Target %unfished to be used in plots showing %unfished. May be
+\item{btarg}{Target \%unfished to be used in plots showing \%unfished. May be
 omitted by setting to NA.}
 
 \item{minbthresh}{Threshold depletion to be used in plots showing depletion.
@@ -395,14 +395,14 @@ dynamics in declining and recovering fish populations. Can. J. Fish. Aquat.
 Sci. 65: 2536-2551.
 }
 \seealso{
-\code{\link{SS_output}}, \code{\link{SSplotBiology}},
-\code{\link{SSplotCatch}}, \code{\link{SSplotComps}},
-\code{\link{SSplotDiscard}}, \code{\link{SSplotIndices}},
-\code{\link{SSplotMnwt}}, \code{\link{SSplotNumbers}},
-\code{\link{SSplotRecdevs}}, \code{\link{SSplotSelex}},
-\code{\link{SSplotSpawnrecruit}}, \code{\link{SSplotSPR}},
-\code{\link{SSplotTags}}, \code{\link{SSplotTimeseries}},
-\code{\link{SSplotYield}}
+\code{\link[=SS_output]{SS_output()}}, \code{\link[=SSplotBiology]{SSplotBiology()}},
+\code{\link[=SSplotCatch]{SSplotCatch()}}, \code{\link[=SSplotComps]{SSplotComps()}},
+\code{\link[=SSplotDiscard]{SSplotDiscard()}}, \code{\link[=SSplotIndices]{SSplotIndices()}},
+\code{\link[=SSplotMnwt]{SSplotMnwt()}}, \code{\link[=SSplotNumbers]{SSplotNumbers()}},
+\code{\link[=SSplotRecdevs]{SSplotRecdevs()}}, \code{\link[=SSplotSelex]{SSplotSelex()}},
+\code{\link[=SSplotSpawnrecruit]{SSplotSpawnrecruit()}}, \code{\link[=SSplotSPR]{SSplotSPR()}},
+\code{\link[=SSplotTags]{SSplotTags()}}, \code{\link[=SSplotTimeseries]{SSplotTimeseries()}},
+\code{\link[=SSplotYield]{SSplotYield()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SS_profile.Rd
+++ b/man/SS_profile.Rd
@@ -106,10 +106,10 @@ and some models are likely to require rerunning with alternate starting
 values.
 
 Also, someday this function will be improved to work directly with the
-plotting function \code{\link{SSplotProfile}}, but they don't yet work well
-together. Thus, even if \code{\link{SS_profile}} is used, the output should
-be read using \code{\link{SSgetoutput}} or by multiple calls to
-\code{\link{SS_output}} before sending to \code{\link{SSplotProfile}}.
+plotting function \code{\link[=SSplotProfile]{SSplotProfile()}}, but they don't yet work well
+together. Thus, even if \code{\link[=SS_profile]{SS_profile()}} is used, the output should
+be read using \code{\link[=SSgetoutput]{SSgetoutput()}} or by multiple calls to
+\code{\link[=SS_output]{SS_output()}} before sending to \code{\link[=SSplotProfile]{SSplotProfile()}}.
 }
 \examples{
 
@@ -169,8 +169,8 @@ SSplotComparisons(profilesummary, legendlabels = paste("h =", h.vec))
 
 }
 \seealso{
-\code{\link{SSplotProfile}}, \code{\link{SSgetoutput}},
-\code{\link{SS_changepars}}, \code{\link{SS_parlines}}
+\code{\link[=SSplotProfile]{SSplotProfile()}}, \code{\link[=SSgetoutput]{SSgetoutput()}},
+\code{\link[=SS_changepars]{SS_changepars()}}, \code{\link[=SS_parlines]{SS_parlines()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_read_summary.Rd
+++ b/man/SS_read_summary.Rd
@@ -28,8 +28,8 @@ summary <- SS_read_summary(file = "c:/mymodel/ss_summary.sso")
 
 }
 \seealso{
-\code{\link{SS_output}}, \code{\link{SS_readforecast}},
-\code{\link{SS_readdat}}, \code{\link{SS_readstarter}}
+\code{\link[=SS_output]{SS_output()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_readstarter]{SS_readstarter()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_readctl.Rd
+++ b/man/SS_readctl.Rd
@@ -30,13 +30,11 @@ SS_readctl(
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{version}{SS version number. Currently "3.24" or "3.30" are supported,
 either as character or numeric values (noting that numeric 3.30  = 3.3). If
-`version = NULL` (the default), the version will be looked for on the first
+\code{version = NULL} (the default), the version will be looked for on the first
 line of the file.}
 
 \item{verbose}{A logical value specifying if output should be printed

--- a/man/SS_readctl_3.24.Rd
+++ b/man/SS_readctl_3.24.Rd
@@ -27,9 +27,7 @@ SS_readctl_3.24(
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{Should there be verbose output while running the file?
 Default=TRUE.}
@@ -90,11 +88,11 @@ that calls SS_readctl_3.24 (this function) or SS_readctl_3.30
 (to be available in future).
 }
 \seealso{
-\code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-\code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.30}}
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readdat]{SS_readdat()}}
+\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}},\code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Yukio Takeuchi, Neil Klaer, Iago Mosqueira, and Kathryn Doering

--- a/man/SS_readctl_3.30.Rd
+++ b/man/SS_readctl_3.30.Rd
@@ -27,9 +27,7 @@ SS_readctl_3.30(
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{Should there be verbose output while running the file?
 Default=TRUE.}
@@ -83,7 +81,7 @@ parameters. Defaults to 0.}
 determined from control file}
 
 \item{datlist}{list or character. If list, should be a list produced from
-\code{\link{SS_writedat}}. If character, should be the file name of an
+\code{\link[=SS_writedat]{SS_writedat()}}. If character, should be the file name of an
 SS data file.}
 }
 \description{
@@ -92,12 +90,12 @@ This function comes with its wrapper function SS_readctl
 that calls SS_readctl_3.24  or SS_readctl_3.30 (this function).
 }
 \seealso{
-\code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-\code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.30}}
-\code{\link{SS_readctl_3.24}},
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readdat]{SS_readdat()}}
+\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}},\code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}
+\code{\link[=SS_readctl_3.24]{SS_readctl_3.24()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Neil Klaer, Yukio Takeuchi, Watal M. Iwasaki, and Kathryn Doering

--- a/man/SS_readdat.Rd
+++ b/man/SS_readdat.Rd
@@ -15,9 +15,7 @@ SS_readdat(
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{version}{SS version number.
 Currently "2.00", "3.00", "3.24" or "3.30" are supported,
@@ -44,12 +42,12 @@ functions to be cleaner (if somewhat redundant) than a single function that
 attempts to do everything. Returned datlist is mostly consistent across versions.
 }
 \seealso{
-\code{\link{SS_readdat_2.00}}, \code{\link{SS_readdat_3.00}},
-\code{\link{SS_readdat_3.24}}, \code{\link{SS_readdat_3.30}},
-\code{\link{SS_readctl}}, \code{\link{SS_readctl_3.24}}
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readdat_2.00]{SS_readdat_2.00()}}, \code{\link[=SS_readdat_3.00]{SS_readdat_3.00()}},
+\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}}, \code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}},
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readctl_3.24]{SS_readctl_3.24()}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian G. Taylor, Allan C. Hicks, Neil L. Klaer, Kelli F. Johnson,

--- a/man/SS_readdat_2.00.Rd
+++ b/man/SS_readdat_2.00.Rd
@@ -9,9 +9,7 @@ SS_readdat_2.00(file, verbose = TRUE, echoall = FALSE, section = NULL)
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{Should there be verbose output while running the file?
 Default=TRUE.}
@@ -31,10 +29,10 @@ for a wrapper function that calls either SS_readdat_2.00 SS_readdat_3.00
 SS_readdat_3.24 or SS_readdat_3.30 (and potentially additional functions in the future).
 }
 \seealso{
-\code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Z. Teresa A'mar, Neil L. Klaer

--- a/man/SS_readdat_3.00.Rd
+++ b/man/SS_readdat_3.00.Rd
@@ -9,9 +9,7 @@ SS_readdat_3.00(file, verbose = TRUE, echoall = FALSE, section = NULL)
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{Should there be verbose output while running the file?
 Default=TRUE.}
@@ -31,10 +29,10 @@ for a wrapper function that calls either SS_readdat_3.24 or SS_readdat_3.30
 (and potentially additional functions in the future).
 }
 \seealso{
-\code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Z. Teresa A'mar

--- a/man/SS_readdat_3.24.Rd
+++ b/man/SS_readdat_3.24.Rd
@@ -9,9 +9,7 @@ SS_readdat_3.24(file, verbose = TRUE, echoall = FALSE, section = NULL)
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{Should there be verbose output while running the file?
 Default=TRUE.}
@@ -31,10 +29,10 @@ for a wrapper function that calls either SS_readdat_3.24 or SS_readdat_3.30
 (and potentially additional functions in the future).
 }
 \seealso{
-\code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Z. Teresa A'mar, Kelli F. Johnson,

--- a/man/SS_readdat_3.30.Rd
+++ b/man/SS_readdat_3.30.Rd
@@ -9,9 +9,7 @@ SS_readdat_3.30(file, verbose = TRUE, echoall = FALSE, section = NULL)
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{Should there be verbose output while running the file?
 Default=TRUE.}
@@ -31,10 +29,10 @@ for a wrapper function that calls either SS_readdat_3.24 or SS_readdat_3.30
 (and potentially additional functions in the future).
 }
 \seealso{
-\code{\link{SS_readdat}}, \code{\link{SS_readdat_3.30}}
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Z. Teresa A'mar, Chris J. Grandin,

--- a/man/SS_readforecast.Rd
+++ b/man/SS_readforecast.Rd
@@ -17,9 +17,7 @@ SS_readforecast(
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{Nfleets}{Number of fleets (not required in 3.30).}
 
@@ -39,9 +37,9 @@ either as character or numeric values (noting that numeric 3.30  = 3.3).}
 read Stock Synthesis forecast file into list object in R
 }
 \seealso{
-\code{\link{SS_readstarter}}, \code{\link{SS_readdat}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readdat]{SS_readdat()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}},
 }
 \author{
 Ian Taylor + Nathan Vaughan

--- a/man/SS_readpar_3.24.Rd
+++ b/man/SS_readpar_3.24.Rd
@@ -10,11 +10,11 @@ SS_readpar_3.24(parfile, datsource, ctlsource, verbose = TRUE)
 \item{parfile}{Filename either with full path or relative to working directory.}
 
 \item{datsource}{list or character. If list, should be a list produced
-from \code{\link{SS_writedat}}. If character, should be the full file location of an
+from \code{\link[=SS_writedat]{SS_writedat()}}. If character, should be the full file location of an
 SS data file.}
 
 \item{ctlsource}{list or character. If list, should be a list produced
-from \code{\link{SS_writectl}}. If character, should be the full file location of an
+from \code{\link[=SS_writectl]{SS_writectl()}}. If character, should be the full file location of an
 SS control file.}
 
 \item{verbose}{Should there be verbose output while running the file?
@@ -24,12 +24,12 @@ Default=TRUE.}
 Read Stock Synthesis (version 3.24) parameter file into list object in R.
 }
 \seealso{
-\code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-\code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.24}}
-\code{\link{SS_readctl_3.24}},
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readdat]{SS_readdat()}}
+\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}},\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}}
+\code{\link[=SS_readctl_3.24]{SS_readctl_3.24()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Nathan R. Vaughan

--- a/man/SS_readpar_3.30.Rd
+++ b/man/SS_readpar_3.30.Rd
@@ -10,11 +10,11 @@ SS_readpar_3.30(parfile, datsource, ctlsource, verbose = TRUE)
 \item{parfile}{Filename either with full path or relative to working directory.}
 
 \item{datsource}{list or character. If list, should be a list produced
-from \code{\link{SS_writedat}}. If character, should be the full file location of an
+from \code{\link[=SS_writedat]{SS_writedat()}}. If character, should be the full file location of an
 SS data file.}
 
 \item{ctlsource}{list or character. If list, should be a list produced
-from \code{\link{SS_writectl}}. If character, should be the full file location of an
+from \code{\link[=SS_writectl]{SS_writectl()}}. If character, should be the full file location of an
 SS control file.}
 
 \item{verbose}{Should there be verbose output while running the file?
@@ -24,13 +24,13 @@ Default=TRUE.}
 Read Stock Synthesis (version 3.30) parameter file into list object in R.
 }
 \seealso{
-\code{\link{SS_readctl}},
-\code{\link{SS_readdat}},
-\code{\link{SS_readstarter}},
-\code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}},
-\code{\link{SS_writedat}}
+\code{\link[=SS_readctl]{SS_readctl()}},
+\code{\link[=SS_readdat]{SS_readdat()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}},
+\code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}},
+\code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Nathan R. Vaughan

--- a/man/SS_readstarter.Rd
+++ b/man/SS_readstarter.Rd
@@ -9,9 +9,7 @@ SS_readstarter(file = "starter.ss", verbose = TRUE)
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{Should there be verbose output while running the file?}
 }
@@ -19,9 +17,9 @@ SS_readstarter(file = "starter.ss", verbose = TRUE)
 read Stock Synthesis starter file into list object in R
 }
 \seealso{
-\code{\link{SS_readforecast}}, \code{\link{SS_readdat}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readforecast]{SS_readforecast()}}, \code{\link[=SS_readdat]{SS_readdat()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_readwtatage.Rd
+++ b/man/SS_readwtatage.Rd
@@ -9,9 +9,7 @@ SS_readwtatage(file = "wtatage.ss", verbose = TRUE)
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{verbose}{A logical value specifying if output should be printed
 to the screen. The default is \code{verbose = TRUE}.}

--- a/man/SS_tune_comps.Rd
+++ b/man/SS_tune_comps.Rd
@@ -236,7 +236,7 @@ Francis, R.I.C.C. (2011). Data weighting in statistical
 fisheries stock assessment models. Can. J. Fish. Aquat. Sci. 68: 1124-1138.
 }
 \seealso{
-\code{\link{SSMethod.TA1.8}}
+\code{\link[=SSMethod.TA1.8]{SSMethod.TA1.8()}}
 }
 \author{
 Ian G. Taylor, Kathryn Doering

--- a/man/SS_varadjust.Rd
+++ b/man/SS_varadjust.Rd
@@ -72,7 +72,7 @@ SS_varadjust(
 
 }
 \seealso{
-\code{\link{SS_tune_comps}}, \code{\link{SS_parlines}}, \code{\link{SS_changepars}}
+\code{\link[=SS_tune_comps]{SS_tune_comps()}}, \code{\link[=SS_parlines]{SS_parlines()}}, \code{\link[=SS_changepars]{SS_changepars()}}
 }
 \author{
 Ian G. Taylor, Gwladys I. Lambert

--- a/man/SS_writectl.Rd
+++ b/man/SS_writectl.Rd
@@ -13,7 +13,7 @@ SS_writectl(
 )
 }
 \arguments{
-\item{ctllist}{List object created by \code{\link{SS_readdat}}.}
+\item{ctllist}{List object created by \code{\link[=SS_readdat]{SS_readdat()}}.}
 
 \item{outfile}{Filename for where to write new control file.}
 
@@ -29,15 +29,15 @@ Defaults to TRUE.}
 }
 \description{
 Write Stock Synthesis control file from list object in R which was probably
-created using \code{\link{SS_readctl}}. This function is a
+created using \code{\link[=SS_readctl]{SS_readctl()}}. This function is a
 wrapper which calls either SS_writectl_3.24 or SS_writectl_3.30
 (and potentially additional functions in the future).
 }
 \seealso{
-\code{\link{SS_writedat_3.24}}, \code{\link{SS_writedat_3.30}},
-\code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-\code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-\code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+\code{\link[=SS_writedat_3.24]{SS_writedat_3.24()}}, \code{\link[=SS_writedat_3.30]{SS_writedat_3.30()}},
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_makedatlist]{SS_makedatlist()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_readforecast]{SS_readforecast()}}, \code{\link[=SS_writeforecast]{SS_writeforecast()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Gwladys I. Lambert, Kathryn Doering

--- a/man/SS_writectl_3.24.Rd
+++ b/man/SS_writectl_3.24.Rd
@@ -15,7 +15,7 @@ SS_writectl_3.24(
 )
 }
 \arguments{
-\item{ctllist}{List object created by \code{\link{SS_readctl}}.}
+\item{ctllist}{List object created by \code{\link[=SS_readctl]{SS_readctl()}}.}
 
 \item{outfile}{Filename for where to write new data file.}
 
@@ -35,10 +35,10 @@ to disable them. This information is not explicitly available in control file, t
 }
 \description{
 write Stock Synthesis control file from list object in R which was probably
-created using \code{\link{SS_readctl}}
+created using \code{\link[=SS_readctl]{SS_readctl()}}
 }
 \seealso{
-\code{\link{SS_readctl}}, \code{\link{SS_readctl_3.24}},\code{\link{SS_readstarter}},
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readctl_3.24]{SS_readctl_3.24()}},\code{\link[=SS_readstarter]{SS_readstarter()}},
 }
 \author{
 Yukio Takeuchi

--- a/man/SS_writectl_3.30.Rd
+++ b/man/SS_writectl_3.30.Rd
@@ -7,7 +7,7 @@
 SS_writectl_3.30(ctllist, outfile, overwrite = FALSE, verbose)
 }
 \arguments{
-\item{ctllist}{List object created by \code{\link{SS_readctl}}.}
+\item{ctllist}{List object created by \code{\link[=SS_readctl]{SS_readctl()}}.}
 
 \item{outfile}{Filename for where to write new data file.}
 
@@ -17,14 +17,14 @@ SS_writectl_3.30(ctllist, outfile, overwrite = FALSE, verbose)
 }
 \description{
 write Stock Synthesis control file from list object in R which was created
-  using \code{\link{SS_readctl}}.This function is designed to be called
-  using \code{\link{SS_writectl}} and should not be called directly.
+using \code{\link[=SS_readctl]{SS_readctl()}}.This function is designed to be called
+using \code{\link[=SS_writectl]{SS_writectl()}} and should not be called directly.
 }
 \seealso{
-\code{\link{SS_readctl}}, \code{\link{SS_readctl_3.30}},\code{\link{SS_readstarter}},
-\code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}}, \code{\link{SS_writeforecast}},
-\code{\link{SS_writedat}}
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readctl_3.30]{SS_readctl_3.30()}},\code{\link[=SS_readstarter]{SS_readstarter()}},
+\code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}}, \code{\link[=SS_writeforecast]{SS_writeforecast()}},
+\code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Kathryn Doering, Yukio Takeuchi, Neil Klaer, Watal M. Iwasaki

--- a/man/SS_writedat.Rd
+++ b/man/SS_writedat.Rd
@@ -14,8 +14,8 @@ SS_writedat(
 )
 }
 \arguments{
-\item{datlist}{List object created by \code{\link{SS_readdat}}
-(or by \code{\link{SS_readdat_3.24}} or \code{\link{SS_readdat_3.24}})}
+\item{datlist}{List object created by \code{\link[=SS_readdat]{SS_readdat()}}
+(or by \code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}} or \code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}})}
 
 \item{outfile}{Filename for where to write new data file.}
 
@@ -31,17 +31,17 @@ the columns (by using write.table instead of print.data.frame)}
 }
 \description{
 Write Stock Synthesis data file from list object in R which was probably
-created using \code{\link{SS_readdat}}. This function is a
+created using \code{\link[=SS_readdat]{SS_readdat()}}. This function is a
 wrapper which calls either SS_writedat_3.24 or SS_writedat_3.30
 (and potentially additional functions in the future). This setup allows those
 functions to be cleaner (if somewhat redundant) than a single function that
 attempts to do everything.
 }
 \seealso{
-\code{\link{SS_writedat_3.24}}, \code{\link{SS_writedat_3.30}},
-\code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-\code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-\code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+\code{\link[=SS_writedat_3.24]{SS_writedat_3.24()}}, \code{\link[=SS_writedat_3.30]{SS_writedat_3.30()}},
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_makedatlist]{SS_makedatlist()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_readforecast]{SS_readforecast()}}, \code{\link[=SS_writeforecast]{SS_writeforecast()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Gwladys I. Lambert

--- a/man/SS_writedat_3.24.Rd
+++ b/man/SS_writedat_3.24.Rd
@@ -13,7 +13,7 @@ SS_writedat_3.24(
 )
 }
 \arguments{
-\item{datlist}{List object created by \code{\link{SS_readdat}}.}
+\item{datlist}{List object created by \code{\link[=SS_readdat]{SS_readdat()}}.}
 
 \item{outfile}{Filename for where to write new data file.}
 
@@ -26,14 +26,14 @@ the columns (by using write.table instead of print.data.frame)}
 }
 \description{
 Write Stock Synthesis data file from list object in R which was probably
-created using \code{\link{SS_readdat}} (which would have called on
-\code{\link{SS_readdat_3.24}}).
+created using \code{\link[=SS_readdat]{SS_readdat()}} (which would have called on
+\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}}).
 }
 \seealso{
-\code{\link{SS_writedat}}, \code{\link{SS_writedat_3.30}},
-\code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-\code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-\code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+\code{\link[=SS_writedat]{SS_writedat()}}, \code{\link[=SS_writedat_3.30]{SS_writedat_3.30()}},
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_makedatlist]{SS_makedatlist()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_readforecast]{SS_readforecast()}}, \code{\link[=SS_writeforecast]{SS_writeforecast()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Gwladys I. Lambert, Kelli F. Johnson,

--- a/man/SS_writedat_3.30.Rd
+++ b/man/SS_writedat_3.30.Rd
@@ -13,7 +13,7 @@ SS_writedat_3.30(
 )
 }
 \arguments{
-\item{datlist}{List object created by \code{\link{SS_readdat}}.}
+\item{datlist}{List object created by \code{\link[=SS_readdat]{SS_readdat()}}.}
 
 \item{outfile}{Filename for where to write new data file.}
 
@@ -26,14 +26,14 @@ the columns (by using write.table instead of print.data.frame)}
 }
 \description{
 Write Stock Synthesis data file from list object in R which was probably
-created using \code{\link{SS_readdat}} (which would have called on
-\code{\link{SS_readdat_3.30}}).
+created using \code{\link[=SS_readdat]{SS_readdat()}} (which would have called on
+\code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}).
 }
 \seealso{
-\code{\link{SS_writedat}}, \code{\link{SS_writedat_3.24}},
-\code{\link{SS_readdat}}, \code{\link{SS_makedatlist}},
-\code{\link{SS_readstarter}}, \code{\link{SS_writestarter}},
-\code{\link{SS_readforecast}}, \code{\link{SS_writeforecast}}
+\code{\link[=SS_writedat]{SS_writedat()}}, \code{\link[=SS_writedat_3.24]{SS_writedat_3.24()}},
+\code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_makedatlist]{SS_makedatlist()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_readforecast]{SS_readforecast()}}, \code{\link[=SS_writeforecast]{SS_writeforecast()}}
 }
 \author{
 Ian G. Taylor, Yukio Takeuchi, Gwladys I. Lambert, Kelli F. Johnson,

--- a/man/SS_writeforecast.Rd
+++ b/man/SS_writeforecast.Rd
@@ -14,7 +14,7 @@ SS_writeforecast(
 )
 }
 \arguments{
-\item{mylist}{List object created by \code{\link{SS_readforecast}}.}
+\item{mylist}{List object created by \code{\link[=SS_readforecast]{SS_readforecast()}}.}
 
 \item{dir}{Directory for new forecast file. Default=NULL (working
 directory).}
@@ -32,12 +32,12 @@ Default=TRUE.}
 }
 \description{
 write Stock Synthesis forecast file from list object in R which was probably
-created using \code{\link{SS_readforecast}}
+created using \code{\link[=SS_readforecast]{SS_readforecast()}}
 }
 \seealso{
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_readdat}},
-\code{\link{SS_writestarter}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_readdat]{SS_readdat()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_writepar_3.24.Rd
+++ b/man/SS_writepar_3.24.Rd
@@ -7,7 +7,7 @@
 SS_writepar_3.24(parlist, outfile, overwrite = TRUE, verbose = FALSE)
 }
 \arguments{
-\item{parlist}{List object created by \code{\link{SS_readpar_3.24}}.}
+\item{parlist}{List object created by \code{\link[=SS_readpar_3.24]{SS_readpar_3.24()}}.}
 
 \item{outfile}{Filename for where to write new parameter file.}
 
@@ -19,12 +19,12 @@ SS_writepar_3.24(parlist, outfile, overwrite = TRUE, verbose = FALSE)
 Write Stock Synthesis (version 3.24) parameter file from list object in R to file.
 }
 \seealso{
-\code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-\code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.24}}
-\code{\link{SS_readctl_3.24}},
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readdat]{SS_readdat()}}
+\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}},\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}}
+\code{\link[=SS_readctl_3.24]{SS_readctl_3.24()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Nathan R. Vaughan

--- a/man/SS_writepar_3.30.Rd
+++ b/man/SS_writepar_3.30.Rd
@@ -7,7 +7,7 @@
 SS_writepar_3.30(parlist, outfile, overwrite = TRUE, verbose = FALSE)
 }
 \arguments{
-\item{parlist}{List object created by \code{\link{SS_readpar_3.30}}.}
+\item{parlist}{List object created by \code{\link[=SS_readpar_3.30]{SS_readpar_3.30()}}.}
 
 \item{outfile}{Filename for where to write new parameter file.}
 
@@ -19,12 +19,12 @@ SS_writepar_3.30(parlist, outfile, overwrite = TRUE, verbose = FALSE)
 Write Stock Synthesis (version 3.30) parameter file from list object in R to file.
 }
 \seealso{
-\code{\link{SS_readctl}}, \code{\link{SS_readdat}}
-\code{\link{SS_readdat_3.24}},\code{\link{SS_readdat_3.30}}
-\code{\link{SS_readctl_3.24}},
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readctl]{SS_readctl()}}, \code{\link[=SS_readdat]{SS_readdat()}}
+\code{\link[=SS_readdat_3.24]{SS_readdat_3.24()}},\code{\link[=SS_readdat_3.30]{SS_readdat_3.30()}}
+\code{\link[=SS_readctl_3.24]{SS_readctl_3.24()}},
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Nathan R. Vaughan

--- a/man/SS_writestarter.Rd
+++ b/man/SS_writestarter.Rd
@@ -14,7 +14,7 @@ SS_writestarter(
 )
 }
 \arguments{
-\item{mylist}{List object created by \code{\link{SS_readstarter}}.}
+\item{mylist}{List object created by \code{\link[=SS_readstarter]{SS_readstarter()}}.}
 
 \item{dir}{Directory for new starter file. Default=NULL (working directory).}
 
@@ -29,12 +29,12 @@ Default=TRUE.}
 }
 \description{
 write Stock Synthesis starter file from list object in R which was probably
-created using \code{\link{SS_readstarter}}
+created using \code{\link[=SS_readstarter]{SS_readstarter()}}
 }
 \seealso{
-\code{\link{SS_readstarter}}, \code{\link{SS_readforecast}},
-\code{\link{SS_writestarter}},
-\code{\link{SS_writeforecast}}, \code{\link{SS_writedat}}
+\code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readforecast]{SS_readforecast()}},
+\code{\link[=SS_writestarter]{SS_writestarter()}},
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writedat]{SS_writedat()}}
 }
 \author{
 Ian Taylor

--- a/man/SS_writewtatage.Rd
+++ b/man/SS_writewtatage.Rd
@@ -14,7 +14,7 @@ SS_writewtatage(
 )
 }
 \arguments{
-\item{mylist}{Object created by \code{\link{SS_readwtatage}}.}
+\item{mylist}{Object created by \code{\link[=SS_readwtatage]{SS_readwtatage()}}.}
 
 \item{dir}{A file path to the directory of interest.
 Typically used with \code{file}, an additional input argument,
@@ -35,15 +35,15 @@ should be overwritten. The default value is \code{overwrite = FALSE}.}
 to the screen. The default is \code{verbose = TRUE}.}
 
 \item{warn}{A logical value specifying if a warning should be
-generated if overwriting \code{file}. 
+generated if overwriting \code{file}.
 The default value is \code{warn = TRUE}.}
 }
 \description{
 Write Stock Synthesis weight-at-age file from R object that was probably
-created using \code{\link{SS_readwtatage}}
+created using \code{\link[=SS_readwtatage]{SS_readwtatage()}}
 }
 \seealso{
-\code{\link{SS_readwtatage}}
+\code{\link[=SS_readwtatage]{SS_readwtatage()}}
 }
 \author{
 Kelli Faye Johnson

--- a/man/SSgetMCMC.Rd
+++ b/man/SSgetMCMC.Rd
@@ -39,11 +39,11 @@ CSV file.}
 
 \item{keystrings}{Vector of strings that partially match parameter names to
 write to the file csv1. This file intended to feed into
-\code{\link{mcmc.out}}.}
+\code{\link[=mcmc.out]{mcmc.out()}}.}
 
 \item{nuisancestrings}{Vector of strings that partially match derived
 quantity names to write to the file csv2. This file intended to feed into
-\code{\link{mcmc.nuisance}}.}
+\code{\link[=mcmc.nuisance]{mcmc.nuisance()}}.}
 
 \item{burnin}{Optional burn-in value to apply on top of the option in the
 starter file.}
@@ -56,8 +56,8 @@ Reads the MCMC output (in the posteriors.sso and derived_posteriors.sso
 files) from a model.
 }
 \seealso{
-\code{\link{mcmc.out}}, \code{\link{mcmc.nuisance}},
-\code{\link{SSplotPars}}
+\code{\link[=mcmc.out]{mcmc.out()}}, \code{\link[=mcmc.nuisance]{mcmc.nuisance()}},
+\code{\link[=SSplotPars]{SSplotPars()}}
 }
 \author{
 Ian Taylor

--- a/man/SSgetoutput.Rd
+++ b/man/SSgetoutput.Rd
@@ -37,7 +37,7 @@ Default=FALSE.}
 runs? Default=TRUE.}
 
 \item{ncols}{Maximum number of columns in Report.sso (same input as for
-\code{\link{SS_output}}).  Default=210.}
+\code{\link[=SS_output]{SS_output()}}).  Default=210.}
 
 \item{listlists}{Save output from each model as a element of a list (i.e.
 make a list of lists). Default = TRUE.}
@@ -49,11 +49,11 @@ in keyvec. Default=FALSE.}
 filenaming convention based on iteration and date stamp.}
 }
 \description{
-Apply the function \code{\link{SS_output}} multiple times and save output as
+Apply the function \code{\link[=SS_output]{SS_output()}} multiple times and save output as
 individual objects or a list of lists.
 }
 \seealso{
-\code{\link{SS_output}} \code{\link{SSsummarize}}
+\code{\link[=SS_output]{SS_output()}} \code{\link[=SSsummarize]{SSsummarize()}}
 }
 \author{
 Ian Taylor

--- a/man/SSplotAgeMatrix.Rd
+++ b/man/SSplotAgeMatrix.Rd
@@ -87,7 +87,7 @@ as a histogram. Values are from the AGE_LENGTH_KEY and AGE_AGE_KEY sections
 of Report.sso ($ALK and $AAK in the list created by SS_output)
 }
 \seealso{
-\code{\link{SSplotNumbers}}
+\code{\link[=SSplotNumbers]{SSplotNumbers()}}
 }
 \author{
 Ian G. Taylor

--- a/man/SSplotBiology.Rd
+++ b/man/SSplotBiology.Rd
@@ -48,39 +48,39 @@ SSplotBiology(
 \item{subplots}{vector controlling which subplots to create
 Numbering of subplots is as follows:
 \itemize{
-  \item 1 growth curve only
-  \item 2    growth curve with CV and SD
-  \item 3    growth curve with maturity and weight
-  \item 4    distribution of length at age (still in development)
-  \item 5    length or wtatage matrix
-  \item 6    maturity
-  \item 7    fecundity from model parameters
-  \item 8    fecundity at weight from BIOLOGY section
-  \item 9    fecundity at length from BIOLOGY section
-  \item 10    spawning output at length
-  \item 11    spawning output at age
-  \item 21    Natural mortality (if age-dependent)
-  \item 22    Time-varying growth persp
-  \item 23    Time-varying growth contour
-  \item 24    plot time-series of any time-varying quantities
-  \item 31    hermaphroditism transition probability
-  \item 32    hermaphroditism cumulative probability
+\item 1 growth curve only
+\item 2    growth curve with CV and SD
+\item 3    growth curve with maturity and weight
+\item 4    distribution of length at age (still in development)
+\item 5    length or wtatage matrix
+\item 6    maturity
+\item 7    fecundity from model parameters
+\item 8    fecundity at weight from BIOLOGY section
+\item 9    fecundity at length from BIOLOGY section
+\item 10    spawning output at length
+\item 11    spawning output at age
+\item 21    Natural mortality (if age-dependent)
+\item 22    Time-varying growth persp
+\item 23    Time-varying growth contour
+\item 24    plot time-series of any time-varying quantities
+\item 31    hermaphroditism transition probability
+\item 32    hermaphroditism cumulative probability
 }
 Additional plots not created by default
 \itemize{
-  \item 101    diagram with labels showing female growth curve
-  \item 102    diagram with labels showing female growth curve & male offsets
-  \item 103    diagram with labels showing female CV = f(A) (offset type 2)
-  \item 104    diagram with labels showing female CV = f(A) & male offset (type 2)
-  \item 105    diagram with labels showing female CV = f(A) (offset type 3)
-  \item 106    diagram with labels showing female CV = f(A) & male offset (type 3)
+\item 101    diagram with labels showing female growth curve
+\item 102    diagram with labels showing female growth curve & male offsets
+\item 103    diagram with labels showing female CV = f(A) (offset type 2)
+\item 104    diagram with labels showing female CV = f(A) & male offset (type 2)
+\item 105    diagram with labels showing female CV = f(A) (offset type 3)
+\item 106    diagram with labels showing female CV = f(A) & male offset (type 3)
 }}
 
 \item{seas}{which season to plot (values other than 1 only work in
 seasonal models but but maybe not fully implemented)}
 
 \item{morphs}{Which morphs to plot (if more than 1 per sex)? By default this
-will be replist[["mainmorphs"]]}
+will be \code{replist[["mainmorphs"]]}}
 
 \item{forecast}{Include forecast years in plots of time-varying biology?}
 
@@ -133,7 +133,7 @@ Plot biology related quantities from Stock Synthesis model output, including
 mean weight, maturity, fecundity, and spawning output.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SSplotCatch.Rd
+++ b/man/SSplotCatch.Rd
@@ -130,7 +130,7 @@ Plot catch related quantities from Stock Synthesis output. Plots include
 harvest rate, continuous F, landings, and discard fraction.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Taylor, Ian Stewart

--- a/man/SSplotCohortCatch.Rd
+++ b/man/SSplotCohortCatch.Rd
@@ -89,7 +89,7 @@ estimated catch-at-age matrix and weight-at-age values by fleet.  Curves are
 shown in units of both numbers and biomass.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Taylor

--- a/man/SSplotComparisons.Rd
+++ b/man/SSplotComparisons.Rd
@@ -80,23 +80,23 @@ SSplotComparisons(
 \item{subplots}{Vector of subplots to be created
 Numbering of subplots is as follows:
 \itemize{
-  \item 1  spawning biomass
-  \item 2  spawning biomass with uncertainty intervals
-  \item 3  biomass ratio (hopefully equal to fraction of unfished)
-  \item 4  biomass ratio with uncertainty
-  \item 5  SPR ratio
-  \item 6  SPR ratio with uncertainty
-  \item 7  F value
-  \item 8  F value with uncertainty
-  \item 9  recruits
-  \item 10  recruits with uncertainty
-  \item 11  recruit devs
-  \item 12  recruit devs with uncertainty
-  \item 13  index fits
-  \item 14  index fits on a log scale
-  \item 15  phase plot
-  \item 16  densities
-  \item 17  cumulative densities
+\item 1  spawning biomass
+\item 2  spawning biomass with uncertainty intervals
+\item 3  biomass ratio (hopefully equal to fraction of unfished)
+\item 4  biomass ratio with uncertainty
+\item 5  SPR ratio
+\item 6  SPR ratio with uncertainty
+\item 7  F value
+\item 8  F value with uncertainty
+\item 9  recruits
+\item 10  recruits with uncertainty
+\item 11  recruit devs
+\item 12  recruit devs with uncertainty
+\item 13  index fits
+\item 14  index fits on a log scale
+\item 15  phase plot
+\item 16  densities
+\item 17  cumulative densities
 }}
 
 \item{plot}{Plot to active plot device?}
@@ -121,12 +121,12 @@ ending year specified in each model.}
 \item{indexfleets}{Fleet numbers for each model to compare
 indices of abundance. Can take different forms:
 \itemize{
-  \item NULL: (default) create a separate plot for each index as long as the fleet
+\item NULL: (default) create a separate plot for each index as long as the fleet
 numbering is the same across all models.
-  \item integer: create a single comparison plot for the chosen index
-  \item vector of length equal to number of models: a single fleet number
+\item integer: create a single comparison plot for the chosen index
+\item vector of length equal to number of models: a single fleet number
 for each model to be compared in a single plot
-  \item list: list of fleet numbers associated with indices within each
+\item list: list of fleet numbers associated with indices within each
 model to be compared, where the list elements are each a vector of the
 same length but the names of the list elements don't matter and can be
 absent.
@@ -143,7 +143,7 @@ these intervals may differ across models.}
 (if \code{indexQlabel=TRUE})}
 
 \item{indexSEvec}{Optional replacement for the SE values in
-summaryoutput[["indices"]] to deal with the issue of differing uncertainty by
+\code{summaryoutput[["indices"]]} to deal with the issue of differing uncertainty by
 models described above.}
 
 \item{indexPlotEach}{TRUE plots the observed index for each model with
@@ -245,8 +245,8 @@ it will be the directory where the model was run.}
 It will be separated from default name by an underscore.}
 
 \item{densitynames}{Vector of names (or subset of names) of parameters or
-derived quantities contained in summaryoutput[["pars"]][["Label"]] or
-summaryoutput[["quants"]][["Label"]] for which to make density plots}
+derived quantities contained in \code{summaryoutput[["pars"]][["Label"]]} or
+\code{summaryoutput[["quants"]][["Label"]]} for which to make density plots}
 
 \item{densityxlabs}{Optional vector of x-axis labels to use in the density
 plots (must be equal in length to the printed vector of quantities that
@@ -334,8 +334,8 @@ SSplotComparisons(mod.sum,
 
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SSsummarize}},
-\code{\link{SS_output}}, \code{\link{SSgetoutput}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SSsummarize]{SSsummarize()}},
+\code{\link[=SS_output]{SS_output()}}, \code{\link[=SSgetoutput]{SSgetoutput()}}
 }
 \author{
 Ian G. Taylor, John R. Wallace

--- a/man/SSplotComps.Rd
+++ b/man/SSplotComps.Rd
@@ -83,7 +83,7 @@ SSplotComps(
 \item{subplots}{vector controlling which subplots to create}
 
 \item{kind}{indicator of type of plot can be "LEN", "SIZE", "AGE", "cond",
-"GSTAGE", "L[at]A", or "W[at]A".}
+"GSTAGE", "L@A", or "W@A".}
 
 \item{sizemethod}{if kind = "SIZE" then this switch chooses which of the
 generalized size bin methods will be plotted.}
@@ -259,14 +259,14 @@ posterior distributions in which the median and mean differ.}
 \item{mainTitle}{Logical indicating if a title for the plot should be produced}
 
 \item{\dots}{additional arguments that will be passed to
-the \code{par} command in the \code{\link{make_multifig}} function.}
+the \code{par} command in the \code{\link[=make_multifig]{make_multifig()}} function.}
 }
 \description{
 Plot composition data and fits from Stock Synthesis output.  Multi-figure
 plots depend on \code{make_multifig}.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{make_multifig}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=make_multifig]{make_multifig()}}
 }
 \author{
 Ian Taylor

--- a/man/SSplotData.Rd
+++ b/man/SSplotData.Rd
@@ -43,8 +43,8 @@ be the directory where the model was run.}
 \item{subplot}{vector controlling which subplots to create
 Currently there are only 2 subplots:
 \itemize{
-  \item 1 equal size points showing presence/absence of data type by year/fleet
-  \item 2 points scaled to indicate quantity or precision of data
+\item 1 equal size points showing presence/absence of data type by year/fleet
+\item 2 points scaled to indicate quantity or precision of data
 }}
 
 \item{fleetcol}{Either the string "default", or a vector of colors to use
@@ -103,8 +103,8 @@ data types may not yet be included. Note, this is based on output from the
 model, not the input data file.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}},
-\code{\link{SS_readdat}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}},
+\code{\link[=SS_readdat]{SS_readdat()}}
 }
 \author{
 Ian Taylor, Chantel Wetzel, Cole Monnahan

--- a/man/SSplotDiscard.Rd
+++ b/man/SSplotDiscard.Rd
@@ -81,7 +81,7 @@ The default is \code{res = 300}.}
 Plot fit to discard fraction from Stock Synthesis output file.
 }
 \seealso{
-\code{\link{SS_plots}}
+\code{\link[=SS_plots]{SS_plots()}}
 }
 \author{
 Ian G. Taylor, Ian J. Stewart, Robbie L. Emmet

--- a/man/SSplotIndices.Rd
+++ b/man/SSplotIndices.Rd
@@ -51,18 +51,18 @@ SSplotIndices(
 \item{subplots}{vector controlling which subplots to create
 Numbering of subplots is as follows:
 \itemize{
-  \item 1  index data by fleet
-  \item 2  index data with fit by fleet
-  \item 3  observed vs expected index values with smoother
-  \item 4  index data by fleet on a log scale (lognormal error only)
-  \item 5  index data with fit by fleet on a log scale (lognormal error only)
-  \item 6  log(observed) vs log(expected) with smoother (lognormal error only)
-  \item 7  time series of time-varying catchability (only if actually time-varying)
-  \item 8  catchability vs. vulnerable biomass (if catchability is not constant)
-  \item 9  comparison of all indices
-  \item 10  index residuals based on total uncertainty
-  \item 11  index residuals based on input uncertainty
-  \item 12  index deviations (independent of index uncertainty)
+\item 1  index data by fleet
+\item 2  index data with fit by fleet
+\item 3  observed vs expected index values with smoother
+\item 4  index data by fleet on a log scale (lognormal error only)
+\item 5  index data with fit by fleet on a log scale (lognormal error only)
+\item 6  log(observed) vs log(expected) with smoother (lognormal error only)
+\item 7  time series of time-varying catchability (only if actually time-varying)
+\item 8  catchability vs. vulnerable biomass (if catchability is not constant)
+\item 9  comparison of all indices
+\item 10  index residuals based on total uncertainty
+\item 11  index residuals based on input uncertainty
+\item 12  index deviations (independent of index uncertainty)
 }}
 
 \item{plot}{plot to active plot device?}
@@ -156,7 +156,7 @@ plots such as observed vs. expected index and plots related to time-varying
 catchability (if present).
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Stewart, Ian Taylor, James Thorson

--- a/man/SSplotMCMC_ExtraSelex.Rd
+++ b/man/SSplotMCMC_ExtraSelex.Rd
@@ -16,7 +16,7 @@ SSplotMCMC_ExtraSelex(
 \arguments{
 \item{post}{A data frame containing either derived_posteriors.sso or a good
 subset of it. This can be an element of the list created by the the
-\code{\link{SSgetMCMC}} function.}
+\code{\link[=SSgetMCMC]{SSgetMCMC()}} function.}
 
 \item{add}{TRUE/FALSE option to add results to an existing plot.}
 

--- a/man/SSplotMnwt.Rd
+++ b/man/SSplotMnwt.Rd
@@ -76,7 +76,7 @@ Plot mean weight data and fits from Stock Synthesis output. Intervals are
 based on T-distributions as specified in model.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Taylor, Ian Stewart

--- a/man/SSplotMovementMap.Rd
+++ b/man/SSplotMovementMap.Rd
@@ -68,7 +68,7 @@ Inspired by plots of MULTIFAN-CL movement patterns presented by Adam
 Langley
 }
 \seealso{
-\code{\link{SS_output}}, \code{\link{SSplotMovementRates}}
+\code{\link[=SS_output]{SS_output()}}, \code{\link[=SSplotMovementRates]{SSplotMovementRates()}}
 }
 \author{
 Ian Taylor

--- a/man/SSplotMovementRates.Rd
+++ b/man/SSplotMovementRates.Rd
@@ -79,7 +79,7 @@ SSplotMovementRates(myreplist)
 
 }
 \seealso{
-\code{\link{SS_output}}, \code{\link{SSplotMovementRates}},
+\code{\link[=SS_output]{SS_output()}}, \code{\link[=SSplotMovementRates]{SSplotMovementRates()}},
 }
 \author{
 Ian Taylor

--- a/man/SSplotNumbers.Rd
+++ b/man/SSplotNumbers.Rd
@@ -101,7 +101,7 @@ Plots include bubble plots, mean age, equilibrium age composition,
 sex-ratio, and ageing imprecision patterns.
 }
 \seealso{
-\code{\link{SS_output}}, \code{\link{SS_plots}}
+\code{\link[=SS_output]{SS_output()}}, \code{\link[=SS_plots]{SS_plots()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SSplotProfile.Rd
+++ b/man/SSplotProfile.Rd
@@ -54,7 +54,7 @@ SSplotProfile(
 )
 }
 \arguments{
-\item{summaryoutput}{List created by the function \code{\link{SSsummarize}}.}
+\item{summaryoutput}{List created by the function \code{\link[=SSsummarize]{SSsummarize()}}.}
 
 \item{plot}{Plot to active plot device?}
 
@@ -147,7 +147,7 @@ The default is \code{res = 300}.}
 \item{plotdir}{Directory where PNG files will be written. by default it will
 be the directory where the model was run.}
 
-\item{add_cutoff}{Add dashed line at ~1.92 to indicate 95% confidence interval
+\item{add_cutoff}{Add dashed line at ~1.92 to indicate 95\% confidence interval
 based on common cutoff of half of chi-squared of p=.95 with 1 degree of
 freedom: \code{0.5*qchisq(p=cutoff_prob, df=1)}. The probability value
 can be adjusted using the \code{cutoff_prob} below.}
@@ -165,15 +165,15 @@ component that contributes more than some minimum fraction of change in
 total.
 }
 \note{
-Someday the function \code{\link{SS_profile}} will be improved and
+Someday the function \code{\link[=SS_profile]{SS_profile()}} will be improved and
 made to work directly with this plotting function, but they don't yet work
-well together. Thus, even if \code{\link{SS_profile}} is used, the output
-should be read using \code{\link{SSgetoutput}} or by multiple calls to
-\code{\link{SS_output}}.
+well together. Thus, even if \code{\link[=SS_profile]{SS_profile()}} is used, the output
+should be read using \code{\link[=SSgetoutput]{SSgetoutput()}} or by multiple calls to
+\code{\link[=SS_output]{SS_output()}}.
 }
 \seealso{
-\code{\link{SSsummarize}}, \code{\link{SS_profile}},
-\code{\link{SS_output}}, \code{\link{SSgetoutput}}
+\code{\link[=SSsummarize]{SSsummarize()}}, \code{\link[=SS_profile]{SS_profile()}},
+\code{\link[=SS_output]{SS_output()}}, \code{\link[=SSgetoutput]{SSgetoutput()}}
 }
 \author{
 Ian Taylor, Ian Stewart

--- a/man/SSplotRecdevs.Rd
+++ b/man/SSplotRecdevs.Rd
@@ -85,7 +85,7 @@ Plot recruitment deviations and associated quantities including derived
 measures related to bias adjustment.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_fitbiasramp}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_fitbiasramp]{SS_fitbiasramp()}}
 }
 \author{
 Ian Taylor, Ian Stewart

--- a/man/SSplotRecdist.Rd
+++ b/man/SSplotRecdist.Rd
@@ -66,7 +66,7 @@ season. This is based on the RECRUITMENT_DIST section of the Report.sso
 file.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SSplotRecdevs}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SSplotRecdevs]{SSplotRecdevs()}}
 }
 \author{
 Ian Taylor

--- a/man/SSplotRetroRecruits.Rd
+++ b/man/SSplotRetroRecruits.Rd
@@ -22,7 +22,7 @@ SSplotRetroRecruits(
 )
 }
 \arguments{
-\item{retroSummary}{List object created by \code{\link{SSsummarize}} that
+\item{retroSummary}{List object created by \code{\link[=SSsummarize]{SSsummarize()}} that
 summarizes the results of a set of retrospective analysis models.ss}
 
 \item{endyrvec}{Vector of years representing the final year of values to
@@ -99,7 +99,7 @@ the Eastern Bering Sea.
 which is on an absolute, rather than log scale.)
 }
 \seealso{
-\code{\link{SSsummarize}}
+\code{\link[=SSsummarize]{SSsummarize()}}
 }
 \author{
 Ian Taylor

--- a/man/SSplotSPR.Rd
+++ b/man/SSplotSPR.Rd
@@ -81,7 +81,7 @@ be the directory where the model was run.}
 Plot SPR quantities, including 1-SPR and phase plot.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SSplotSelex.Rd
+++ b/man/SSplotSelex.Rd
@@ -72,8 +72,7 @@ multi-line plot (default = 1).}
 (1=females, 2=males)}
 
 \item{selexlines}{Vector to select which lines get plotted. values are 1.
-Selectivity, 2. Retention, 3. Discard mortality, 4. Keep = Sel\\emph{Ret, 5. Dead
-= Sel\}(Ret+(1-Ret)\*Mort).}
+Selectivity, 2. Retention, 3. Discard mortality, 4. Keep.}
 
 \item{subplot}{Vector controlling which subplots to create}
 

--- a/man/SSplotSelex.Rd
+++ b/man/SSplotSelex.Rd
@@ -72,8 +72,8 @@ multi-line plot (default = 1).}
 (1=females, 2=males)}
 
 \item{selexlines}{Vector to select which lines get plotted. values are 1.
-Selectivity, 2. Retention, 3. Discard mortality, 4. Keep = Sel*Ret, 5. Dead
-= Sel*(Ret+(1-Ret)*Mort).}
+Selectivity, 2. Retention, 3. Discard mortality, 4. Keep = Sel\\emph{Ret, 5. Dead
+= Sel\}(Ret+(1-Ret)\*Mort).}
 
 \item{subplot}{Vector controlling which subplots to create}
 
@@ -128,7 +128,7 @@ Plot selectivity, including retention and other quantities, with additional
 plots for time-varying selectivity.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SSplotSexRatio.Rd
+++ b/man/SSplotSexRatio.Rd
@@ -43,7 +43,7 @@ SSplotSexRatio(
 \item{replist}{A list object created by \code{\link{SS_output}()}.}
 
 \item{kind}{indicator of type of plot can be "LEN", "SIZE", "AGE", "cond",
-"GSTAGE", "L[at]A", or "W[at]A".}
+"GSTAGE", "L@A", or "W@A".}
 
 \item{sexratio.option}{code to choose among (1) female:male ratio or
 (2) fraction females out of the total}
@@ -128,7 +128,7 @@ Interval Estimation for a Binomial Proportion. Statistical Science.
 16(2): 101-133. http://www.jstor.org/stable/2676784.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{make_multifig_sexratio}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=make_multifig_sexratio]{make_multifig_sexratio()}}
 }
 \author{
 Cole Monnahan, Ian Taylor

--- a/man/SSplotSpawnrecruit.Rd
+++ b/man/SSplotSpawnrecruit.Rd
@@ -89,7 +89,7 @@ of points, where the points are disconnected (lty=NA) by default}
 
 \item{ptcol}{vector or single value for the color of the points, "default"
 will by replaced by a vector of colors of length equal to
-nrow(replist[["recruit"]])}
+\code{nrow(replist[["recruit"]])}}
 
 \item{legend}{add a legend to the figure?}
 
@@ -128,7 +128,7 @@ if this point differs from virgin values}
 Plot spawner-recruit curve based on output from Stock Synthesis model.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SSplotSummaryF.Rd
+++ b/man/SSplotSummaryF.Rd
@@ -60,7 +60,7 @@ Plots the summary F (or harvest rate) as set up in the starter file Needs a
 lot of work to be generalized
 }
 \seealso{
-\code{\link{SSplotTimeseries}}, ~~~
+\code{\link[=SSplotTimeseries]{SSplotTimeseries()}}, ~~~
 }
 \author{
 Allan Hicks

--- a/man/SSplotTags.Rd
+++ b/man/SSplotTags.Rd
@@ -105,7 +105,7 @@ be the directory where the model was run.}
 Plot observed and expected tag recaptures in aggregate and by tag group.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Andre E. Punt, Ian G. Taylor, Ashleigh J. Novak

--- a/man/SSplotTimeseries.Rd
+++ b/man/SSplotTimeseries.Rd
@@ -38,15 +38,15 @@ SSplotTimeseries(
 \item{subplot}{number controlling which subplot to create
 Numbering of subplots is as follows:
 \itemize{
-  \item 1 Total biomass (mt) with forecast
-  \item 3: Total biomass (mt) at beginning of season 1 with forecast
-  \item 4: Summary biomass (mt) with forecast
-  \item 6: Summary biomass (mt) at beginning of season 1 with forecast
-  \item 7: Spawning output with forecast with ~95% asymptotic intervals
-  \item 9: Fraction of unfished with forecast with ~95% asymptotic intervals
-  \item 11: Age-0 recruits (1,000s) with forecast with ~95% asymptotic intervals
-  \item 14: Age-0 recruits (1,000s) by birth season with forecast
-  \item 15: Fraction of total Age-0 recruits by birth season with forecast
+\item 1 Total biomass (mt) with forecast
+\item 3: Total biomass (mt) at beginning of season 1 with forecast
+\item 4: Summary biomass (mt) with forecast
+\item 6: Summary biomass (mt) at beginning of season 1 with forecast
+\item 7: Spawning output with forecast with ~95\% asymptotic intervals
+\item 9: Fraction of unfished with forecast with ~95\% asymptotic intervals
+\item 11: Age-0 recruits (1,000s) with forecast with ~95\% asymptotic intervals
+\item 14: Age-0 recruits (1,000s) by birth season with forecast
+\item 15: Fraction of total Age-0 recruits by birth season with forecast
 }}
 
 \item{add}{add to existing plot? (not yet implemented)}
@@ -111,7 +111,7 @@ Plot timeseries data contained in TIME_SERIES output from Stock Synthesis
 report file. Some values have optional uncertainty intervals.
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Taylor, Ian Stewart

--- a/man/SSplotYield.Rd
+++ b/man/SSplotYield.Rd
@@ -33,9 +33,9 @@ SSplotYield(
 \item{subplots}{vector controlling which subplots to create
 Numbering of subplots is as follows:
 \itemize{
-  \item 1 yield curve
-  \item 2 yield curve with reference points
-  \item 3 surplus production vs. biomass plots (Walters et al. 2008)
+\item 1 yield curve
+\item 2 yield curve with reference points
+\item 3 surplus production vs. biomass plots (Walters et al. 2008)
 }}
 
 \item{refpoints}{character vector of which reference points to display in
@@ -85,7 +85,7 @@ dynamics in declining and recovering fish populations.  Can. J. Fish. Aquat.
 Sci. 65: 2536-2551
 }
 \seealso{
-\code{\link{SS_plots}}, \code{\link{SS_output}}
+\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Stewart, Ian Taylor

--- a/man/SSsummarize.Rd
+++ b/man/SSsummarize.Rd
@@ -43,10 +43,10 @@ be summarized. NULL=all genders. Default=NULL.}
 "numbers" giving units of spawning for each model.}
 
 \item{lowerCI}{Quantile for lower bound on calculated intervals. Default =
-0.025 for 95\\% intervals.}
+0.025 for 95\% intervals.}
 
 \item{upperCI}{Quantile for upper bound on calculated intervals. Default =
-0.975 for 95\\% intervals.}
+0.975 for 95\% intervals.}
 
 \item{verbose}{A logical value specifying if output should be printed
 to the screen. The default is \code{verbose = TRUE}.}

--- a/man/SSsummarize.Rd
+++ b/man/SSsummarize.Rd
@@ -19,9 +19,9 @@ SSsummarize(
 }
 \arguments{
 \item{biglist}{A list of lists, one for each model. The individual lists can
-be created by \code{\link{SS_output}} or the list of lists can be
-created by \code{\link{SSgetoutput}} (which iteratively calls
-\code{\link{SS_output}}).}
+be created by \code{\link[=SS_output]{SS_output()}} or the list of lists can be
+created by \code{\link[=SSgetoutput]{SSgetoutput()}} (which iteratively calls
+\code{\link[=SS_output]{SS_output()}}).}
 
 \item{sizeselfactor}{A string or vector of strings indicating which elements
 of the selectivity at length output to summarize. Default=c("Lsel").}
@@ -43,20 +43,20 @@ be summarized. NULL=all genders. Default=NULL.}
 "numbers" giving units of spawning for each model.}
 
 \item{lowerCI}{Quantile for lower bound on calculated intervals. Default =
-0.025 for 95\% intervals.}
+0.025 for 95\\% intervals.}
 
 \item{upperCI}{Quantile for upper bound on calculated intervals. Default =
-0.975 for 95\% intervals.}
+0.975 for 95\\% intervals.}
 
 \item{verbose}{A logical value specifying if output should be printed
 to the screen. The default is \code{verbose = TRUE}.}
 }
 \description{
 Summarize various quantities from the model output collected by
-\code{\link{SSgetoutput}} and return them in a list of tables and vectors.
+\code{\link[=SSgetoutput]{SSgetoutput()}} and return them in a list of tables and vectors.
 }
 \seealso{
-\code{\link{SSgetoutput}}
+\code{\link[=SSgetoutput]{SSgetoutput()}}
 }
 \author{
 Ian Taylor

--- a/man/SStableComparisons.Rd
+++ b/man/SStableComparisons.Rd
@@ -55,8 +55,8 @@ reduction of the full information in various parts of the list created using
 the \code{SSsummarize} function.
 }
 \seealso{
-\code{\link{SSsummarize}}, \code{\link{SSplotComparisons}},
-\code{\link{SS_output}}
+\code{\link[=SSsummarize]{SSsummarize()}}, \code{\link[=SSplotComparisons]{SSplotComparisons()}},
+\code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian Taylor

--- a/man/TSCplot.Rd
+++ b/man/TSCplot.Rd
@@ -27,7 +27,7 @@ TSCplot(
 )
 }
 \arguments{
-\item{SSout}{The output from \code{\link{SS_output}}}
+\item{SSout}{The output from \code{\link[=SS_output]{SS_output()}}}
 
 \item{yrs}{The vector of years to plot}
 
@@ -78,14 +78,14 @@ and total dead catch.
 }
 \description{
 Creates a plot of catch and spawning biomass from the output of
-\code{\link{SS_output}} for the NOAA TSC report.
+\code{\link[=SS_output]{SS_output()}} for the NOAA TSC report.
 }
 \details{
 It creates a plot on the current graphics device, in a pdf file, or as a png
 image of the figure used in the TSC report produced by the NWFSC.  It
-expects the SS results read in by \code{\link{SS_output}}.  If MCMC results
+expects the SS results read in by \code{\link[=SS_output]{SS_output()}}.  If MCMC results
 are to be plotted, a 'mcmc' list element should be added using the
-\code{\link{SSgetMCMC}} function. See the examples below.
+\code{\link[=SSgetMCMC]{SSgetMCMC()}} function. See the examples below.
 }
 \examples{
 
@@ -113,7 +113,7 @@ TSCplot(base, ylimDepl = c(0, 1.25), pchSpace = 1, MCMC = TRUE)
 
 }
 \seealso{
-\code{\link{SS_output}} \code{\link{SSgetMCMC}}
+\code{\link[=SS_output]{SS_output()}} \code{\link[=SSgetMCMC]{SSgetMCMC()}}
 }
 \author{
 Allan Hicks

--- a/man/file_increment.Rd
+++ b/man/file_increment.Rd
@@ -31,7 +31,7 @@ name before the extension.
 \details{
 The \code{.par} file, which is the only file extension searched for
 with the default entry that does not end in \code{.sso}, is
-modified differently.\code{_i.sso} is added to the file name.
+modified differently.\verb{_i.sso} is added to the file name.
 }
 \author{
 Kelli Faye Johnson

--- a/man/getADMBHessian.Rd
+++ b/man/getADMBHessian.Rd
@@ -25,7 +25,7 @@ Explanation of the methods (in PDF form) published here:
 \url{https://github.com/admb-project/admb-examples/blob/master/admb-tricks/covariance-calculations/ADMB_Covariance_Calculations.pdf}
 }
 \seealso{
-\code{\link{read.admbFit}}, \code{\link{NegLogInt_Fn}}
+\code{\link[=read.admbFit]{read.admbFit()}}, \code{\link[=NegLogInt_Fn]{NegLogInt_Fn()}}
 }
 \author{
 Cole Monnahan

--- a/man/get_SIS_info.Rd
+++ b/man/get_SIS_info.Rd
@@ -21,23 +21,23 @@ get_SIS_info(
 \item{dir}{Directory where the file will be written}
 
 \item{writecsv}{Write results to a CSV file (where the name will have the
-format "[species]_2019_SIS_info.csv" where \code{species}
+format "[stock]_2019_SIS_info.csv" where \code{stock}
 is an additional input}
 
 \item{stock}{String to prepend id info to filename for CSV file}
 
 \item{final_year}{Year of assessment and reference points
-(typically will be model[["endyr"]] + 1)}
+(typically will be \code{model[["endyr"]] + 1})}
 
 \item{data_year}{Last year of of timeseries data}
 
 \item{sciencecenter}{Origin of assessment report}
 
-\item{Mgt_Council}{Council jurisdiction. Currently the only option oustside of the default is Gulf of Mexico (`"GM"`)}
+\item{Mgt_Council}{Council jurisdiction. Currently the only option oustside of the default is Gulf of Mexico (\code{"GM"})}
 }
 \description{
 Processes model results contained in the list created by
-\code{\link{SS_output}} in a format that is more convenient for submission
+\code{\link[=SS_output]{SS_output()}} in a format that is more convenient for submission
 to SIS. Currently the results are returned invisibly as a list of two tables
 and written to a CSV file from which results could be copied into SIS.
 In the future some more direct link could be explored to avoid the manual
@@ -56,7 +56,7 @@ info <- get_SIS_info(model, stock = "SimpleExample")
 
 }
 \seealso{
-\code{\link{SS_output}}
+\code{\link[=SS_output]{SS_output()}}
 }
 \author{
 Ian G. Taylor, Andi Stephens

--- a/man/make_multifig.Rd
+++ b/man/make_multifig.Rd
@@ -254,7 +254,7 @@ Function created as an alternative to lattice package for multi-figure plots
 of composition data and fits from Stock Synthesis output.
 }
 \seealso{
-\code{\link{SS_plots}},\code{\link{SSplotComps}}
+\code{\link[=SS_plots]{SS_plots()}},\code{\link[=SSplotComps]{SSplotComps()}}
 }
 \author{
 Ian Taylor

--- a/man/make_multifig_sexratio.Rd
+++ b/man/make_multifig_sexratio.Rd
@@ -46,8 +46,8 @@ make_multifig_sexratio(
 )
 }
 \arguments{
-\item{dbase}{element of list created by \code{\link{SS_output}} passed from
-\code{\link{SSplotSexRatio}}}
+\item{dbase}{element of list created by \code{\link[=SS_output]{SS_output()}} passed from
+\code{\link[=SSplotSexRatio]{SSplotSexRatio()}}}
 
 \item{sexratio.option}{code to choose among (1) female:male ratio or
 (2) fraction females out of the total (the default)}
@@ -138,7 +138,7 @@ passed to this function via the ... argument.}
 \item{\dots}{additional arguments (NOT YET IMPLEMENTED).}
 }
 \description{
-Modified version of \code{\link{make_multifig}} for multi-figure
+Modified version of \code{\link[=make_multifig]{make_multifig()}} for multi-figure
 plots of sex ratio data with crude confidence intervals (+/i 1 se) and
 fits from Stock Synthesis output.
 }
@@ -147,8 +147,7 @@ The SE of the sex ratio is crude and calculated as
 follows. First, assume a multinomial which as MLEs of proportions. Then
 use the delta method of the ratio F/M, using the MLE as the expected
 values and analytical variances and covariance between F and M. After
-some algebra this calculation reduces to: SE(F/M)= sqrt((f/m)^2*(
-(1-f)/(f*N) + (1-m)/(m*N) +2/N )). Confidence intervals created from
+some algebra this calculation reduces to: \code{SE(F/M)= sqrt((f/m)^2*( (1-f)/(f*N) + (1-m)/(m*N) +2/N ))}. Confidence intervals created from
 these should be considered very crude and would not necessarily be
 appropriate for future alternative compositional likelihoods.
 
@@ -156,8 +155,8 @@ This function was derived from make_multifig and hence has a lot of
 overlap in functionality and arguments.
 }
 \seealso{
-\code{\link{SS_plots}},\code{\link{SSplotSexRatio}}
+\code{\link[=SS_plots]{SS_plots()}},\code{\link[=SSplotSexRatio]{SSplotSexRatio()}}
 }
 \author{
-Cole Monnahan. Adapted from \code{\link{make_multifig}}.
+Cole Monnahan. Adapted from \code{\link[=make_multifig]{make_multifig()}}.
 }

--- a/man/mcmc.nuisance.Rd
+++ b/man/mcmc.nuisance.Rd
@@ -28,9 +28,9 @@ directory for particular run.}
 
 \item{file}{Filename either with full path or relative to working directory.
 
-  Contents of the file that is referenced here should contain posterior samples
-  for nuisance parameters, e.g., posteriors.sso or
-  something written by \code{\link{SSgetMCMC}}.}
+Contents of the file that is referenced here should contain posterior samples
+for nuisance parameters, e.g., posteriors.sso or
+something written by \code{\link{SSgetMCMC}}.}
 
 \item{file2}{Optional second file containing posterior samples for nuisance
 parameters. This could be derived_posteriors.sso.}
@@ -41,13 +41,13 @@ addition to \code{file1}.}
 \item{printstats}{Return all the statistics for a closer look.}
 
 \item{burn}{Optional burn-in value to apply on top of the option in the
-starter file and \code{\link{SSgetMCMC}}.}
+starter file and \code{\link[=SSgetMCMC]{SSgetMCMC()}}.}
 
 \item{header}{Data file with header?}
 
 \item{thin}{Optional thinning value to apply on top of the option in the
 starter file, in the \code{mcsave} runtime command, and in
-\code{\link{SSgetMCMC}}.}
+\code{\link[=SSgetMCMC]{SSgetMCMC()}}.}
 
 \item{trace}{Plot trace for param # (to help sort out problem parameters).}
 
@@ -61,10 +61,10 @@ want to consider.}
 }
 \description{
 Summarize nuisance MCMC output (used in combination with
-\code{\link{mcmc.out}} for key parameters).
+\code{\link[=mcmc.out]{mcmc.out()}} for key parameters).
 }
 \seealso{
-\code{\link{mcmc.out}}, \code{\link{SSgetMCMC}}
+\code{\link[=mcmc.out]{mcmc.out()}}, \code{\link[=SSgetMCMC]{SSgetMCMC()}}
 }
 \author{
 Ian Stewart

--- a/man/mcmc.out.Rd
+++ b/man/mcmc.out.Rd
@@ -36,9 +36,9 @@ directory for particular run.}
 
 \item{file}{Filename either with full path or relative to working directory.
 
-  Contents of the file that is referenced here should contain posterior samples
-  for nuisance parameters, e.g., posteriors.sso or
-  something written by \code{\link{SSgetMCMC}}.}
+Contents of the file that is referenced here should contain posterior samples
+for nuisance parameters, e.g., posteriors.sso or
+something written by \code{\link{SSgetMCMC}}.}
 
 \item{namefile}{The (optional) file name of the dimension and names of
 posteriors.}
@@ -52,11 +52,11 @@ posteriors.}
 \item{closeall}{By default close all open devices.}
 
 \item{burn}{Optional burn-in value to apply on top of the option in the
-starter file and \code{\link{SSgetMCMC}}.}
+starter file and \code{\link[=SSgetMCMC]{SSgetMCMC()}}.}
 
 \item{thin}{Optional thinning value to apply on top of the option in the
 starter file, in the \code{-mcsave} runtime command, and in
-\code{\link{SSgetMCMC}}.}
+\code{\link[=SSgetMCMC]{SSgetMCMC()}}.}
 
 \item{scatter}{Can add a scatter-plot of all params at end, default is none.}
 
@@ -101,7 +101,7 @@ mtext("M (natural mortality)", side = 2, outer = T, line = 1.5, cex = 1.1)
 }
 }
 \seealso{
-\code{\link{mcmc.nuisance}}, \code{\link{SSgetMCMC}}
+\code{\link[=mcmc.nuisance]{mcmc.nuisance()}}, \code{\link[=SSgetMCMC]{SSgetMCMC()}}
 }
 \author{
 Ian Stewart, Allan Hicks (modifications)

--- a/man/populate_multiple_folders.Rd
+++ b/man/populate_multiple_folders.Rd
@@ -59,7 +59,7 @@ populate_multiple_folders(
 
 }
 \seealso{
-\code{\link{copy_SS_inputs}}
+\code{\link[=copy_SS_inputs]{copy_SS_inputs()}}
 }
 \author{
 Ian Taylor

--- a/man/r4ss-package.Rd
+++ b/man/r4ss-package.Rd
@@ -44,5 +44,5 @@ Andrew B. Cooper, Andi Stephens, Neil L. Klaer, Carey R. McGilliard,
 Iago Mosqueira, Watal M. Iwasaki, Kathryn L. Doering, Andrea M. Havron,
 Nathan Vaughan, LaTreese S. Denson, and Ashleigh J. Novak
 
-Package maintainer: Ian G. Taylor <Ian.Taylor@noaa.gov>
+Package maintainer: Ian G. Taylor \href{mailto:Ian.Taylor@noaa.gov}{Ian.Taylor@noaa.gov}
 }

--- a/man/read.admbFit.Rd
+++ b/man/read.admbFit.Rd
@@ -20,7 +20,7 @@ and correlations. Required for Jim Thorson's Laplace
 Approximation but likely useful for other purposes.
 }
 \seealso{
-\code{\link{getADMBHessian}}, \code{\link{NegLogInt_Fn}}
+\code{\link[=getADMBHessian]{getADMBHessian()}}, \code{\link[=NegLogInt_Fn]{NegLogInt_Fn()}}
 }
 \author{
 James Thorson

--- a/man/rm_dollar_sign.Rd
+++ b/man/rm_dollar_sign.Rd
@@ -18,7 +18,7 @@ file.}
 \item{allow_recursive}{Should dollar sign references of list in list be
 replaced? If this is FALSE, then only the first reference will be replaced.
 For example, \code{F$first$second} would become \code{F[["first"]]$second} when
-alow_recursive is FALSE, but would become \code{F[["first"]][["second"]]} if TRUE.}
+allow_recursive is FALSE, but would become \code{F[["first"]][["second"]]} if TRUE.}
 
 \item{max_loops}{How many times should dollar signs be looked for
 recursively, if allow_recursive is TRUE? Defaults to 5. This is meant to
@@ -26,38 +26,40 @@ prevent an infinite loop in case the function does not work properly.}
 }
 \value{
 A character vector of the modified text. As a side effect, produces
-a text file out_file that was written out from R using writeLines().
+a text file (name specified in out_file) written out from R using writeLines().
 }
 \description{
 The dollar sign is convienent to write, but allows for partial matching,
 which we don't often want. This function takes a file and changes all dollar
 signs to double brackets with names in quotations instead. Note that this
-function will incorrectly convert text that includesnames in backticks that
-include a dollar sign (for example, test$\code{my$name} will not convert correctly).
-Note also that if a dollar sign is within a text string, it will also not
-convert correctly (for example, "See test$name" would become
-"See test[\link{"name"}]", which is not parsable R code. Luckily, this is easily
-discoverable by loading or sourcing the function.)
+function will incorrectly convert text enclosed in backticks that includes a dollar sign.
+Note also that if a dollar sign is within a text
+string enclosed with quotation marks, it will also not  convert correctly
+(for example, "See test$name" would become
+"See test[\link{"name"}]", which is not parsable R code due to 2 sets of quotation
+marks.) Luckily, this last issue is easily discoverable by attempting to load or source
+the function because an error will be produced.
 }
-\author{
-Kathryn Doering
-#' @example
+\examples{
 test_text <- c("x$my_name <- y$test"
-"x[\link{'my_name'}]",
-"no_replace_here <- 44",
-"x$names<-new_assign;x$\code{22}",
-"x$names <- new_assign; x$\code{22}",
-"x$\verb{$$weirdcharacters}<-222",
-"x$\code{nameinbacktick}",
-"x$mylist$my_col$YetAnotherCol",
-"x$mylist$my_col$\verb{1_somename}",
-"x$\code{bad$name} <- 55",
-"x$\code{other_$badname}")
+                 "x[['my_name']]",
+                 "no_replace_here <- 44",
+                 "x$names<-new_assign;x$`22`",
+                 "x$names <- new_assign; x$`22`",
+                 "x$`$$weirdcharacters`<-222",
+                 "x$`nameinbacktick`",
+                 "x$mylist$my_col$YetAnotherCol",
+                 "x$mylist$my_col$`1_somename`",
+                 "x$`bad$name` <- 55",
+                 "x$`other_$badname`")
 writeLines(test_text, "test_rm_dollar_sign.txt")
 on.exit(file.remove("test_rm_dollar_sign.txt"), add = TRUE)
 
-new_text <- rm_dollar_sign(
-file = "test_rm_dollar_sign.txt",
-out_file = NULL)
-new_text
+ new_text <- rm_dollar_sign(
+   file = "test_rm_dollar_sign.txt",
+   out_file = NULL)
+   new_text
+}
+\author{
+Kathryn Doering
 }

--- a/man/rm_dollar_sign.Rd
+++ b/man/rm_dollar_sign.Rd
@@ -41,7 +41,7 @@ marks.) Luckily, this last issue is easily discoverable by attempting to load or
 the function because an error will be produced.
 }
 \examples{
-test_text <- c("x$my_name <- y$test"
+test_text <- c("x$my_name <- y$test",
                  "x[['my_name']]",
                  "no_replace_here <- 44",
                  "x$names<-new_assign;x$`22`",
@@ -53,12 +53,11 @@ test_text <- c("x$my_name <- y$test"
                  "x$`bad$name` <- 55",
                  "x$`other_$badname`")
 writeLines(test_text, "test_rm_dollar_sign.txt")
-on.exit(file.remove("test_rm_dollar_sign.txt"), add = TRUE)
-
- new_text <- rm_dollar_sign(
+ new_text <- r4ss:::rm_dollar_sign(
    file = "test_rm_dollar_sign.txt",
    out_file = NULL)
    new_text
+file.remove("test_rm_dollar_sign.txt")
 }
 \author{
 Kathryn Doering

--- a/man/rm_dollar_sign.Rd
+++ b/man/rm_dollar_sign.Rd
@@ -9,9 +9,7 @@ rm_dollar_sign(file, out_file = file, allow_recursive = TRUE, max_loops = 5)
 \arguments{
 \item{file}{Filename either with full path or relative to working directory.
 
-
-
-  See the formal arguments for a possible default filename.}
+See the formal arguments for a possible default filename.}
 
 \item{out_file}{The name or path of a new file to write to. This is by
 default the same as the original file. Set to NULL to avoid writing a new
@@ -19,8 +17,8 @@ file.}
 
 \item{allow_recursive}{Should dollar sign references of list in list be
 replaced? If this is FALSE, then only the first reference will be replaced.
-For example, F$first$second would become F[["first"]]$second when
-alow_recursive is FALSE, but would become F[["first"]][["second"]] if TRUE.}
+For example, \code{F$first$second} would become \code{F[["first"]]$second} when
+alow_recursive is FALSE, but would become \code{F[["first"]][["second"]]} if TRUE.}
 
 \item{max_loops}{How many times should dollar signs be looked for
 recursively, if allow_recursive is TRUE? Defaults to 5. This is meant to
@@ -28,38 +26,38 @@ prevent an infinite loop in case the function does not work properly.}
 }
 \value{
 A character vector of the modified text. As a side effect, produces
- a text file out_file that was written out from R using writeLines().
+a text file out_file that was written out from R using writeLines().
 }
 \description{
 The dollar sign is convienent to write, but allows for partial matching,
 which we don't often want. This function takes a file and changes all dollar
 signs to double brackets with names in quotations instead. Note that this
 function will incorrectly convert text that includesnames in backticks that
-include a dollar sign (for example, test$`my$name` will not convert correctly).
-Note also that if a dollar sign is within a text string, it will also not 
-convert correctly (for example, "See test$name" would become 
-"See test[["name"]]", which is not parsable R code. Luckily, this is easily 
+include a dollar sign (for example, test$\code{my$name} will not convert correctly).
+Note also that if a dollar sign is within a text string, it will also not
+convert correctly (for example, "See test$name" would become
+"See test[\link{"name"}]", which is not parsable R code. Luckily, this is easily
 discoverable by loading or sourcing the function.)
 }
 \author{
 Kathryn Doering
 #' @example
 test_text <- c("x$my_name <- y$test"
-                 "x[['my_name']]",
-                 "no_replace_here <- 44",
-                 "x$names<-new_assign;x$`22`",
-                 "x$names <- new_assign; x$`22`",
-                 "x$`$$weirdcharacters`<-222",
-                 "x$`nameinbacktick`",
-                 "x$mylist$my_col$YetAnotherCol",
-                 "x$mylist$my_col$`1_somename`",
-                 "x$`bad$name` <- 55",
-                 "x$`other_$badname`")
+"x[\link{'my_name'}]",
+"no_replace_here <- 44",
+"x$names<-new_assign;x$\code{22}",
+"x$names <- new_assign; x$\code{22}",
+"x$\verb{$$weirdcharacters}<-222",
+"x$\code{nameinbacktick}",
+"x$mylist$my_col$YetAnotherCol",
+"x$mylist$my_col$\verb{1_somename}",
+"x$\code{bad$name} <- 55",
+"x$\code{other_$badname}")
 writeLines(test_text, "test_rm_dollar_sign.txt")
 on.exit(file.remove("test_rm_dollar_sign.txt"), add = TRUE)
 
- new_text <- rm_dollar_sign(
-   file = "test_rm_dollar_sign.txt",
-   out_file = NULL)
-   new_text
+new_text <- rm_dollar_sign(
+file = "test_rm_dollar_sign.txt",
+out_file = NULL)
+new_text
 }

--- a/man/rm_dollar_sign.Rd
+++ b/man/rm_dollar_sign.Rd
@@ -36,7 +36,7 @@ function will incorrectly convert text enclosed in backticks that includes a dol
 Note also that if a dollar sign is within a text
 string enclosed with quotation marks, it will also not  convert correctly
 (for example, "See test$name" would become
-"See test[\link{"name"}]", which is not parsable R code due to 2 sets of quotation
+"See test[["name"]]", which is not parsable R code due to 2 sets of quotation
 marks.) Luckily, this last issue is easily discoverable by attempting to load or source
 the function because an error will be produced.
 }

--- a/man/run_SS_models.Rd
+++ b/man/run_SS_models.Rd
@@ -63,8 +63,8 @@ run_SS_models(dirvec = dirvec)
 
 }
 \seealso{
-\code{\link{copy_SS_inputs}},
-\code{\link{populate_multiple_folders}}
+\code{\link[=copy_SS_inputs]{copy_SS_inputs()}},
+\code{\link[=populate_multiple_folders]{populate_multiple_folders()}}
 }
 \author{
 Ian Taylor

--- a/man/selShapes.Rd
+++ b/man/selShapes.Rd
@@ -9,8 +9,8 @@ selShapes()
 \description{
 Currently implemented only for
 \enumerate{
-  \item logisitic (type 1)
-  \item double normal (type 24)
+\item logisitic (type 1)
+\item double normal (type 24)
 }
 This could possibly be hosted on a Shiny server instead of within r4ss
 }

--- a/man/stackpoly.Rd
+++ b/man/stackpoly.Rd
@@ -26,7 +26,7 @@ stackpoly(
 \arguments{
 \item{x}{A numeric data frame or matrix with the 'x' values. If 'y' is NULL,
 these will become the 'y' values and the 'x' positions will be the integers
-from 1 to dim(x)[1].}
+from 1 to \code{dim(x)[1]}.}
 
 \item{y}{The 'y' values.}
 

--- a/man/translate_3.30_to_3.24_var_adjust.Rd
+++ b/man/translate_3.30_to_3.24_var_adjust.Rd
@@ -26,5 +26,5 @@ A dataframe of 3.24 variance adjustments.
 }
 \description{
 This functionality used to be in SS_readctl_3.30, but ware removed to avoid
- confusion.
+confusion.
 }

--- a/man/write.fwf.Rd
+++ b/man/write.fwf.Rd
@@ -29,9 +29,8 @@ write.fwf(
 
 \item{file}{Filename either with full path or relative to working directory.
 
-
-  See \code{\link[utils]{write.table}} for more information because a file,
-  a connection, or \code{""} are allowed.}
+See \code{\link[utils]{write.table}} for more information because a file,
+a connection, or \code{""} are allowed.}
 
 \item{append}{logical, append to existing data in \code{file}}
 
@@ -49,7 +48,7 @@ the output}
 \item{rowCol}{character, rownames column name}
 
 \item{justify}{character, alignment of character columns; see
-\code{\link{format}}}
+\code{\link[=format]{format()}}}
 
 \item{formatInfo}{logical, return information on number of levels, widths
 and format}
@@ -71,8 +70,8 @@ the initial letter.}
 \item{scientific}{logical, if TRUE, allow numeric values to be formatted
 using scientific notation.}
 
-\item{\dots}{further arguments to \code{\link{format.info}} and
-\code{\link{format}}}
+\item{\dots}{further arguments to \code{\link[=format.info]{format.info()}} and
+\code{\link[=format]{format()}}}
 }
 \value{
 Besides its effect to write/export data \code{write.fwf} can provide
@@ -86,7 +85,7 @@ no exponential representation, while 1 represents exponent of length one
 i.e. \code{1e+6} and 2 \code{1e+06} or \code{1e+16}}
 }
 \description{
-\code{write.fwf} writes object in *f*ixed *w*idth *f*ormat.
+\code{write.fwf} writes object in \emph{f}ixed \emph{w}idth \emph{f}ormat.
 }
 \details{
 Note: This function is copied from the gdata package version 2.18.0 on CRAN
@@ -100,31 +99,31 @@ was converted to these roxygen2 comments using the Rd2roxygen package
 https://yihui.org/rd2roxygen.
 
 Original documentation from gdata version of the function:
-#' While *F*ixed *w*idth *f*ormat is no longer widely used, it remains common
+#' While \emph{F}ixed \emph{w}idth \emph{f}ormat is no longer widely used, it remains common
 in some disciplines.
 
 Output is similar to \code{print(x)} or \code{format(x)}. Formatting is done
-completely by \code{\link{format}} on a column basis. Columns in the output
+completely by \code{\link[=format]{format()}} on a column basis. Columns in the output
 are by default separated with a space i.e. empty column with a width of one
 character, but that can be changed with \code{sep} argument as passed to
-\code{\link{write.table}} via \dots{}.
+\code{\link[=write.table]{write.table()}} via \dots{}.
 
-As mentioned formatting is done completely by \code{\link{format}}.
+As mentioned formatting is done completely by \code{\link[=format]{format()}}.
 Arguments can be passed to \code{format} via \code{\dots{}} to further
 modify the output. However, note that the returned \code{formatInfo} might
-not properly account for this, since \code{\link{format.info}} (which is
+not properly account for this, since \code{\link[=format.info]{format.info()}} (which is
 used to collect information about formatting) lacks the arguments of
-\code{\link{format}}.
+\code{\link[=format]{format()}}.
 
 \code{quote} can be used to quote fields in the output. Since all columns of
-\code{x} are converted to character (via \code{\link{format}}) during the
+\code{x} are converted to character (via \code{\link[=format]{format()}}) during the
 output, all columns will be quoted! If quotes are used,
-\code{\link{read.table}} can be easily used to read the data back into .
+\code{\link[=read.table]{read.table()}} can be easily used to read the data back into .
 Check examples. Do read the details about \code{quoteInfo} argument.
 
-Use only *true* character, i.e., avoid use of tabs, i.e., "\\t", or similar
+Use only \emph{true} character, i.e., avoid use of tabs, i.e., "\\t", or similar
 separators via argument \code{sep}. Width of the separator is taken as the
-number of characters evaluated via \code{\link{nchar}(sep)}.
+number of characters evaluated via \verb{[nchar](sep)}.
 
 Use argument \code{na} to convert missing/unknown values. Only single value
 can be specified. Use \code{gdata::NAToUnknown} prior to export if you need
@@ -133,12 +132,12 @@ greater flexibility.
 If \code{rowCol} is not \code{NULL} and \code{rownames=TRUE}, rownames will
 also have column name with \code{rowCol} value. This is mainly for
 flexibility with tools outside . Note that (at least in 2.4.0) it is not
-"easy" to import data back to with \code{\link{read.fwf}} if you also export
+"easy" to import data back to with \code{\link[=read.fwf]{read.fwf()}} if you also export
 rownames. This is the reason, that default is \code{rownames=FALSE}.
 
 Information about format of output will be returned if
 \code{formatInfo=TRUE}. Returned value is described in value section. This
-information is gathered by \code{\link{format.info}} and care was taken to
+information is gathered by \code{\link[=format.info]{format.info()}} and care was taken to
 handle numeric properly. If output contains rownames, values account for
 this. Additionally, if \code{rowCol} is not \code{NULL} returned values
 contain also information about format of rownames.
@@ -166,7 +165,7 @@ or (with \code{quoteInfo=FALSE})
 
 Argument \code{width} can be used to increase the width of the columns in
 the output. This argument is passed to the width argument of
-\code{\link{format}} function. Values in \code{width} are recycled if there
+\code{\link[=format]{format()}} function. Values in \code{width} are recycled if there
 is less values than the number of columns. If the specified width is to
 short in comparison to the "width" of the data in particular column, error
 is issued.


### PR DESCRIPTION
Simplify documentation of all r4ss functions by switching to markdown format in roxygen2 comments at the top of each file as discussed in issue #470. The `development` branch had moved on since making initial progress on this so I rebased the changes in this branch onto development and resolved a few conflicts. Hopefully it all got worked out appropriately but I will wait for checks to pass before merging this pull request. There are changes in a huge number of files, but they are almost exclusively in the comments at the top.