### PR TITLE
Add error check for need_catch_mult in fleet_info

### DIFF
--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -214,9 +214,13 @@ SS_readdat_3.30 <-
     #   stop execution as SS do so.
     if (any(datlist[["fleetinfo"]][["type"]] != 1 &
       datlist[["fleetinfo"]][["need_catch_mult"]] == 1)) {
-        stop("Need_catch_mult can be used only for fleet_type=1 fleet= ",
-          which(datlist[["fleetinfo"]][["type"]] != 1 &
-                datlist[["fleetinfo"]][["need_catch_mult"]] == 1))
+        stop(
+          "Catch multipler can be used only for fleet_type = 1; Check fleet = ",
+          paste0(which(datlist[["fleetinfo"]][["type"]] != 1 &
+                datlist[["fleetinfo"]][["need_catch_mult"]] == 1), 
+            collapse = ", "), 
+          " in fleet info."
+          )
       }
     if (echoall) {
       message("Fleet information:")

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -210,6 +210,14 @@ SS_readdat_3.30 <-
       "need_catch_mult",
       "fleetname"
     )
+    # If need_catch_mult is 1 for fleets other than catch fleets,
+    #   stop execution as SS do so.
+    if (any(datlist[["fleetinfo"]][["type"]] != 1 &
+      datlist[["fleetinfo"]][["need_catch_mult"]] == 1)) {
+        stop("Need_catch_mult can be used only for fleet_type=1 fleet= ",
+          which(datlist[["fleetinfo"]][["type"]] != 1 &
+                datlist[["fleetinfo"]][["need_catch_mult"]] == 1))
+      }
     if (echoall) {
       message("Fleet information:")
       print(datlist[["fleetinfo"]])


### PR DESCRIPTION
4th column of fleet_info indicates if catch multiplier is to be used by setting this column to 1.  Catch multiplier can only be used for catch fleets. However SS_readdat_3.30 does not check if 4th column is 1 for fleets other than catch fleets. In the case of SS, it stop reading datfile if 4th column of fleet_info is 1 for non-catch fleets. This PR add similar error check for 4th column of fleet_info.

