### PR TITLE
More for #324 sablefish environmental index in figures.

### DIFF
--- a/R/SSplotIndices.R
+++ b/R/SSplotIndices.R
@@ -772,7 +772,7 @@ SSplotIndices <-
 
         # residual/deviation plots
         if (plot) {
-          if (10 %in% subplots) {
+          if (10 %in% subplots & all(cpueuse[["Obs"]] >= 0)) {
             index_resids.fn(option = 1)
           }
           if (11 %in% subplots) {
@@ -784,7 +784,7 @@ SSplotIndices <-
         }
         if (print) {
           #### residuals based on total uncertainty
-          if (10 %in% subplots) {
+          if (10 %in% subplots & all(cpueuse[["Obs"]] >= 0)) {
             file <- paste0("index10_resids_SE_total_", Fleet, ".png")
             caption <- paste0("Residuals of fit to index for ", Fleet, ".")
             if (error == 0) {


### PR DESCRIPTION
@taylori this really simple change is a pull request for you because you were the one that worked with #326 and #324. Sablefish models are still running into errors and I tracked the latest one down to this where `index_resids.fn` doesn't play nice with the normal distribution.

@mkapur this fix should fix the error you were having with building the pdf.