### PR TITLE
allow SS_readctl_3.30 to read tv trends, small fixes

### DIFF
--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1676,26 +1676,45 @@ get_tv_parlabs <- function(full_parms,
     tmp_parname <- rownames(full_parms)[i]
     # Add lines to the data frame as you go. (maybe can use the same approach as long parlines)
     if (i %in% par_num[["env"]]) {
-      parlab <- c(parlab, paste0("# ", tmp_parname, "_ENV_add"))
+      tmp_pat <- abs(full_parms[["env_var&link"]][i])
+      if(isTRUE(tmp_pat > 400 & tmp_pat < 500)){ # pattern 4 needs 2 pars, all else 1.
+        parlab <- c(parlab, paste0("# ", rep(tmp_parname, times = 2),
+            c("_ENV_offset", "_ENV_lgst_slope")
+          )
+        )
+      } else {
+        parlab <- c(parlab, paste0("# ", tmp_parname, "_ENV_add"))
+      }
     }
     if (i %in% par_num[["block"]]) {
       n_blk <- full_parms[["Block"]][i]
-      tmp_blk_design <- block_design[[n_blk]]
-      # Get the start year for each block
-      if(is.null(tmp_blk_design)){
-        stop("Time blocks used in parameter setup, but not defined in the top", 
-             "of the control file. Please define the time blocks.")
-      }
-      blk_start_yrs <- tmp_blk_design[seq(1, length(tmp_blk_design), by = 2)]
-      lbl <- block_method_label[block_fxn[i] + 1]
-      parlab <- c(
-        parlab,
-        paste0(
-          "# ",
-          rep(tmp_parname, times = length(blk_start_yrs)),
-          "_BLK", n_blk, lbl, blk_start_yrs
+      if(n_blk > 0) {
+        tmp_blk_design <- block_design[[n_blk]]
+        # Get the start year for each block
+        if(is.null(tmp_blk_design)){
+          stop("Time blocks used in parameter setup, but not defined in the top", 
+               "of the control file. Please define the time blocks.")
+        }
+        blk_start_yrs <- tmp_blk_design[seq(1, length(tmp_blk_design), by = 2)]
+        lbl <- block_method_label[block_fxn[i] + 1]
+        parlab <- c(
+          parlab,
+          paste0(
+            "# ",
+            rep(tmp_parname, times = length(blk_start_yrs)),
+            "_BLK", n_blk, lbl, blk_start_yrs
+          )
         )
-      )
+      } else { #trends
+        parlab <- c(
+          parlab,
+          paste0(
+            "# ",
+            rep(tmp_parname, times = 3),
+            c("_TrendFinal", "_TrendInfl", "_TrendWidth_yrs")
+          )
+        )
+      }
     }
     if (i %in% par_num[["dev"]]) {
       # parameter name if there is devs

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -540,7 +540,24 @@ SS_readdat_3.30 <-
         message("N_agebins = 0, skipping read remaining age-related stuff")
       }
     }
-
+    # check DM pars ----)
+    if (any(datlist[["len_info"]][["CompError"]] == 1) |
+        any(datlist[["age_info"]][["CompError"]] == 1)) {
+      N_dirichlet_parms <- max(c(datlist[["len_info"]][["ParmSelect"]], 
+                                 datlist[["age_info"]][["ParmSelect"]]))
+      # double check this
+      N_dir_labs <- seq_len(N_dirichlet_parms)
+      for(i in N_dir_labs) {
+        if(!i %in% c(datlist[["len_info"]][["ParmSelect"]], 
+                    datlist[["age_info"]][["ParmSelect"]])) {
+          warning("Dirichlet multinomial parameters must be sequential with no ", 
+                  " missing integers starting from 1. \nMissing DM parameter ",
+                  "labeled  ", i, ", so SS will exit on error for this model ", 
+                  "configuration. \nPlease revise the numbering of the DM ", 
+                  "parameters in the length/age info ParmSelect column.")
+        }
+      }
+    }
     ###############################################################################
     ## Mean size-at-age data ----
     datlist[["use_MeanSize_at_Age_obs"]] <- get.val(dat, ind)

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -414,13 +414,14 @@ SS_readdat_3.30 <-
           )
       }
       # warn if any 0 values in the lencomp, because SS will exit on error
-      zero_lencomp <- apply(datlist[["lencomp"]][,-(1:6)], MARGIN = 1, FUN = sum) == 0
-      if(any(zero_lencomp == TRUE)) {
-        warning("Lines of all zero length comp found. SS will exit on error if", 
-                " a line of comps is all zeros. Line(s) ", 
-                paste0(which(zero_lencomp), collapse = ", "))
+      if(!is.null(datlist[["lencomp"]])) {
+        zero_lencomp <- apply(datlist[["lencomp"]][,-(1:6)], MARGIN = 1, FUN = sum) == 0
+        if(any(zero_lencomp == TRUE)) {
+          warning("Lines of all zero length comp found. SS will exit on error if", 
+                  " a line of comps is all zeros. Line(s) ", 
+                  paste0(which(zero_lencomp), collapse = ", "))
+        }
       }
-      
       # echo values
       if (echoall) {
         message("\nFirst 2 rows of lencomp:")


### PR DESCRIPTION
- SS_readctl_3.30 can now read time varying trends. Before, would exit on error with a confusing warning.
- fix: SS_readctl_3.30 correctly reads the number of parameters for env link option 4, which requires 2 short parameter lines, not 1 like the other options.
- feat: adds a warning to SS_readdat_3.30 if the data file does not have consecutively numbered Dirichlet Multinomial parameters starting from 0. SS will exit on error while reading input files, but warning instead of error allows  users to fix this within the list read in using SS_readdat.
- fix: A check that there are no lines of all 0 length comps errors out when there are no length comp lines. Adds in a fix so this check is skipped if there are no lines.