### PR TITLE
#514: rename 2 elements in forecast file read/write

### DIFF
--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -267,8 +267,8 @@ SS_readforecast <- function(file = "forecast.ss", Nfleets = NULL, Nareas = NULL,
 
     forelist <- add_elem(forelist, "N_forecast_loops")
     forelist <- add_elem(forelist, "First_forecast_loop_with_stochastic_recruitment")
-    forelist <- add_elem(forelist, "Forecast_loop_control_3")
-    forelist <- add_elem(forelist, "Forecast_loop_control_4")
+    forelist <- add_elem(forelist, "fcast_rec_option")
+    forelist <- add_elem(forelist, "fcast_rec_val")
     forelist <- add_elem(forelist, "Forecast_loop_control_5")
     forelist <- add_elem(forelist, "FirstYear_for_caps_and_allocations")
     forelist <- add_elem(forelist, "stddev_of_log_catch_ratio")

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -120,8 +120,16 @@ SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
       wl("N_forecast_loops")
 
       wl("First_forecast_loop_with_stochastic_recruitment")
-      wl("Forecast_loop_control_3")
-      wl("Forecast_loop_control_4")
+      if(!is.null(mylist[["Forecast_loop_control_3"]])) {
+        warning("Forecast_loop_control_3 has been renamed to fcast_rec_option\n", 
+                " so only fcast_rec_option will be written to the file.")
+      }
+      if(!is.null(mylist[["Forecast_loop_control_4"]])) {
+        warning("Forecast_loop_control_4 has been renamed to fcast_rec_val\n", 
+                " so only fcast_rec_val will be written to the file.")
+      }
+      wl("fcast_rec_option")
+      wl("fcast_rec_val")
       wl("Forecast_loop_control_5")
       wl("FirstYear_for_caps_and_allocations")
       wl("stddev_of_log_catch_ratio")


### PR DESCRIPTION
Breaking change: rename Forecast_loop_control_3 to fcast_rec_option and FOrecast_loop_control_4 to fcast_rec_val. Users will be given a warning if the elements with the old names are not null.

Addresses #514 .