### PR TITLE
fix: number of tag pars to read in ctl file

### DIFF
--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -25,6 +25,10 @@
 #'  or 3) if comments in the control file should be used instead to determine
 #'  the the predM_fleets. Used only in control file 3.30 syntax if
 #'  `use_datlist = FALSE`.
+#' @param Ntag_fleets The number of catch fleets in the model (fleets of )
+#'  type 1 or 2; not surveys). Used to set the number of survey parameters. 
+#'  Only used in control file 3.30 reading if tagging data is in the model and 
+#'  `use_datlist = FALSE`.
 #' @param N_rows_equil_catch Integer value of the number of parameter lines to
 #'  read for equilibrium catch. Defaults to NULL, which means the function will
 #'  attempt to figure out how many lines of equilibrium catch to read from the
@@ -35,7 +39,7 @@
 #' @param Nsurveys Number of surveys, for 3.24 and lower version models.
 #' @param N_dirichlet_parms Integer value of the number of Dirichlet-Multinomial
 #'  parameters. Defaults to 0. Used only in control file 3.30 syntax if
-#'  `use_datlist = FALSE`..
+#'  `use_datlist = FALSE`.
 #' @param ptype LOGICAL if `TRUE`, which is the default,
 #'  a column will be included in the output indicating parameter type.
 #'  Using `TRUE` can be useful, but causes problems for [SS_writectl],
@@ -92,6 +96,7 @@ SS_readctl <- function(file, version = NULL, verbose = FALSE, echoall = lifecycl
                        N_CPUE_obs = NULL,
                        catch_mult_fleets = NULL,
                        predM_fleets = NULL,
+                       Ntag_fleets = NULL,
                        N_rows_equil_catch = NULL,
                        N_dirichlet_parms = NULL,
                        ptype = FALSE) {
@@ -188,6 +193,7 @@ SS_readctl <- function(file, version = NULL, verbose = FALSE, echoall = lifecycl
       N_tag_groups = N_tag_groups,
       catch_mult_fleets = catch_mult_fleets,
       predM_fleets = predM_fleets,
+      Ntag_fleets = Ntag_fleets,
       N_rows_equil_catch = N_rows_equil_catch,
       N_dirichlet_parms = N_dirichlet_parms,
       use_datlist = use_datlist,

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -19,6 +19,9 @@
 #'  is not used for any fleets; 2) use_datlist = TRUE and datlist is specified;
 #'  or 3) if comments in the control file should be used instead to determine
 #'  the the predM_fleets.
+#' @param Ntag_fleets The number of catch fleets in the model (fleets of )
+#'  type 1 or 2; not surveys). Used to set the number of survey parameters. 
+#'  Only used if tagging data is in the model and `use_datlist` is FALSE.
 #' @param N_rows_equil_catch Integer value of the number of parameter lines to
 #'  read for equilibrium catch. Defaults to NULL, which means the function will
 #'  attempt to figure out how many lines of equilibrium catch to read from the
@@ -45,6 +48,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE, echoall = lifecycle::deprecat
                             Nsexes = NULL,
                             Npopbins = NULL,
                             Nfleets = NULL,
+                            Ntag_fleets = NULL,
                             Do_AgeKey = NULL,
                             N_tag_groups = NULL,
                             catch_mult_fleets = NULL,
@@ -283,6 +287,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE, echoall = lifecycle::deprecat
     }
     ctllist[["N_tag_groups"]] <- N_tag_groups <- datlist[["N_tag_groups"]]
     ctllist[["fleetnames"]] <- fleetnames <- datlist[["fleetnames"]]
+    Ntag_fleets <- length(which(datlist$fleetinfo$type < 3))
   }
   # specifications ----
   ctllist[["sourcefile"]] <- file
@@ -1496,11 +1501,11 @@ SS_readctl_3.30 <- function(file, verbose = FALSE, echoall = lifecycle::deprecat
     # . one initial Tag loss parameter
     # . one continuos Tag loss parameter
     # . NB over-dispersion paramater
-    # For each fleet
+    # For each fleet (of type 1 or 2 only, not surveys):
     # . one tag reporting rate paramater
     # . one tag reporting rate decay paramater
     #
-    #  In total N_tag_groups*3+ Nfleets*2 parameters are needed to read
+    #  In total N_tag_groups*3+ Ntag_fleets*2 parameters are needed to read
     ctllist <- add_df(ctllist,
       name = "TG_Loss_init",
       nrow = ctllist[["N_tag_groups"]],
@@ -1527,19 +1532,19 @@ SS_readctl_3.30 <- function(file, verbose = FALSE, echoall = lifecycle::deprecat
     )
     ctllist <- add_df(ctllist,
       name = "TG_Report_fleet",
-      nrow = ctllist[["Nfleets"]],
+      nrow = Ntag_fleets,
       ncol = 14,
       col.names = lng_par_colnames,
       comments =
-        paste0("TG_report_fleet_par_", 1:ctllist[["Nfleets"]])
+        paste0("TG_report_fleet_par_", 1:Ntag_fleets)
     )
     ctllist <- add_df(ctllist,
       name = "TG_Report_fleet_decay",
-      nrow = ctllist[["Nfleets"]],
+      nrow = Ntag_fleets,
       ncol = 14,
       col.names = lng_par_colnames,
       comments =
-        paste0("TG_report_decay_par_", 1:ctllist[["Nfleets"]])
+        paste0("TG_report_decay_par_", 1:Ntag_fleets)
     )
   }
 

--- a/man/SS_readctl.Rd
+++ b/man/SS_readctl.Rd
@@ -25,6 +25,7 @@ SS_readctl(
   N_CPUE_obs = NULL,
   catch_mult_fleets = NULL,
   predM_fleets = NULL,
+  Ntag_fleets = NULL,
   N_rows_equil_catch = NULL,
   N_dirichlet_parms = NULL,
   ptype = FALSE
@@ -103,6 +104,11 @@ or 3) if comments in the control file should be used instead to determine
 the the predM_fleets. Used only in control file 3.30 syntax if
 \code{use_datlist = FALSE}.}
 
+\item{Ntag_fleets}{The number of catch fleets in the model (fleets of )
+type 1 or 2; not surveys). Used to set the number of survey parameters.
+Only used in control file 3.30 reading if tagging data is in the model and
+\code{use_datlist = FALSE}.}
+
 \item{N_rows_equil_catch}{Integer value of the number of parameter lines to
 read for equilibrium catch. Defaults to NULL, which means the function will
 attempt to figure out how many lines of equilibrium catch to read from the
@@ -111,7 +117,7 @@ control file comments. Used only in control file 3.30 syntax if
 
 \item{N_dirichlet_parms}{Integer value of the number of Dirichlet-Multinomial
 parameters. Defaults to 0. Used only in control file 3.30 syntax if
-\code{use_datlist = FALSE}..}
+\code{use_datlist = FALSE}.}
 
 \item{ptype}{LOGICAL if \code{TRUE}, which is the default,
 a column will be included in the output indicating parameter type.

--- a/man/SS_readctl_3.30.Rd
+++ b/man/SS_readctl_3.30.Rd
@@ -18,6 +18,7 @@ SS_readctl_3.30(
   Nsexes = NULL,
   Npopbins = NULL,
   Nfleets = NULL,
+  Ntag_fleets = NULL,
   Do_AgeKey = NULL,
   N_tag_groups = NULL,
   catch_mult_fleets = NULL,
@@ -68,6 +69,10 @@ if \code{use_datlist = FALSE}.}
 
 \item{Nfleets}{number of fishery and survey fleets in the model. This information is also not
 explicitly available in control file}
+
+\item{Ntag_fleets}{The number of catch fleets in the model (fleets of )
+type 1 or 2; not surveys). Used to set the number of survey parameters.
+Only used if tagging data is in the model and \code{use_datlist} is FALSE.}
 
 \item{Do_AgeKey}{Flag to indicate if 7 additional ageing error parameters to
 be read set 1 (but in fact any non zero numeric in R) or TRUE to enable to


### PR DESCRIPTION

Fixes an assumption in SS_readctl about how many lines of tagging params to read in 3.30. It should only be a parameter for each fleet of type 1 or type 2  ONLY( not including survey fleets).