### PR TITLE
change: address change in data new files

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -1447,10 +1447,13 @@ SS_output <-
       # figure out which fleet uses which parameter,
       # currently (as of SS version 3.30.10.00), requires reading data file
       if (verbose) {
-        message("Reading data.ss_new for info on Dirichlet-Multinomial parameters")
+        message("Reading data.ss_new (or data_echo.ss_new) for info on Dirichlet-Multinomial parameters")
       }
+      datname <- ifelse(file.exists(file.path(dir, "data.ss_new")),
+                        "data.ss_new",
+                        "data_echo.ss_new")
       datfile <- SS_readdat(
-        file = file.path(dir, "data.ss_new"),
+        file = file.path(dir, datname),
         verbose = verbose, version = "3.30"
       )
       # deal with case where data file is empty

--- a/R/copy_SS_inputs.R
+++ b/R/copy_SS_inputs.R
@@ -102,8 +102,12 @@ copy_SS_inputs <- function(dir.old = NULL,
       to = file.path(dir.new, starter[["ctlfile"]]),
       overwrite = overwrite
     )
+    # check data new file could be data.ss_new or data_echo.ss_new
+    dat_name <- 
+      ifelse(file.exists(file.path(dir.old, "data.ss_new")), 
+             "data.ss_new", "data_echo.ss_new")
     results[2] <- file.copy(
-      from = file.path(dir.old, "data.ss_new"),
+      from = file.path(dir.old, dat_name),
       to = file.path(dir.new, starter[["datfile"]]),
       overwrite = overwrite
     )


### PR DESCRIPTION
In 3.30.19, SS3 will split data.ss_new instead into a file to echo back inputs (data_echo.ss_new), an expected values data file (if asked for), and a file for each bootstrap fle asked for. This PR allows SS_output and copy_SS_inputs to support data new files being named either data.ss_new or data_echo.ss_new.