### PR TITLE
fix(get_dat_new_name): if was changing to NA

### DIFF
--- a/R/helper_fxns.R
+++ b/R/helper_fxns.R
@@ -15,7 +15,7 @@
 #'
 get_dat_new_name <- function(dir) {
   datname <- tail(
-    dir(path = dir, pattern = "data_*e*c*h*o*\\.ss_new"),
+    dir(path = dir, pattern = "data_?e?c?h?o?\\.ss_new"),
     1
   )
   ifelse(length(datname) == 0, NA, datname)

--- a/R/helper_fxns.R
+++ b/R/helper_fxns.R
@@ -4,17 +4,19 @@
 
 #' Get the name of the data .ss_new file in a directory
 #'
+#' In previous versions of Stock Synthesis,
+#' the file new data file was named `data.ss_new`.
+#' `_echo` was added to the name when the file was parsed into three separate
+#' files.
 #' @param dir Relative or absolute path to a directory
 #' @return A string with the name of the data .ss_new file. If not found, will
-#'  be NA.
+#'  be NA. Both of strings are searched for using `dir(pattern = )` and
+#'  if both exist, then `data_echo.ss_new` is returned.
+#'
 get_dat_new_name <- function(dir) {
-  datname <-
-    ifelse(file.exists(file.path(dir, "data.ss_new")),
-      "data.ss_new", "data_echo.ss_new"
-    )
-  if (!file.exists(file.path(dir, "data_echo.ss_new"))) {
-    datname <- as.character(NA)
-    warning("Neither data.ss_new or data_echo.ss_new found in dir ", dir)
-  }
-  datname
+  datname <- tail(
+    dir(path = dir, pattern = "data_*e*c*h*o*\\.ss_new"),
+    1
+  )
+  ifelse(length(datname) == 0, NA, datname)
 }


### PR DESCRIPTION
close #592 using dir(pattern) and ifelse

The pattern matching is done with `[e]*[c]*[h]*[o]*` which means 0+ instances of those characters in square brackets. Thanks to @k-doering-NOAA for mentioning what happens when the length of the match is nothing. The call to `tail()` is still fine because it returns `character(0)` and the `ifelse()` call changes it to `NA`. The `tail()` is needed in case both data.ss_new and data_echo.ss_new both exist. The returned value is alphabetized so the latter, which is the newer file, would always be the last value.