### PR TITLE
change path to reusable workflows

### DIFF
--- a/.github/workflows/call-calc-coverage.yml
+++ b/.github/workflows/call-calc-coverage.yml
@@ -13,4 +13,4 @@ on:
       - 'README.md'
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/calc-coverage.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -10,4 +10,4 @@ on:
 name: call-doc-and-style-r
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/doc-and-style-r.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -13,4 +13,4 @@ on:
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-stock-synthesis/workflows/.github/workflows/r-cmd-check.yml@main
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main


### PR DESCRIPTION
Reusable workflows now in https://github.com/nmfs-fish-tools/ghactions4r

Thanks for the reminder in #598 , @iantaylor-NOAA !