### PR TITLE
Fix a bug reading in ss.log

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -574,7 +574,11 @@ SS_output <-
       }
     }
     if (length(logfile) == 1 && file.info(file.path(dir, logfile))$size > 0) {
-      logfile <- read.table(file.path(dir, logfile))[, c(4, 6)]
+      logfile <- readLines(file.path(dir, logfile))
+      logfile <- grep("^size", logfile, value = TRUE)
+      if(!length(logfile)){
+        stop("Error reading ss.log. Check the file, it should contain 4 rows starting with 'size'")
+      }
       names(logfile) <- c("TempFile", "Size")
       maxtemp <- max(logfile[["Size"]])
       if (maxtemp == 0) {


### PR DESCRIPTION
Somewhere in new changes with SS, the ss.log file has the 'size' rows appearing on different line numbers. This removes hard-coded line numbers and does a regexp match on lines that begin with 'size'. There is also now an error message if these rows are not found.