### PR TITLE
test: Add back the r4ss tests that require an exe and models

### DIFF
--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -14,3 +14,8 @@ on:
 jobs:
   call-workflow:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+  call-workflow-extra:
+    # this step runs the r4ss tests again, after downloading ss3 exes and the
+    # nmfs-stock-synthesis/ss-test-models repo.
+    uses: nmfs-stock-synthesis/workflows/.github/workflows/r4ss-extra-tests.yml@main
+


### PR DESCRIPTION
This add back in tests that require an executable and model files. This used to be part of the rcmdcheck workflow, but was removed since it was only need by r4ss and we wanted the rcmdcheck workflow to be generic to all r pkgs. Now, there is a separate reusable workflow referenced that runs these tests for r4ss.