### PR TITLE
Fix argversion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r4ss
 Type: Package
 Title: R Code for Stock Synthesis
-Version: 1.43.1
+Version: 1.43.2
 Author: Ian G. Taylor, Ian J. Stewart, Allan C. Hicks, Tommy M. Garrison,
     Andre E. Punt, John R. Wallace, Chantel R. Wetzel, James T. Thorson,
     Yukio Takeuchi, Kotaro Ono, Cole C. Monnahan, Christine C. Stawitz,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# r4ss 1.43.2 (04 April 2022)
+* Standardize version = "3.30" in read and write functions and
+  deprecate NULL as an option
+
 # r4ss 1.43.1 (18 Febuarary 2022)
 * Added Common Utilty Functions
 

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -1456,7 +1456,7 @@ SS_output <-
       datname <- get_dat_new_name(dir)
       datfile <- SS_readdat(
         file = file.path(dir, datname),
-        verbose = verbose, version = "3.30"
+        verbose = verbose,
       )
       # deal with case where data file is empty
       if (is.null(datfile)) {

--- a/R/SS_profile.R
+++ b/R/SS_profile.R
@@ -42,9 +42,7 @@
 #' re-run a subset of the cases in situations where the function was
 #' interrupted or some runs fail to converge. Must be a subset of 1:n, where n
 #' is the length of profilevec.
-#' @param SSversion SS version number. Currently only "3.24" or "3.30" are
-#' supported, either as character or numeric values
-#' (noting that numeric 3.30  = 3.3).
+#' @template version
 #' @param prior_check Check to make sure the starter file is set to include
 #' the prior likelihood contribution in the total likelihood.  Default = TRUE.
 #' @param read_like Read the table of likelihoods from each model as it finishes.
@@ -199,7 +197,7 @@ SS_profile <-
            saveoutput = TRUE,
            overwrite = TRUE,
            whichruns = NULL,
-           SSversion = "3.30",
+           version = "3.30",
            prior_check = TRUE,
            read_like = TRUE,
            verbose = TRUE) {
@@ -236,7 +234,7 @@ SS_profile <-
       stop("You should input either 'linenum' or 'string' (but not both)")
     }
     if (usepar) { # if using parfile
-      if (parfile != "ss.par" & (SSversion == "3.30" | SSversion == 3.3)) {
+      if (parfile != "ss.par" & (version == "3.30" | version == 3.3)) {
         stop("'parfile' input needs to be 'ss.par' for SS version 3.30 models")
       }
       if (is.null(parlinenum) & is.null(parstring)) {
@@ -350,14 +348,6 @@ SS_profile <-
       )
     }
 
-    if (is.null(parfile)) {
-      # in 3.24, the par file name matched the executable
-      parfile <- paste0(model, ".par")
-      if (SSversion == "3.30" | SSversion == 3.3) { # turns out 3.30 != "3.30" in R
-        # in 3.30, it should always be ss.par
-        parfile <- "ss.par"
-      }
-    }
     if (usepar) {
       file.copy(parfile, "parfile_original_backup.sso")
     }

--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -113,27 +113,11 @@ SS_readctl <- function(file,
     )
     Nsexes <- Ngenders
   }
-
-  # wrapper function to call old or new version of SS_readctl
-
-  # automatic testing of version number
   if (is.null(version)) {
-    # look for 3.24 or 3.30 at the top of the chosen file
-    version <- scan(file, what = character(), nlines = 1, quiet = !verbose)
-    version <- substring(version, 3, 6)[1]
-    # if that fails, look for data.ss_new file in the same directory
-    if (version %in% c("3.24", "3.30")) {
-      if (verbose) cat("assuming version", version, "based on first line of control file\n")
-    } else {
-      newfile <- file.path(dirname(file), "control.ss_new")
-      if (file.exists(newfile)) {
-        version <- scan(newfile, what = character(), nlines = 1, quiet = !verbose)
-        version <- substring(version, 3, 6)
-        if (verbose) cat("assuming version", version, "based on first line of control.ss_new\n")
-      } else {
-        stop("input 'version' required due to missing value at top of", file)
-      }
-    }
+    lifecycle::deprecate_warn(
+      when = "1.43.2",
+      what = "SS_readctl(version = 'must be 3.24 or 3.30')"
+    )
   }
 
   nver <- as.numeric(substring(version, 1, 4))

--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -9,8 +9,7 @@
 #'
 #' @template file
 #' @template readctl_vars
-#' @param version SS version number. Currently only "3.24" or "3.30" are supported,
-#' either as character or numeric values (noting that numeric 3.30  = 3.3).
+#' @template version
 #' @param N_CPUE_obs Number of CPUE observations. Used only in control file 3.24
 #'  syntax if `use_datlist = FALSE`.
 #' @param catch_mult_fleets Integer vector of fleets using the catch multiplier
@@ -78,7 +77,10 @@
 #'   verbose = FALSE,
 #'   datlist = datfilename, use_datlist = TRUE
 #' )
-SS_readctl <- function(file, version = NULL, verbose = FALSE, echoall = lifecycle::deprecated(),
+SS_readctl <- function(file,
+                       version = "3.30",
+                       verbose = FALSE,
+                       echoall = lifecycle::deprecated(),
                        use_datlist = TRUE,
                        datlist = "data.ss_new",
                        ## Parameters that are not defined in control file

--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -114,7 +114,7 @@ SS_readctl <- function(file,
     Nsexes <- Ngenders
   }
   if (is.null(version)) {
-    lifecycle::deprecate_warn(
+    lifecycle::deprecate_stop(
       when = "1.43.2",
       what = "SS_readctl(version = 'must be 3.24 or 3.30')"
     )

--- a/R/SS_readdat.R
+++ b/R/SS_readdat.R
@@ -31,7 +31,11 @@
 #' [SS_writestarter()],
 #' [SS_writeforecast()], [SS_writedat()]
 
-SS_readdat <- function(file, version = NULL, verbose = TRUE, echoall = FALSE, section = NULL) {
+SS_readdat <- function(file,
+                       version = "3.30",
+                       verbose = TRUE,
+                       echoall = FALSE,
+                       section = NULL) {
 
   # automatic testing of version number ----
   if (is.null(version)) {

--- a/R/SS_readdat.R
+++ b/R/SS_readdat.R
@@ -37,25 +37,11 @@ SS_readdat <- function(file,
                        echoall = FALSE,
                        section = NULL) {
 
-  # automatic testing of version number ----
   if (is.null(version)) {
-    # look for 3.24 or 3.30 at the top of the chosen file
-    version <- scan(file, what = character(), nlines = 5, quiet = !verbose)
-    version <- substring(version, 3, 6)
-    version <- version[version %in% c("3.24", "3.30")]
-    # if that fails, look for data.ss_new file in the same directory
-    if (length(version) > 0) {
-      if (verbose) cat("assuming version", version, "based on first five lines of data file\n")
-    } else {
-      newfile <- file.path(dirname(file), "data.ss_new")
-      if (file.exists(newfile)) {
-        version <- scan(newfile, what = character(), nlines = 1, quiet = !verbose)
-        version <- substring(version, 3, 6)
-        if (verbose) cat("assuming version", version, "based on first line of data.ss_new\n")
-      } else {
-        stop("input 'version' required due to missing value at top of", file)
-      }
-    }
+    lifecycle::deprecate_warn(
+      when = "1.43.2",
+      what = "SS_readctl(version = 'must be 3.24 or 3.30')"
+    )
   }
   nver <- as.numeric(substring(version, 1, 4))
   if (verbose) cat("Char version is ", version, "\n")

--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -7,8 +7,7 @@
 #' @param Nfleets Number of fleets (not required in 3.30).
 #' @param Nareas Number of areas (not required in 3.30).
 #' @param nseas number of seasons (not required in 3.30).
-#' @param version SS version number. Currently only "3.24" or "3.30" are supported,
-#' either as character or numeric values (noting that numeric 3.30  = 3.3).
+#' @template version
 #' @param readAll Should the function continue even if Forecast = 0 or -1
 #' (at which point SS stops reading)?
 #' @param verbose Should there be verbose output while running the file?
@@ -18,8 +17,13 @@
 #' [SS_writestarter()],
 #' [SS_writeforecast()], [SS_writedat()],
 
-SS_readforecast <- function(file = "forecast.ss", Nfleets = NULL, Nareas = NULL, nseas = NULL,
-                            version = "3.30", readAll = FALSE, verbose = TRUE) {
+SS_readforecast <- function(file = "forecast.ss",
+                            Nfleets = NULL,
+                            Nareas = NULL,
+                            nseas = NULL,
+                            version = "3.30",
+                            readAll = FALSE,
+                            verbose = TRUE) {
 
   # function to read Stock Synthesis forecast files
   if (!(version == "3.24" | version == "3.30" | version == 3.3)) {

--- a/R/SS_varadjust.R
+++ b/R/SS_varadjust.R
@@ -16,8 +16,7 @@
 #' @param maxrows Maximum number of rows to search among in 3.30 models
 #' (may need to increase from default if you have a huge number of fleets)
 #' @param overwrite Overwrite file if it exists?
-#' @param version SS version number. Currently only "3.24" or "3.30" are supported,
-#' either as character or numeric values (noting that numeric 3.30  = 3.3).
+#' @template version
 #' @param verbose TRUE/FALSE switch for amount of detail produced by function.
 #' Default=TRUE.
 #' @author Ian G. Taylor, Gwladys I. Lambert

--- a/R/SS_writectl.R
+++ b/R/SS_writectl.R
@@ -34,9 +34,15 @@ SS_writectl <- function(ctllist,
     stop("Input 'ctllist' should be a list with component type == 'Stock_Synthesis_control_file")
   }
   if (is.null(version)) {
-    lifecycle::deprecate_warn(
+    lifecycle::deprecate_stop(
       when = "1.43.2",
       what = "SS_readctl(version = 'must be 3.24 or 3.30')"
+    )
+  }
+  if(ifelse(version == "3.3", "3.30", version) != ctllist[["ReadVersion"]]) {
+    stop(
+      "Input 'version' does not match ctllist[['ReadVersion']] of ",
+      "'", ctllist[["ReadVersion"]], "'."
     )
   }
   if (!(version == "3.24" | version == "3.30" | version == 3.3)) {

--- a/R/SS_writectl.R
+++ b/R/SS_writectl.R
@@ -33,9 +33,11 @@ SS_writectl <- function(ctllist,
   if (ctllist[["type"]] != "Stock_Synthesis_control_file") {
     stop("Input 'ctllist' should be a list with component type == 'Stock_Synthesis_control_file")
   }
-  # check version input
   if (is.null(version)) {
-    version <- ctllist[["ReadVersion"]]
+    lifecycle::deprecate_warn(
+      when = "1.43.2",
+      what = "SS_readctl(version = 'must be 3.24 or 3.30')"
+    )
   }
   if (!(version == "3.24" | version == "3.30" | version == 3.3)) {
     stop("Input 'version' should be either '3.24' or '3.30'")

--- a/R/SS_writectl.R
+++ b/R/SS_writectl.R
@@ -7,10 +7,7 @@
 #'
 #' @param ctllist List object created by [SS_readdat()].
 #' @param outfile Filename for where to write new control file.
-#' @param version SS version number. Currently only "3.24" or "3.30" are supported,
-#' either as character or numeric values (noting that numeric 3.30 = 3.3).
-#' Defaults to NULL, which means that the function will attempt to determine the
-#' version from `ctllist`.
+#' @template version
 #' @param overwrite Should existing files be overwritten? Defaults to FALSE.
 #' @param verbose Should there be verbose output while running the file?
 #' Defaults to FALSE.
@@ -20,7 +17,10 @@
 #' [SS_readdat()],
 #' [SS_readstarter()], [SS_writestarter()],
 #' [SS_readforecast()], [SS_writeforecast()]
-SS_writectl <- function(ctllist, outfile, version = NULL, overwrite = FALSE,
+SS_writectl <- function(ctllist,
+                        outfile,
+                        version = "3.30",
+                        overwrite = FALSE,
                         verbose = FALSE) {
   # function to write Stock Synthesis data files
   if (verbose) {

--- a/man-roxygen/version.R
+++ b/man-roxygen/version.R
@@ -1,4 +1,4 @@
 #' @param version SS version number. Currently "3.24" or "3.30" are supported,
-#'  either as character or numeric values (noting that numeric 3.30  = 3.3). If
-#'  `version = NULL` (the default), the version will be looked for on the first
-#'  line of the file.
+#'  either as character or numeric values (noting that numeric 3.30  = 3.3).
+#'  `version = NULL` is no longer the default or an allowed entry.
+#'  The default is `version = "3.30"`.

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -146,6 +146,7 @@ test_that("SS_readctl and SS_writectl works for 3.24", {
   }
   SS_writectl(
     ctllist = ctl_3.24,
+    version = "3.24",
     verbose = FALSE,
     overwrite = TRUE,
     outfile = file.path(sim_3.24, "testctl.ss")
@@ -182,6 +183,7 @@ test_that("SS_readctl and SS_writectl works for 3.24 when datlist = FALSE", {
     ctllist = ctl_3.24,
     verbose = FALSE,
     overwrite = TRUE,
+    version = "3.24",
     outfile = file.path(sim_3.24, "testctl.ss")
   )
   expect_true(file.exists(file.path(sim_3.24, "testctl.ss")))


### PR DESCRIPTION
Standardize the input argument `version = "3.30"` rather than having some use the `NULL` option.

I am not sure if the third commit that removes checks for `NULL` should be left in. I purposefully made it the last commit and separated it from everything else such that we can easily remove the commit from this pull request.

I did **NOT** find `version = NULL` in any of the tests, nor did I write any tests 👎 😢  One additional thing to think about is your request in #641 to update the check to see if the version in the list matches the argument. I have not addressed this as of yet, which is why this is just a draft. I think I will just make a stop() call if the values do not match. Let me know if you do not agree.