### PR TITLE
gha: calculate more accurate code coverage

### DIFF
--- a/.github/workflows/call-calc-coverage.yml
+++ b/.github/workflows/call-calc-coverage.yml
@@ -3,14 +3,16 @@ name: call-calc_coverage
 # on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 # The default is to run the workflow on every push or pull request to every branch.
 on:
-  push:
-    paths-ignore:
-      - '.github/**'
-      - 'README.md'
-  pull_request:
-    paths-ignore:
-      - '.github/**'
-      - 'README.md'
+  workflow_dispatch:
+  # temporarily turn off
+  # push:
+  #   paths-ignore:
+  #     - '.github/**'
+  #     - 'README.md'
+  # pull_request:
+  #   paths-ignore:
+  #     - '.github/**'
+  #     - 'README.md'
 jobs:
   call-workflow:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main

--- a/.github/workflows/call-r4ss-extras-codecov.yml
+++ b/.github/workflows/call-r4ss-extras-codecov.yml
@@ -1,0 +1,27 @@
+# Run code cov
+name: calc code coverage
+# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+# only run on pushes to main when there have been code changes
+# or on pull requests
+on: 
+  push: 
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+      - 'README.md'
+  pull_request:
+    branches:
+      - main
+    # paths-ignore:
+    #   - '.github/**'
+    #   - 'README.md'
+  workflow_dispatch:
+jobs:
+  call-workflow-extra:
+    # this step runs the r4ss tests again, after downloading ss3 exes and the
+    # nmfs-stock-synthesis/ss-test-models repo.
+    uses: nmfs-stock-synthesis/workflows/.github/workflows/r4ss-extra-tests.yml@main
+    with:
+      run-codecov: true
+


### PR DESCRIPTION
Addresses #645

As discussed in https://github.com/r4ss/r4ss/issues/574#issuecomment-1087962225 , code coverage is currently not accurate, because there are tests in r4ss that rely on executables and models. This adds a workflow where the ss3 exes and model files are downloaded before calculating code coverage to improve the accuracy.

Note this also switches to using ubuntu instead of osx to run the job; I think this should work fine, but if it doesn't we can switch the github runner to osx.