### PR TITLE
fix SS_read.R for SS3.30.19 with ss_new=T

### DIFF
--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -57,7 +57,7 @@ SS_read <- function(dir = NULL,
   )
 
   if (ss_new) {
-    datname <- "data.ss_new"
+    datname <- get_dat_new_name(dir)
     ctlname <- "control.ss_new"
   } else {
     datname <- start[["datfile"]]


### PR DESCRIPTION
The change I made is only one line in SS_read.R
```
  if (ss_new) {
    datname <- "data.ss_new"
```
is changed to use get_dat_new_name 
```
  if (ss_new) {
    datname <- get_dat_new_name(dir)
 ```
This change allow SS_read function to work with SS3.30.19* with ss_new=T
I only tested with the case starter$N_bootstraps =2. If it is not 2, some additional care might be needed.

