### PR TITLE
Improve codecov by adding tests for functions that don't have any

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@ docs
 ^jenkins
 ^\.github/
 ^\.github$
+^\.covrignore$

--- a/.covrignore
+++ b/.covrignore
@@ -1,0 +1,1 @@
+R/r4ss_logo.R

--- a/R/SS_doRetro.R
+++ b/R/SS_doRetro.R
@@ -2,7 +2,9 @@
 #'
 #' Do retrospective analyses by creating new directories, copying model files,
 #' and iteratively changing the starter file to set the number of years of data
-#' to exclude.
+#' to exclude. Note that there was a  bug for retrospectives in 3.30.01;
+#' the user should update their model to a newer version of Stock Synthesis to
+#' run retrospectives
 #'
 #'
 #' @param masterdir Directory where everything takes place.

--- a/R/SSmohnsrho.R
+++ b/R/SSmohnsrho.R
@@ -89,21 +89,28 @@ SSmohnsrho <-
       mohnSSB.all[i] <-
         sum((summaryoutput[["SpawnBio"]][ind, i + 1] - summaryoutput[["SpawnBio"]][ind, 1]) /
           summaryoutput[["SpawnBio"]][ind, 1]) / length(ind)
-
       ind <- which(summaryoutput[["recruits"]][["Yr"]] == startyr):which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1])
       mohnRec.all[i] <-
         sum((summaryoutput[["recruits"]][ind, i + 1] - summaryoutput[["recruits"]][ind, 1]) /
           summaryoutput[["recruits"]][ind, 1]) / length(ind)
-
+      if(length(which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1)) != 0) {
       ind <- which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1):which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1])
       mohnBratio.all[i] <-
         sum((summaryoutput[["Bratio"]][ind, i + 1] - summaryoutput[["Bratio"]][ind, 1]) /
           summaryoutput[["Bratio"]][ind, 1]) / length(ind)
-
+      } else {
+        warning("Skipping Wood's Hole Mohns Rho on Bratio, as Bratio is not available for year after the first model year.")
+        mohnBratio.all[i] <- NA
+      }
+      if(length(which(summaryoutput[["Fvalue"]][["Yr"]] == startyr)) != 0) {
       ind <- which(summaryoutput[["Fvalue"]][["Yr"]] == startyr):which(summaryoutput[["Fvalue"]][["Yr"]] == endyrvec[i + 1])
       mohnF.all[i] <-
         sum((summaryoutput[["Fvalue"]][ind, i + 1] - summaryoutput[["Fvalue"]][ind, 1]) /
           summaryoutput[["Fvalue"]][ind, 1]) / length(ind)
+      } else {
+        warning("Skipping Wood's Hole Mohn's Rho on Fvalue, ecause Fvalue is not available for first model year.")
+        mohnF.all[i] <- NA
+      }
     }
 
     mohn.out <- list()

--- a/R/copy_SS_inputs.R
+++ b/R/copy_SS_inputs.R
@@ -137,11 +137,14 @@ copy_SS_inputs <- function(dir.old = NULL,
     # figure out which files are executables
     is.exe <- file.info(dir(dir.exe, full.names = TRUE))$exe
     exefiles <- dir(dir.exe)[is.exe != "no"]
+    if (.Platform[["OS.type"]] == "unix") {
+      # Anything without an extension is listed (may need to make this more
+      # specific??)
+      exefiles <- list.files(dir.exe, pattern = "^[^.]+$")
+      message("Unix binaries are: ", paste0(exefiles, collapse = ", "))
+    }
     if (length(exefiles) == 0) {
       warning("No executable files found in ", dir.exe)
-      if (.Platform[["OS.type"]] == "unix") {
-        warning("Stock Synthesis executables cannot yet be copied for Mac or Linux")
-      }
     }
     if (length(exefiles) > 1) {
       warning("Copying multiple executable files")

--- a/R/getADMBHessian.R
+++ b/R/getADMBHessian.R
@@ -1,22 +1,18 @@
-##' Read admodel.hes file
-##'
-##' This function reads in all of the information contained in the
-##' admodel.hes file. Some of this is needed for relaxing the
-##' covariance matrix, and others just need to be recorded and
-##' rewritten to file so ADMB "sees" what it's expecting.
-##' @param File Directory in which .hes file is located.
-##' @param FileName Name of .hes file.
-##' @return A list with elements num.pars, hes, hybrid_bounded_flag, and scale.
-##' @author Cole Monnahan
-##' @export
-##' @seealso [read.admbFit()], [NegLogInt_Fn()]
-##' @note Explanation of the methods (in PDF form) published here:
-##' <https://github.com/admb-project/admb-examples/blob/master/admb-tricks/covariance-calculations/ADMB_Covariance_Calculations.pdf>
-getADMBHessian <- function(File, FileName) {
-  ## This function reads in all of the information contained in the
-  ## admodel.hes file. Some of this is needed for relaxing the
-  ## covariance matrix, and others just need to be recorded and
-  ## rewritten to file so ADMB "sees" what it's expecting.
+#' Read admodel.hes file
+#'
+#' This function reads in all of the information contained in the
+#' .hes file. Some is needed for relaxing the covariance matrix, while the rest 
+#' is recorded and rewritten to file as ADMB expects.
+#' @param File Directory in which .hes file is located. Defaults to the working
+#'  directory.
+#' @param FileName Name of .hes file. Defaults to admodel.hes.
+#' @return A list with elements num.pars, hes, hybrid_bounded_flag, and scale.
+#' @author Cole Monnahan
+#' @export
+#' @seealso [read.admbFit()], [NegLogInt_Fn()]
+#' @note Explanation of the methods (in PDF form):
+#' <https://github.com/admb-project/admb-examples/blob/master/admb-tricks/covariance-calculations/ADMB_Covariance_Calculations.pdf>
+getADMBHessian <- function(File = getwd(), FileName = "admodel.hes") {
   filename <- file(file.path(File, FileName), "rb")
   on.exit(close(filename))
   num.pars <- readBin(filename, "integer", 1)

--- a/tests/testthat/test-TSCplot.R
+++ b/tests/testthat/test-TSCplot.R
@@ -1,0 +1,21 @@
+example_path <- system.file("extdata", package = "r4ss")
+# create a temporary directory location to write files to.
+# to view the temp_path location, you can add a browser() statement after
+# creating the temp_path directory and see what temp_path is. R should write
+# to the same location for the same R session (if you restart R, temp_path will)
+# change.
+temp_path <- file.path(tempdir(), "test_simple")
+dir.create(temp_path, showWarnings = FALSE)
+# remove all artifacts created from testing. (developers: simply comment out
+# the line below if you want to keep artifacts for troubleshooting purposes)
+on.exit(unlink(temp_path, recursive = TRUE), add = TRUE)
+
+out <- SS_output(file.path(example_path, "simple_3.30.13"),
+  verbose = FALSE, printstats = FALSE, hidewarn = TRUE
+)
+
+test_that("TSCplot function runs", {
+  # Note: could look into using snapshot test to verify output
+  spawning_df <- TSCplot(out, makePNG = file.path(temp_path, "tscplot.png"))
+  expect_equivalent(ncol(spawning_df), 4)
+})

--- a/tests/testthat/test-plotCI.R
+++ b/tests/testthat/test-plotCI.R
@@ -1,0 +1,11 @@
+test_that("plotCI function works", {
+  # Note: could look into using snapshot test to verify output
+  set.seed(123)
+  x <- 1:10
+  y <- rnorm(10)
+  uiw <- 1
+  liw <- 2
+  output <- plotCI(x = x, y = y, uiw = uiw, liw = liw)
+  expect_equivalent(x, output[["x"]])
+  expect_equivalent(y, output[["y"]])
+})

--- a/tests/testthat/test-populate_multiple_folders.R
+++ b/tests/testthat/test-populate_multiple_folders.R
@@ -1,0 +1,24 @@
+example_path <- system.file("extdata", package = "r4ss")
+# create a temporary directory location to write files to.
+# to view the temp_path location, you can add a browser() statement after
+# creating the temp_path directory and see what temp_path is. R should write
+# to the same location for the same R session (if you restart R, temp_path will)
+# change.
+temp_path <- file.path(tempdir(), "test_pop_mult_folders")
+dir.create(temp_path, showWarnings = FALSE)
+# remove all artifacts created from testing. (developers: simply comment out
+# the line below if you want to keep artifacts for troubleshooting purposes)
+on.exit(unlink(temp_path, recursive = TRUE), add = TRUE)
+
+test_that("populate_multiple_folders runs", {
+  copy_info <- populate_multiple_folders(outerdir.old = example_path,
+                            outerdir.new = temp_path,
+                            exe.file = NULL,
+                            verbose = FALSE
+                            )
+  expect_true(all(copy_info[["results.files"]]))
+  lapply(copy_info[["dir"]], function(d) {
+    expect_true(file.exists(file.path(temp_path, d)))
+    expect_length(list.files(file.path(temp_path,d)), 4)
+  })
+})

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -104,7 +104,13 @@ test_that("SS_doRetro runs on simple_3.30.12 model", {
     endyrvec = endyrvec,
     legendlabels = paste("Data", 0:-2, "years")
   )
+  #calculate Mohn's rho values
+  # TODO: add better tests for mohns rho. Some values aren't calcualted b/c they
+  # are missing in the summaries for this model run.
+  mohns_rho <-  SSmohnsrho(retroSummary)
+  expect_length(mohns_rho, 12)
 })
+
 
 test_that("SS_RunJitter runs on newest simple model", {
   path_simple <- tail(dir(runs_path, full.names = TRUE), 1)

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -163,5 +163,23 @@ test_that("SS_profile runs on simple_3.30.12 model", {
   expect_equal(min(plotprofile.out$TOTAL), 0)
 })
 
+test_that("Run an SS3 model and read the hessian", {
+  path_3.30.12 <- file.path(runs_path, "simple_3.30.12")
+  skip_if((!file.exists(file.path(path_3.30.12, "ss"))) &
+            (!file.exists(file.path(path_3.30.12, "ss.exe"))),
+          message = "skipping test that requires SS executable"
+  )
+  copy_results <- copy_SS_inputs(dir.old = path_3.30.12, 
+                 dir.new = file.path(tmp_path, "test_mod_run"), copy_exe = TRUE)
+  expect_true(copy_results)
+  run_results <- run_SS_models(dirvec = file.path(tmp_path, "test_mod_run"))
+  expect_true(run_results[["results"]] == "ran model")
+  hes <- getADMBHessian(File = file.path(tmp_path, "test_mod_run"), 
+                 FileName = "admodel.hes")
+  expect_length(hes, 4)
+  expect_true(is.matrix(hes[["hes"]]))
+})
+
+
 # clean up (should delete the temporary directory in which everything was run)
 unlink(tmp_path, recursive = TRUE)

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -35,40 +35,6 @@ test_that("SS_doRetro runs on simple_3.24 model", {
   expect_true(all(unlist(retro_ran) == TRUE))
 })
 
-# test commented out b/c there seems to be a bug for retrospectives in 3.30.01;
-# the user should update their model to a newer version of Stock synthesis to
-# run retrospectives
-# test_that("SS_doRetro runs on simple_3.30.01 model", {
-#   path_3.30.01 <- file.path(runs_path, "simple_3.30.01")
-#   skip_if((!file.exists(file.path(path_3.30.01, "ss"))) &
-#             (!file.exists(file.path(path_3.30.01, "ss.exe"))),
-#           message = "skipping test that requires SS executable")
-#   SS_doRetro(
-#     masterdir = path_3.30.01,
-#     oldsubdir = "", newsubdir = "retrospectives", years = 0:-2
-#   )
-#   retro_subdirs <- file.path(path_3.30.01, "retrospectives", paste0("retro", c("0", "-1", "-2")))
-#   retro_ran <- lapply(retro_subdirs,
-#          function(d) file.exists(file.path(d, "Report.sso")))
-#   expect_true(all(unlist(retro_ran) == TRUE))
-#
-#   # read model output from the retrospectives
-#   retroModels <- SSgetoutput(
-#     dirvec = file.path(path_3.30.01,
-#       "retrospectives",
-#       paste0("retro", 0:-2)
-#     )
-#   )
-#   # summarize the model output
-#   retroSummary <- SSsummarize(retroModels)
-#   # set the fector of ending years
-#   endyrvec <- retroSummary$endyrs + 0:-2
-#   SSplotComparisons(retroSummary,
-#     endyrvec = endyrvec,
-#     legendlabels = paste("Data", 0:-2, "years")
-#   )
-# })
-
 test_that("SS_doRetro runs on simple_3.30.12 model", {
   path_3.30.12 <- file.path(runs_path, "simple_3.30.12")
   skip_if((!file.exists(file.path(path_3.30.12, "ss"))) &


### PR DESCRIPTION
Related to #316 (note this issue was closed a while ago because it is open-ended and not helpful).

While looking at codecov.io for r4ss, I realized there were a number of files that don't have any coverage at all. I attempted to add tests for some of these functions that I know get use.

This PR should increase code coverage, for the functions `SS_mohnsrho`, `getADMBHessian`, `TSCplot`, `plotCI`, and `populate_multiple_folders`. 

I also made some changes to functions and documentation as noticed while working on adding these tests. In particular, there was an issue with the Mohn's rho calculation where the necessary output was not available. I added a check for this and skipped the particular calculations, but there may be a smarter way of dealing with this problem.