### PR TITLE
fix(SS_writedat_3.30): Adds check for no mean size

### DIFF
--- a/R/SS_writedat_3.30.R
+++ b/R/SS_writedat_3.30.R
@@ -392,6 +392,9 @@ SS_writedat_3.30 <- function(datlist,
   }
 
   writeComment("#\n#_MeanSize_at_Age_obs")
+  if (is.null(d[["MeanSize_at_Age_obs"]]) && d[["use_MeanSize_at_Age_obs"]]) {
+    d[["use_MeanSize_at_Age_obs"]] <- 0
+  }
   wl("use_MeanSize_at_Age_obs")
   print.df(d[["MeanSize_at_Age_obs"]])
 


### PR DESCRIPTION
Users might erroneously have `d[["use_MeanSize_at_Age_obs"]] == 1`
when there are no observations. This happened to me in a
simulation when prior to sampling I had mean size, then
after sampling the data frame was NULL.
Thus, the new check ensures that the observations are not NULL
and if they are, then it sets d[["use_MeanSize_at_Age_obs"]] to 0.

@k-doering-NOAA did I use the `&&` appropriately here or should it be `&`?