### PR TITLE
677 `SS_read()` allows a url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r4ss
 Type: Package
 Title: R Code for Stock Synthesis
-Version: 1.45.0
+Version: 1.45.1
 Authors@R: c(person(given = "Ian G.", family = "Taylor",
   email = "Ian.Taylor@noaa.gov", role = c("aut","cre")),
   person(given = "Ian J.", family = "Stewart", role = "aut"),

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -10,7 +10,7 @@
 #' the control and data files.
 #'
 #' @param dir A file path to the directory of interest or a raw github URL (see
-#' example). The default value is \code{dir = NULL}.
+#' example). The default is the current working directory, `dir = getwd()`.
 #' @param ss_new A logical that controls if the `.ss_new` files or
 #'   the original input files are read in.
 #'   The default is to read the original files.
@@ -45,7 +45,7 @@
 #' # Read in an example from GitHub stored in user-examples,
 #' # wrapped in `dontrun` because it requires an Internet connection
 #' \dontrun{
-#' webexample <- SS_read(file.path(
+#' webexample <- SS_read(dir = file.path(
 #'   "https://raw.githubusercontent.com",
 #'   "nmfs-stock-synthesis",
 #'   "user-examples",
@@ -54,12 +54,9 @@
 #'   "simple_long_wtatage"
 #' ))
 #' }
-SS_read <- function(dir = NULL,
+SS_read <- function(dir = getwd(),
                     ss_new = FALSE,
                     verbose = FALSE) {
-  if (is.null(dir)) {
-    dir <- getwd()
-  }
 
   # Read in starter first to find the names of the input files
   start <- SS_readstarter(

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -90,7 +90,7 @@ SS_read <- function(dir = NULL,
   # return a list of the lists for each file
   invisible(list(
     dir = dir,
-    path = normalizePath(dir),
+    path = normalizePath(dir, mustWork = FALSE),
     dat = dat,
     ctl = ctl,
     start = start,

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -5,9 +5,9 @@
 #' Functionality comes from the `r4ss::SS_read*()` functions.
 #' This function simplifies the number of lines of code you need to write by
 #' using all of the read functions to read in the
-#' starter, control, data, and forecast files and maybe the weight-at-age file.
-#' The starter file is helpful because it provides names for the
-#' control and data files.
+#' starter, control, data, and forecast files and if requested, the
+#' weight-at-age file. The starter file is helpful because it provides names for
+#' the control and data files.
 #'
 #' @param dir A file path to the directory of interest or a raw github URL (see
 #' example). The default value is \code{dir = NULL}.

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -5,7 +5,7 @@
 #' Functionality comes from the `r4ss::SS_read*()` functions.
 #' This function simplifies the number of lines of code you need to write by
 #' using all of the read functions to read in the
-#' starter, control, data, and forecast files.
+#' starter, control, data, and forecast files and maybe the weight-at-age file.
 #' The starter file is helpful because it provides names for the
 #' control and data files.
 #'
@@ -21,13 +21,13 @@
 #' The first element is the directory that was provided in the argument `dir`.
 #' The second element is the result of `normalizePath(dir)`,
 #' which gives the full path.
-#' The remaining four elements are list objects from reading in
+#' The remaining five elements are list objects resulting from reading in
 #' the following input files:
 #' * data
 #' * control
 #' * starter
 #' * forecast
-#' * wtatage (will be NULL if not required by the model)
+#' * wtatage (will be `NULL` if not required by the model)
 #'
 #' @export
 #' @seealso
@@ -43,6 +43,18 @@
 #' inputs <- SS_read(
 #'   dir = system.file("extdata", "simple_3.30.13", package = "r4ss")
 #' )
+#' # Read in an example from GitHub stored in user-examples,
+#' # wrapped in `dontrun` because it requires an Internet connection
+#' \dontrun{
+#' webexample <- SS_read(file.path(
+#'   "https://raw.githubusercontent.com",
+#'   "nmfs-stock-synthesis",
+#'   "user-examples",
+#'   "main",
+#'   "model_files",
+#'   "simple_long_wtatage"
+#' ))
+#' }
 SS_read <- function(dir = NULL,
                     ss_new = FALSE,
                     verbose = FALSE) {

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -9,14 +9,13 @@
 #' The starter file is helpful because it provides names for the
 #' control and data files.
 #'
-#' @template dir
+#' @param dir A file path to the directory of interest or a raw github URL (see
+#' example). The default value is \code{dir = NULL}.
 #' @param ss_new A logical that controls if the `.ss_new` files or
 #'   the original input files are read in.
 #'   The default is to read the original files.
 #' @template verbose
-#'
 #' @author Ian G. Taylor, Kelli F. Johnson
-#'
 #' @return An invisible list is returned.
 #' The first element is the directory that was provided in the argument `dir`.
 #' The second element is the result of `normalizePath(dir)`,

--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -14,9 +14,11 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   if (verbose) {
     message("running SS_readstarter")
   }
-  size <- file.info(file)$size
-  if (is.na(size) || size == 0) stop("file empty or missing:", file)
-  starter <- readLines(file, warn = F)
+
+  starter <- readLines(file, warn = FALSE)
+  if (length(starter) == 0) {
+    stop("The following file was empty: ", file)
+  }
   mylist <- list()
 
   mylist[["sourcefile"]] <- file

--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -1,15 +1,27 @@
-#' read starter file
-#'
-#' read Stock Synthesis starter file into list object in R
-#'
+#' Read Stock Synthesis starter file as a list
 #'
 #' @template file
-#' @param verbose Should there be verbose output while running the file?
+#' @template verbose
+#' @return A list with essentially on element for each line of input values.
+#' Entries for the name of the control and data file are particularly helpful,
+#' i.e., `ctlfile` and `datfile`, respectively.
+#' @examples
+#' starter_list <- SS_readstarter(
+#'   system.file("extdata", "simple_3.30.13", "starter.ss"),
+#'   verbose = FALSE
+#' )
+#' # The following lines should be TRUE and demonstrate how you can know the
+#' # names of the control and data file given information in the starter file.
+#' starter_list[["ctlfile"]] == "simple_control.ss"
+#' starter_list[["datfile"]] == "simple_data.ss"
 #' @author Ian G. Taylor, Kathryn L. Doering
 #' @export
-#' @seealso [SS_readforecast()], [SS_readdat()],
-#' [SS_writestarter()],
-#' [SS_writeforecast()], [SS_writedat()]
+#' @seealso
+#' * [SS_readforecast()],
+#' * [SS_readdat()],
+#' * [SS_writestarter()],
+#' * [SS_writeforecast()],
+#' * [SS_writedat()]
 SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   if (verbose) {
     message("running SS_readstarter")
@@ -143,7 +155,10 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   }
   mylist[["F_report_units"]] <- allnums[i]
   i <- i + 1
-  if (!is.na(mylist[["F_report_units"]]) && mylist[["F_report_units"]] %in% 4:5) {
+  if (
+    !is.na(mylist[["F_report_units"]]) &&
+    mylist[["F_report_units"]] %in% 4:5
+  ) {
     mylist[["F_age_range"]] <- allnums[i]
     i <- i + 1
     mylist[["F_age_range"]][2] <- allnums[i]
@@ -185,9 +200,11 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
     if (verbose) message("Reading a random seed value:", mylist[["seed"]])
     mylist[["final"]] <- final <- allnums[i]
     if (!is.na(final) && final %in% c(3.30, 999)) {
-      if (verbose) message("Read of starter file complete. Final value: ", final)
+      if (verbose) {
+        message("Read of starter file complete. Final value: ", final)
+      }
     } else {
-      warning("Final value is ", allnums[i], " but should be either 3.30 or 999")
+      warning("Final value is ", allnums[i], " but should be 3.30 or 999")
     }
   }
   if (final == 3.30) {

--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -14,7 +14,7 @@
 #' # names of the control and data file given information in the starter file.
 #' starter_list[["ctlfile"]] == "simple_control.ss"
 #' starter_list[["datfile"]] == "simple_data.ss"
-#' @author Ian G. Taylor, Kathryn L. Doering, Kelli Johnson
+#' @author Ian G. Taylor, Kathryn L. Doering, Kelli F. Johnson
 #' @export
 #' @seealso
 #' * [SS_readforecast()],

--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -2,9 +2,9 @@
 #'
 #' @template file
 #' @template verbose
-#' @return A list with essentially on element for each line of input values.
-#' Entries for the name of the control and data file are particularly helpful,
-#' i.e., `ctlfile` and `datfile`, respectively.
+#' @return A list with one element for each line of input values.
+#' List elements containing the name of the control and data file are
+#' particularly helpful, i.e., `ctlfile` and `datfile`, respectively.
 #' @examples
 #' starter_list <- SS_readstarter(
 #'   system.file("extdata", "simple_3.30.13", "starter.ss"),
@@ -14,7 +14,7 @@
 #' # names of the control and data file given information in the starter file.
 #' starter_list[["ctlfile"]] == "simple_control.ss"
 #' starter_list[["datfile"]] == "simple_data.ss"
-#' @author Ian G. Taylor, Kathryn L. Doering
+#' @author Ian G. Taylor, Kathryn L. Doering, Kelli Johnson
 #' @export
 #' @seealso
 #' * [SS_readforecast()],

--- a/R/SS_readwtatage.R
+++ b/R/SS_readwtatage.R
@@ -1,24 +1,26 @@
-#' Read weight-at-age data file
-#'
-#' Read in a weight-at-age data file into a data frame in R.
+#' Read in a weight-at-age data file as a data frame
 #'
 #' @template file
 #' @template verbose
 #' @export
 #' @return Returns a data frame with a variable number of columns based on the
 #' number of ages that are included in the file. Though, the first columns
-#' will always be Yr, Seas, Sex, Bio_Pattern, BirthSeas, and Fleet.
+#' will always be `Yr`, `Seas`, `Sex`, `Bio_Pattern`, `BirthSeas`, and `Fleet`.
 #' The seventh column will be age zero.
 #' The last or next to last column will be the maximum age included
-#' in the weight-at-age data. For SS version 3.30 and greater, the last column
-#' will be a column of comments.
+#' in the weight-at-age data. For Stock Synthesis versions 3.30 and greater,
+#' the last column will be a column of comments.
+#'
+#' `NULL` is returned if `file` does not exist or if the file does exist but
+#' it is empty. This behavior is different than other `SS_read*` functions that
+#' error if either of the previous checks are `TRUE`. Thus, a complicated check
+#' involving [tryCatch()] is used around [readLines()] to allow for returning
+#' `NULL` rather than `stop()`. Additionally, this check accommodates a URL
+#' for `file`.
 #' @author Kelli F. Johnson, Ian G. Taylor
 #'
 SS_readwtatage <- function(file = "wtatage.ss", verbose = TRUE) {
 
-  # Complicated check because of the early return of NULL rather than an error
-  # and readLines() will error out if the file does not exist
-  # but file.exists() and file.info() do not work on URLs
   test <- tryCatch(
     expr = readLines(file),
     error = function(x) "No file",

--- a/R/SS_readwtatage.R
+++ b/R/SS_readwtatage.R
@@ -15,7 +15,16 @@
 #' @author Kelli F. Johnson, Ian G. Taylor
 #'
 SS_readwtatage <- function(file = "wtatage.ss", verbose = TRUE) {
-  if (!file.exists(file) | file.info(file)$size == 0) {
+
+  # Complicated check because of the early return of NULL rather than an error
+  # and readLines() will error out if the file does not exist
+  # but file.exists() and file.info() do not work on URLs
+  test <- tryCatch(
+    expr = readLines(file),
+    error = function(x) "No file",
+    warning = function(x) "No file"
+  )
+  if (test[1] == "No file" | length(test) <= 2) {
     if (verbose) {
       message("Skipping weight-at-age file. File missing or empty: ", file)
     }

--- a/tests/testthat/test-readwrite.R
+++ b/tests/testthat/test-readwrite.R
@@ -83,3 +83,10 @@ test_that("empty files lead to NULL or error", {
     SS_readstarter("nonexistentfile.ss", verbose = FALSE)
   ))
 })
+
+test_that("ss_read works with a URL", {
+  skip_if_offline(host = "github.com")
+  list_objs <- SS_read(dir = 
+  "https://github.com/nmfs-stock-synthesis/test-models/tree/main/models/Simple")
+  expect_vector(list_objs, ptype = "list")
+})

--- a/tests/testthat/test-readwrite.R
+++ b/tests/testthat/test-readwrite.R
@@ -72,3 +72,14 @@ test_that("models can be read and written", {
 
   # todo: run the models with no est to make sure the written files work with SS
 })
+
+test_that("empty files lead to NULL or error", {
+  expect_null((SS_readwtatage("nonexistentfile.ss", verbose = FALSE)))
+  expect_message((SS_readwtatage("nonexistentfile.ss")))
+  # Have to catch warning because as of 3rd edition of {testthat},
+  # `expect_*` can only trap one expectation and the following leads to
+  # both an error and a warning.
+  expect_error(suppressWarnings(
+    SS_readstarter("nonexistentfile.ss", verbose = FALSE)
+  ))
+})

--- a/tests/testthat/test-readwrite.R
+++ b/tests/testthat/test-readwrite.R
@@ -84,9 +84,11 @@ test_that("empty files lead to NULL or error", {
   ))
 })
 
-test_that("ss_read works with a URL", {
+test_that("ss_read works with a raw github URL", {
   skip_if_offline(host = "github.com")
   list_objs <- SS_read(dir = 
-  "https://github.com/nmfs-stock-synthesis/test-models/tree/main/models/Simple")
-  expect_vector(list_objs, ptype = "list")
+  "https://raw.githubusercontent.com/nmfs-stock-synthesis/test-models/main/models/Simple")
+  expect_true(is.list(list_objs))
+  expect_equal(names(list_objs), c("dir", "path", "dat", "ctl", "start", "fore",
+   "wtatage"))
 })


### PR DESCRIPTION
Had to rework the check for non-existent files or files without any information in `SS_readstarter()` and `SS_readwtatage()` to accommodate a URL yet would still return `NULL` in the latter function when appropriate.

* Allows for a URL to `SS_read(dir=)`, which facilitates using `users-examples` in the Stock Synthesis organization.
* Increases documentation of `SS_read` functions by adding an example with weight-at-age data and providing some detailed information about `SS_readstarter()` that might be helpful to new users.
* Uses @template verbose instead of bespoke text.
* Adds `mustWork = FALSE` to normalize path because a URL will lead to a warning.
* Adds test using a URL
* Fixes formatting of line length and a few other minor formatting issues.