### PR TITLE
Remove faster from tests; deprecate echoall argument in SS_readdat* functions

### DIFF
--- a/R/SS_readdat.R
+++ b/R/SS_readdat.R
@@ -15,8 +15,7 @@
 #'  line of the file.
 #' @param verbose Should there be verbose output while running the file?
 #' Default=TRUE.
-#' @param echoall Debugging tool (not fully implemented) of echoing blocks of
-#' data as it is being read.
+#' @param echoall Deprecated.
 #' @param section Which data set to read. Only applies for a data.ss_new file
 #' created by Stock Synthesis. Allows the choice of either expected values
 #' (section=2) or bootstrap data (section=3+). Leaving default of section=NULL
@@ -34,7 +33,7 @@
 SS_readdat <- function(file,
                        version = "3.30",
                        verbose = TRUE,
-                       echoall = FALSE,
+                       echoall = lifecycle::deprecated(),
                        section = NULL) {
   if (is.null(version)) {
     lifecycle::deprecate_warn(
@@ -42,6 +41,13 @@ SS_readdat <- function(file,
       what = "SS_readctl(version = 'must be 3.24 or 3.30')"
     )
     version <- "3.30"
+  }
+  if (lifecycle::is_present(echoall)) {
+    lifecycle::deprecate_warn(
+      when = "1.45.0",
+      what = "SS_readdat(echoall)",
+      details = "Please use verbose = TRUE instead"
+    )
   }
   nver <- as.numeric(substring(version, 1, 4))
   if (verbose) cat("Char version is ", version, "\n")
@@ -51,7 +57,7 @@ SS_readdat <- function(file,
   if (nver < 3) {
     datlist <- SS_readdat_2.00(
       file = file, verbose = verbose,
-      echoall = echoall, section = section
+      section = section
     )
   }
 
@@ -59,7 +65,7 @@ SS_readdat <- function(file,
   if ((nver >= 3) && (nver < 3.2)) {
     datlist <- SS_readdat_3.00(
       file = file, verbose = verbose,
-      echoall = echoall, section = section
+      section = section
     )
   }
 
@@ -67,14 +73,14 @@ SS_readdat <- function(file,
   if ((nver >= 3.2) && (nver < 3.3)) {
     datlist <- SS_readdat_3.24(
       file = file, verbose = verbose,
-      echoall = echoall, section = section
+      section = section
     )
   }
   # call function for SS version 3.30 ----
   if (nver >= 3.3) {
     datlist <- SS_readdat_3.30(
       file = file, verbose = verbose,
-      echoall = echoall, section = section
+      section = section
     )
   }
   # return the result

--- a/R/SS_readdat_2.00.R
+++ b/R/SS_readdat_2.00.R
@@ -193,7 +193,6 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   names(catch) <- c(fleetnames[1:Nfleet], "year", "seas")
   datlist[["catch"]] <- catch
   i <- i + Nvals
-  if (echoall) print(catch)
 
 
   # CPUE
@@ -218,10 +217,6 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   }
   datlist[["CPUEinfo"]] <- CPUEinfo
   datlist[["CPUE"]] <- CPUE
-  if (echoall) {
-    print(CPUEinfo)
-    print(CPUE)
-  }
 
   # discards
   # datlist[["discard_units"]] <- discard_units <- allnums[i]; i <- i+1
@@ -277,14 +272,12 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
     # don't know if this is needed for version 2.00
     # datlist[["DF_for_meanbodywt"]] <- allnums[i]
     # i <- i+1
-    # if(echoall) cat("DF_for_meanbodywt =",datlist[["DF_for_meanbodywt"]],"\n")
     datlist[["DF_for_meanbodywt"]] <- NULL
   } else {
     datlist[["DF_for_meanbodywt"]] <- NULL
     meanbodywt <- NULL
   }
   datlist[["meanbodywt"]] <- meanbodywt
-  if (echoall) print(meanbodywt)
 
   datlist[["comp_tail_compression"]] <- allnums[i]
   i <- i + 1
@@ -301,12 +294,10 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   i <- i + 1
   datlist[["lbin_vector"]] <- lbin_vector <- allnums[i:(i + N_lbins - 1)]
   i <- i + N_lbins
-  if (echoall) print(lbin_vector)
 
   datlist[["N_lencomp"]] <- N_lencomp <- allnums[i]
   i <- i + 1
 
-  # if(verbose) cat(datlist[-15:0 + length(datlist)])
   if (verbose) cat("N_lencomp =", N_lencomp, "\n")
 
   if (N_lencomp > 0) {
@@ -345,7 +336,6 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
     agebin_vector <- NULL
   }
   datlist[["agebin_vector"]] <- agebin_vector
-  if (echoall) print(agebin_vector)
 
   datlist[["N_ageerror_definitions"]] <- N_ageerror_definitions <- allnums[i]
   i <- i + 1

--- a/R/SS_readdat_3.00.R
+++ b/R/SS_readdat_3.00.R
@@ -23,10 +23,10 @@
 SS_readdat_3.00 <- function(file, verbose = TRUE,
                             echoall = lifecycle::deprecated(), section = NULL) {
   # function to read Stock Synthesis data files
-  if (lifecycle::is_present(verbose)) {
+  if (lifecycle::is_present(echoall)) {
     lifecycle::deprecate_warn(
       when = "1.45.0",
-      what = "SS_readdat_3.00(verbose)",
+      what = "SS_readdat_3.00(echoall)",
       details = "Please use verbose = TRUE instead."
     )
   }

--- a/R/SS_readdat_3.00.R
+++ b/R/SS_readdat_3.00.R
@@ -23,10 +23,10 @@
 SS_readdat_3.00 <- function(file, verbose = TRUE,
                             echoall = lifecycle::deprecated(), section = NULL) {
   # function to read Stock Synthesis data files
-  if (lifecycle::is_present(echoall)) {
+  if (lifecycle::is_present(verbose)) {
     lifecycle::deprecate_warn(
       when = "1.45.0",
-      what = "SS_readdat_3.00(echoall)",
+      what = "SS_readdat_3.00(verbose)",
       details = "Please use verbose = TRUE instead."
     )
   }
@@ -156,10 +156,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   names(fleetinfo1) <- fleetnames
   fleetinfo1[["input"]] <- c("#_surveytiming", "#_areas")
   datlist[["fleetinfo1"]] <- fleetinfo1
-  ## if(verbose){
-  ##   cat("fleetinfo1:\n")
-  ##   print(t(fleetinfo1))
-  ## }
 
   datlist[["units_of_catch"]] <- units_of_catch <- allnums[i:(i + Nfleet - 1)]
   i <- i + Nfleet
@@ -169,10 +165,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   names(fleetinfo2) <- fleetnames[1:Nfleet]
   fleetinfo2[["input"]] <- c("#_units_of_catch", "#_se_log_catch")
   datlist[["fleetinfo2"]] <- fleetinfo2
-  ## if(verbose){
-  ##   cat("fleetinfo2:\n")
-  ##   print(t(fleetinfo2))
-  ## }
 
 
   # more dimensions
@@ -218,10 +210,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   }
   datlist[["CPUEinfo"]] <- CPUEinfo
   datlist[["CPUE"]] <- CPUE
-  if (verbose) {
-    print(CPUEinfo)
-    print(CPUE)
-  }
 
   # discards
   # datlist[["discard_units"]] <- discard_units <- allnums[i]; i <- i+1
@@ -262,8 +250,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   # meanbodywt
   datlist[["N_meanbodywt"]] <- N_meanbodywt <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_meanbodywt =", N_meanbodywt, "\n")
-
 
   if (N_meanbodywt > 0) {
     Ncols <- 6
@@ -277,14 +263,12 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     # don't know if this is needed for version 2.00
     # datlist[["DF_for_meanbodywt"]] <- allnums[i]
     # i <- i+1
-    # if(verbose) cat("DF_for_meanbodywt =",datlist[["DF_for_meanbodywt"]],"\n")
     datlist[["DF_for_meanbodywt"]] <- NULL
   } else {
     datlist[["DF_for_meanbodywt"]] <- NULL
     meanbodywt <- NULL
   }
   datlist[["meanbodywt"]] <- meanbodywt
-  if (verbose) print(meanbodywt)
 
   datlist[["lbin_method"]] <- lbin_method <- allnums[i]
   i <- i + 1
@@ -296,7 +280,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     i <- i + 1
     datlist[["maximum_size"]] <- allnums[i]
     i <- i + 1
-    if (verbose) cat("bin width, min, max =", datlist[["binwidth"]], ", ", datlist[["minimum_size"]], ", ", datlist[["maximum_size"]], "\n")
   } else {
     datlist[["binwidth"]] <- NA
     datlist[["minimum_size"]] <- NA
@@ -330,9 +313,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["N_lencomp"]] <- N_lencomp <- allnums[i]
   i <- i + 1
-
-  # if(verbose) cat(datlist[-15:0 + length(datlist)])
-  if (verbose) cat("N_lencomp =", N_lencomp, "\n")
 
   if (N_lencomp > 0) {
     Ncols <- N_lbins * datlist[["Nsexes"]] + 6
@@ -370,7 +350,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     agebin_vector <- NULL
   }
   datlist[["agebin_vector"]] <- agebin_vector
-  if (verbose) print(agebin_vector)
 
   datlist[["N_ageerror_definitions"]] <- N_ageerror_definitions <- allnums[i]
   i <- i + 1
@@ -389,7 +368,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["N_agecomp"]] <- N_agecomp <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_agecomp =", N_agecomp, "\n")
 
   datlist[["Lbin_method"]] <- allnums[i]
   i <- i + 1
@@ -493,17 +471,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     i <- i + N_sizefreq_methods
     datlist[["Nobs_per_method"]] <- Nobs_per_method <- allnums[i:(i + N_sizefreq_methods - 1)]
     i <- i + N_sizefreq_methods
-    if (verbose) {
-      cat("details of generalized size frequency methods:\n")
-      print(data.frame(
-        method = 1:N_sizefreq_methods,
-        nbins = nbins_per_method,
-        units = units_per_method,
-        scale = scale_per_method,
-        mincomp = mincomp_per_method,
-        nobs = Nobs_per_method
-      ))
-    }
     # get list of bin vectors
     sizefreq_bins_list <- list()
     for (imethod in 1:N_sizefreq_methods) {

--- a/R/SS_readdat_3.24.R
+++ b/R/SS_readdat_3.24.R
@@ -9,8 +9,7 @@
 #' @template file
 #' @param verbose Should there be verbose output while running the file?
 #' Default=TRUE.
-#' @param echoall Debugging tool (not fully implemented) of echoing blocks of
-#' data as it is being read.
+#' @param echoall Deprecated.
 #' @param section Which data set to read. Only applies for a data.ss_new file
 #' created by Stock Synthesis. Allows the choice of either expected values
 #' (section=2) or bootstrap data (section=3+). Leaving default of section=NULL
@@ -22,7 +21,16 @@
 #' [SS_readstarter()], [SS_readforecast()],
 #' [SS_writestarter()],
 #' [SS_writeforecast()], [SS_writedat()]
-SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NULL) {
+SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = lifecycle::deprecated(), section = NULL) {
+  
+  # deprecated arguments
+    if (lifecycle::is_present(echoall)) {
+    lifecycle::deprecate_warn(
+      when = "1.45.0",
+      what = "SS_readdat_3.24(echoall)",
+      details = "Please use verbose = TRUE instead"
+    )
+  }
   # function to read Stock Synthesis data files
 
   if (verbose) cat("running SS_readdat_3.24\n")
@@ -124,7 +132,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   } else {
     fleetnames <- "fleet1"
   }
-  # if(verbose) cat("fleetnames:",fleetnames,'\n')
   datlist[["fleetnames"]] <- fleetnames
   datlist[["surveytiming"]] <- surveytiming <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
@@ -146,10 +153,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   names(fleetinfo1) <- fleetnames
   fleetinfo1[["input"]] <- c("#_surveytiming", "#_areas")
   datlist[["fleetinfo1"]] <- fleetinfo1
-  ## if(verbose){
-  ##   cat("fleetinfo1:\n")
-  ##   print(t(fleetinfo1))
-  ## }
 
   datlist[["units_of_catch"]] <- units_of_catch <- allnums[i:(i + Nfleet - 1)]
   i <- i + Nfleet
@@ -159,10 +162,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   names(fleetinfo2) <- fleetnames[1:Nfleet]
   fleetinfo2[["input"]] <- c("#_units_of_catch", "#_se_log_catch")
   datlist[["fleetinfo2"]] <- fleetinfo2
-  ## if(verbose){
-  ##   cat("fleetinfo2:\n")
-  ##   print(t(fleetinfo2))
-  ## }
 
 
   # more dimensions
@@ -184,7 +183,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   names(catch) <- c(fleetnames[1:Nfleet], "year", "seas")
   datlist[["catch"]] <- catch
   i <- i + Nvals
-  if (echoall) print(catch)
 
   # CPUE
   datlist[["N_cpue"]] <- N_cpue <- allnums[i]
@@ -207,10 +205,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   }
   datlist[["CPUEinfo"]] <- CPUEinfo
   datlist[["CPUE"]] <- CPUE
-  if (echoall) {
-    print(CPUEinfo)
-    print(CPUE)
-  }
 
   # discards
   # datlist[["discard_units"]] <- discard_units <- allnums[i]; i <- i+1
@@ -254,7 +248,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   if (verbose) cat("N_meanbodywt =", N_meanbodywt, "\n")
   datlist[["DF_for_meanbodywt"]] <- allnums[i]
   i <- i + 1
-  if (echoall) cat("DF_for_meanbodywt =", datlist[["DF_for_meanbodywt"]], "\n")
 
   if (N_meanbodywt > 0) {
     Ncols <- 6
@@ -268,12 +261,10 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
     meanbodywt <- NULL
   }
   datlist[["meanbodywt"]] <- meanbodywt
-  if (echoall) print(meanbodywt)
 
   # length data
   datlist[["lbin_method"]] <- lbin_method <- allnums[i]
   i <- i + 1
-  if (echoall) cat("lbin_method =", lbin_method, "\n")
   if (lbin_method == 2) {
     datlist[["binwidth"]] <- allnums[i]
     i <- i + 1
@@ -281,7 +272,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
     i <- i + 1
     datlist[["maximum_size"]] <- allnums[i]
     i <- i + 1
-    if (echoall) cat("bin width, min, max =", datlist[["binwidth"]], ", ", datlist[["minimum_size"]], ", ", datlist[["maximum_size"]], "\n")
   } else {
     datlist[["binwidth"]] <- NA
     datlist[["minimum_size"]] <- NA
@@ -292,7 +282,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
     i <- i + 1
     datlist[["lbin_vector_pop"]] <- allnums[i:(i + N_lbinspop - 1)]
     i <- i + N_lbinspop
-    if (echoall) cat("N_lbinspop =", N_lbinspop, "\nlbin_vector_pop:\n")
   } else {
     datlist[["N_lbinspop"]] <- NA
     datlist[["lbin_vector_pop"]] <- NA
@@ -308,7 +297,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   i <- i + 1
   datlist[["lbin_vector"]] <- lbin_vector <- allnums[i:(i + N_lbins - 1)]
   i <- i + N_lbins
-  if (echoall) print(lbin_vector)
 
   datlist[["N_lencomp"]] <- N_lencomp <- allnums[i]
   i <- i + 1
@@ -352,7 +340,6 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
     agebin_vector <- NULL
   }
   datlist[["agebin_vector"]] <- agebin_vector
-  if (echoall) print(agebin_vector)
 
   datlist[["N_ageerror_definitions"]] <- N_ageerror_definitions <- allnums[i]
   i <- i + 1

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -9,8 +9,7 @@
 #' @template file
 #' @param verbose Should there be verbose output while running the file?
 #' Default=TRUE.
-#' @param echoall Debugging tool (not fully implemented) of echoing blocks of
-#' data as it is being read.
+#' @param echoall Deprecated.
 #' @param section Which data set to read. Only applies for a data.ss_new file
 #' created by Stock Synthesis. Allows the choice of either expected values
 #' (section=2) or bootstrap data (section=3+). Leaving default of section=NULL
@@ -24,16 +23,17 @@
 #' [SS_writestarter()],
 #' [SS_writeforecast()], [SS_writedat()]
 SS_readdat_3.30 <-
-  function(file, verbose = TRUE, echoall = FALSE, section = NULL) {
+  function(file, verbose = TRUE, echoall = lifecycle::deprecated(), section = NULL) {
+    if (lifecycle::is_present(echoall)) {
+      lifecycle::deprecate_warn(
+        when = "1.45.0",
+        what = "SS_readdat_3.30(echoall)",
+        details = "Please use verbose = TRUE instead"
+      )
+    }
+    
     if (verbose) {
       message("Running SS_readdat_3.30")
-    }
-    if (echoall) {
-      message("Echoing blocks of data as it's being read")
-      if (!verbose) {
-        message("Changing input 'verbose' to TRUE")
-        verbose <- TRUE
-      }
     }
     dat <- readLines(file, warn = FALSE)
     if (length(dat) < 20) {
@@ -223,7 +223,7 @@ SS_readdat_3.30 <-
         " in fleet info."
       )
     }
-    if (echoall) {
+    if (verbose) {
       message("Fleet information:")
       print(datlist[["fleetinfo"]])
     }
@@ -271,10 +271,6 @@ SS_readdat_3.30 <-
     CPUEinfo_names <- c("Fleet", "Units", "Errtype", "SD_Report")
     colnames(datlist[["CPUEinfo"]]) <- CPUEinfo_names[1:ncol(datlist[["CPUEinfo"]])]
     rownames(datlist[["CPUEinfo"]]) <- datlist[["fleetnames"]]
-    if (echoall) {
-      message("CPUE information:")
-      print(datlist[["CPUEinfo"]])
-    }
 
     ## CPUE data matrix
     CPUE <- get.df(dat, ind)
@@ -284,7 +280,7 @@ SS_readdat_3.30 <-
     } else {
       datlist[["CPUE"]] <- NULL
     }
-    if (echoall) {
+    if (verbose) {
       message("CPUE data:")
       print(datlist[["CPUE"]])
     }
@@ -307,14 +303,6 @@ SS_readdat_3.30 <-
       datlist[["discard_fleet_info"]] <- NULL
       datlist[["discard_data"]] <- NULL
     }
-    if (echoall & !is.null(datlist[["discard_fleet_info"]])) {
-      message("Discard fleet information:")
-      print(datlist[["discard_fleet_info"]])
-    }
-    if (echoall & !is.null(datlist[["discard_data"]])) {
-      message("Discard data:")
-      print(datlist[["discard_data"]])
-    }
 
     ###############################################################################
     ## Mean body weight data ----""
@@ -334,10 +322,6 @@ SS_readdat_3.30 <-
     }
     if (verbose) {
       message("use_meanbodywt (0/1): ", datlist[["use_meanbodywt"]])
-    }
-    if (echoall & !is.null(datlist[["meanbodywt"]])) {
-      message("meanbodywt:")
-      print(datlist[["meanbodywt"]])
     }
 
     ###############################################################################
@@ -386,10 +370,6 @@ SS_readdat_3.30 <-
         "minsamplesize"
       )[1:ncol(datlist[["len_info"]])]
       rownames(datlist[["len_info"]]) <- datlist[["fleetnames"]]
-      if (echoall) {
-        message("\nlen_info:")
-        print(datlist[["len_info"]])
-      }
       ## Length comp data
       datlist[["N_lbins"]] <- get.val(dat, ind)
       if (verbose) {
@@ -427,14 +407,6 @@ SS_readdat_3.30 <-
           )
         }
       }
-      # echo values
-      if (echoall) {
-        message("\nFirst 2 rows of lencomp:")
-        print(head(datlist[["lencomp"]], 2))
-        message("\nLast 2 rows of lencomp:")
-        print(tail(datlist[["lencomp"]], 2))
-        cat("\n")
-      }
     }
 
     ###############################################################################
@@ -445,10 +417,6 @@ SS_readdat_3.30 <-
     }
     if (datlist[["N_agebins"]]) {
       datlist[["agebin_vector"]] <- get.vec(dat, ind)
-      if (echoall) {
-        message("agebin_vector:")
-        print(datlist[["agebin_vector"]])
-      }
     } else {
       datlist[["agebin_vector"]] <- NULL
     }
@@ -463,12 +431,6 @@ SS_readdat_3.30 <-
         datlist[["ageerror"]] <- NULL
       }
       # echo values
-      if (echoall) {
-        message("\nN_ageerror_definitions:")
-        print(datlist[["N_ageerror_definitions"]])
-        message("\nageerror:")
-        print(datlist[["ageerror"]])
-      }
     }
 
 
@@ -492,7 +454,7 @@ SS_readdat_3.30 <-
       # conditional age-at-length data and differs from lbin_method for the length
       # data read above
       datlist[["Lbin_method"]] <- get.val(dat, ind)
-      if (echoall) {
+      if (verbose) {
         message("\nage_info:")
         print(datlist[["age_info"]])
       }
@@ -522,7 +484,6 @@ SS_readdat_3.30 <-
             }
           )
       }
-      # echo values
       # warn if any 0 values in the agecomp:
       if (!is.null(datlist[["agecomp"]])) {
         zero_agecomp <- apply(datlist[["agecomp"]][, -(1:9)], MARGIN = 1, FUN = sum) == 0
@@ -535,13 +496,6 @@ SS_readdat_3.30 <-
         }
       }
 
-      if (echoall) {
-        message("\nFirst 2 rows of agecomp:")
-        print(head(datlist[["agecomp"]], 2))
-        message("\nLast 2 rows of agecomp:")
-        print(tail(datlist[["agecomp"]], 2))
-        cat("\n")
-      }
     } else {
       if (verbose) {
         message("N_agebins = 0, skipping read remaining age-related stuff")
@@ -630,14 +584,6 @@ SS_readdat_3.30 <-
             NULL
           }
         )
-      # echo values
-      if (echoall) {
-        message("\nFirst 2 rows of MeanSize_at_Age_obs:")
-        print(head(datlist[["MeanSize_at_Age_obs"]], 2))
-        message("\nLast 2 rows of MeanSize_at_Age_obs:")
-        print(tail(datlist[["MeanSize_at_Age_obs"]], 2))
-        cat("\n")
-      }
       # The formatting of the mean size at age in data.ss_new has sample sizes
       # on a separate line below the mean size values, and this applies to the
       # -9999 line as well. The lines below is an attempt to work around this
@@ -662,14 +608,6 @@ SS_readdat_3.30 <-
       datlist[["envdat"]] <- get.df(dat, ind)
       colnames(datlist[["envdat"]]) <- c("Yr", "Variable", "Value")
 
-      # echo values
-      if (echoall) {
-        message("\nFirst 2 rows of envdat:")
-        print(head(datlist[["envdat"]], 2))
-        message("\nLast 2 rows of envdat:")
-        print(tail(datlist[["envdat"]], 2))
-        cat("\n")
-      }
     } else {
       datlist[["envdat"]] <- NULL
     }
@@ -684,7 +622,7 @@ SS_readdat_3.30 <-
       datlist[["scale_per_method"]] <- get.vec(dat, ind)
       datlist[["mincomp_per_method"]] <- get.vec(dat, ind)
       datlist[["Nobs_per_method"]] <- get.vec(dat, ind)
-      if (echoall) {
+      if (verbose) {
         message("Details of generalized size frequency methods:")
         print(data.frame(
           method = 1:datlist[["N_sizefreq_methods"]],
@@ -724,10 +662,6 @@ SS_readdat_3.30 <-
               NULL
             }
           )
-        if (echoall) {
-          message("Method ", imethod, " (first two rows, ten columns):")
-          print(datlist[["sizefreq_data_list"]][[imethod]][1:min(Nrows, 2), 1:min(Ncols, 10)])
-        }
         if (any(datlist[["sizefreq_data_list"]][[imethod]][, "Method"] != imethod)) {
           stop(
             "Problem with method in size frequency data:\n",
@@ -766,10 +700,6 @@ SS_readdat_3.30 <-
           "TG", "Area", "Yr", "Season",
           "tfill", "Gender", "Age", "Nrelease"
         )
-        if (echoall) {
-          message("Head of tag release data:")
-          print(head(datlist[["tag_releases"]]))
-        }
       } else {
         datlist[["tag_releases"]] <- NULL
       }
@@ -778,7 +708,7 @@ SS_readdat_3.30 <-
         Ncols <- 5
         datlist[["tag_recaps"]] <- get.df(dat, ind, datlist[["N_recap_events"]])
         colnames(datlist[["tag_recaps"]]) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
-        if (echoall) {
+        if (verbose) {
           message("Head of tag recapture data:")
           print(head(datlist[["tag_recaps"]]))
         }

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -46,7 +46,6 @@ SS_readdat_3.30 <-
     }
 
     Comments <- get_comments(dat)
-    ###############################################################################
     ## Divide data file into sections ----
     sec.end.inds <- grep("^999\\b", dat)
     ## Run some checks to ensure that only the section break 999's are being captured
@@ -97,7 +96,6 @@ SS_readdat_3.30 <-
       }
       dat <- dat[start:end]
     }
-    ###############################################################################
     ## Internally defined functions ----
     find.index <- function(dat, ind, str) {
       ## Find the first line at position ind or later that
@@ -167,7 +165,6 @@ SS_readdat_3.30 <-
       return(df)
     }
 
-    ###############################################################################
     ## Set up the data lines for parsing ----
     ## Remove any preceeding whitespace on all lines.
     dat <- gsub("^[[:blank:]]+", "", dat)
@@ -181,11 +178,8 @@ SS_readdat_3.30 <-
     datlist[["sourcefile"]] <- file
     datlist[["type"]] <- "Stock_Synthesis_data_file"
     datlist[["ReadVersion"]] <- "3.30"
-    if (verbose) {
-      message("SS_readdat_3.30 - read version = ", datlist[["ReadVersion"]])
-    }
     datlist[["Comments"]] <- Comments
-    ##############################################################################
+
     ## Get general model information ----
     ind <- 1
     datlist[["styr"]] <- get.val(dat, ind)
@@ -198,8 +192,9 @@ SS_readdat_3.30 <-
     datlist[["Nages"]] <- get.val(dat, ind)
     datlist[["N_areas"]] <- get.val(dat, ind)
     datlist[["Nfleets"]] <- get.val(dat, ind)
-
-    ###############################################################################
+    if (verbose) {
+      message("Read general model dimensions.")
+    }
     ## Fleet data ----
     datlist[["fleetinfo"]] <- get.df(dat, ind, datlist[["Nfleets"]])
     colnames(datlist[["fleetinfo"]]) <- c(
@@ -224,8 +219,7 @@ SS_readdat_3.30 <-
       )
     }
     if (verbose) {
-      message("Fleet information:")
-      print(datlist[["fleetinfo"]])
+      message("Read Fleet information.")
     }
 
     datlist[["fleetnames"]] <- datlist[["fleetinfo"]][["fleetname"]]
@@ -233,7 +227,6 @@ SS_readdat_3.30 <-
     datlist[["units_of_catch"]] <- as.numeric(datlist[["fleetinfo"]][["units"]])
     datlist[["areas"]] <- as.numeric(datlist[["fleetinfo"]][["area"]])
 
-    ##############################################################################
     ### Bycatch Data (only added for fleets with type = 2) ----
     if (any(datlist[["fleetinfo"]][["type"]] == 2)) {
       nbycatch <- length(datlist[["fleetinfo"]][["type"]][datlist[["fleetinfo"]][["type"]] == 2])
@@ -252,8 +245,11 @@ SS_readdat_3.30 <-
         datlist[["bycatch_fleet_info"]],
         datlist[["fleetinfo"]][datlist[["fleetinfo"]][["type"]] == 2, "fleetname", drop = FALSE]
       )
+      if (verbose) {
+        message("Read bycatch data.")
+      }
     }
-    ###############################################################################
+    
     ## Catch data ----
     datlist[["catch"]] <- get.df(dat, ind)
     colnames(datlist[["catch"]]) <- c(
@@ -263,14 +259,19 @@ SS_readdat_3.30 <-
       "catch",
       "catch_se"
     )
-
-    ###############################################################################
+    if (verbose) {
+      message("Read catches.")
+    }
     ## CPUE data  ----
     datlist[["CPUEinfo"]] <- get.df(dat, ind, datlist[["Nfleets"]])
     # note SD_Report column wasn't present in early 3.30 versions of SS
     CPUEinfo_names <- c("Fleet", "Units", "Errtype", "SD_Report")
     colnames(datlist[["CPUEinfo"]]) <- CPUEinfo_names[1:ncol(datlist[["CPUEinfo"]])]
     rownames(datlist[["CPUEinfo"]]) <- datlist[["fleetnames"]]
+
+    if (verbose) {
+      message("Read CPUE data.")
+    }
 
     ## CPUE data matrix
     CPUE <- get.df(dat, ind)
@@ -280,12 +281,8 @@ SS_readdat_3.30 <-
     } else {
       datlist[["CPUE"]] <- NULL
     }
-    if (verbose) {
-      message("CPUE data:")
-      print(datlist[["CPUE"]])
-    }
 
-    ###############################################################################
+    
     ## Discard data ----
     ## fleet.nums.with.catch is defined in the catch section above.
     datlist[["N_discard_fleets"]] <- get.val(dat, ind)
@@ -299,12 +296,14 @@ SS_readdat_3.30 <-
       ## Discard data
       datlist[["discard_data"]] <- get.df(dat, ind)
       colnames(datlist[["discard_data"]]) <- c("Yr", "Seas", "Flt", "Discard", "Std_in")
+      if (verbose) {
+        message("Read discards.")
+      }
     } else {
       datlist[["discard_fleet_info"]] <- NULL
       datlist[["discard_data"]] <- NULL
     }
 
-    ###############################################################################
     ## Mean body weight data ----""
     datlist[["use_meanbodywt"]] <- get.val(dat, ind)
     if (datlist[["use_meanbodywt"]]) {
@@ -316,15 +315,14 @@ SS_readdat_3.30 <-
           "Value", "Std_in"
         )
       }
+      if (verbose) {
+        message("Read mean body weight.")
+      }
     } else {
       datlist[["DF_for_meanbodywt"]] <- NULL
       datlist[["meanbodywt"]] <- NULL
     }
-    if (verbose) {
-      message("use_meanbodywt (0/1): ", datlist[["use_meanbodywt"]])
-    }
 
-    ###############################################################################
     ## Population size structure - Length ----
     datlist[["lbin_method"]] <- get.val(dat, ind)
     if (datlist[["lbin_method"]] == 2) {
@@ -352,14 +350,8 @@ SS_readdat_3.30 <-
       datlist[["N_lbinspop"]] <- NULL
       datlist[["lbin_vector_pop"]] <- NULL
     }
-    if (verbose) {
-      message("N_lbinspop: ", datlist[["N_lbinspop"]])
-    }
     ## Length Comp information matrix (new for 3.30)
     datlist[["use_lencomp"]] <- get.val(dat, ind)
-    if (verbose) {
-      message("use_lencomp (0/1): ", datlist[["use_lencomp"]])
-    }
     # only read all the stuff related to length comps if switch above = 1
     if (datlist[["use_lencomp"]]) {
       # note: minsamplesize column not present in early 3.30 versions of SS
@@ -372,9 +364,6 @@ SS_readdat_3.30 <-
       rownames(datlist[["len_info"]]) <- datlist[["fleetnames"]]
       ## Length comp data
       datlist[["N_lbins"]] <- get.val(dat, ind)
-      if (verbose) {
-        message("N_lbins: ", datlist[["N_lbins"]])
-      }
       datlist[["lbin_vector"]] <- get.vec(dat, ind)
       datlist[["lencomp"]] <- get.df(dat, ind)
       if (!is.null(datlist[["lencomp"]])) {
@@ -407,14 +396,13 @@ SS_readdat_3.30 <-
           )
         }
       }
+      if (verbose) {
+        message("Read Length composition data.")
+      }
     }
 
-    ###############################################################################
     ## Population size structure - Age ----
     datlist[["N_agebins"]] <- get.val(dat, ind)
-    if (verbose) {
-      message("N_agebins: ", datlist[["N_agebins"]])
-    }
     if (datlist[["N_agebins"]]) {
       datlist[["agebin_vector"]] <- get.vec(dat, ind)
     } else {
@@ -434,7 +422,6 @@ SS_readdat_3.30 <-
     }
 
 
-    ###############################################################################
     ## Age Comp information matrix ----
     if (datlist[["N_agebins"]]) {
       datlist[["age_info"]] <- get.df(dat, ind, datlist[["Nfleets"]])
@@ -454,13 +441,7 @@ SS_readdat_3.30 <-
       # conditional age-at-length data and differs from lbin_method for the length
       # data read above
       datlist[["Lbin_method"]] <- get.val(dat, ind)
-      if (verbose) {
-        message("\nage_info:")
-        print(datlist[["age_info"]])
-      }
     }
-
-    ###############################################################################
     ## Age comp matrix ----
     if (datlist[["N_agebins"]]) {
       datlist[["agecomp"]] <- get.df(dat, ind)
@@ -495,10 +476,8 @@ SS_readdat_3.30 <-
           )
         }
       }
-
-    } else {
       if (verbose) {
-        message("N_agebins = 0, skipping read remaining age-related stuff")
+        message("Read age composition data.")
       }
     }
     # check DM pars ----)
@@ -525,12 +504,8 @@ SS_readdat_3.30 <-
         }
       }
     }
-    ###############################################################################
     ## Mean size-at-age data ----
     datlist[["use_MeanSize_at_Age_obs"]] <- get.val(dat, ind)
-    if (verbose) {
-      message("use_MeanSize_at_Age_obs (0/1): ", datlist[["use_MeanSize_at_Age_obs"]])
-    }
     if (datlist[["use_MeanSize_at_Age_obs"]]) {
       ind.tmp <- ind # save current position in case necessary to re-read
       endmwa <- ind - 2 + grep("-9999", dat[ind:length(dat)])[1]
@@ -592,27 +567,26 @@ SS_readdat_3.30 <-
       if (length(test) == 1) {
         ind <- ind - 1
       }
+      if (verbose) {
+        "Read Mean Size at Age observations."
+      }
     } else {
       datlist[["MeanSize_at_Age_obs"]] <- NULL
     }
 
-    ###############################################################################
     ## Environment variables ----
     datlist[["N_environ_variables"]] <- get.val(dat, ind)
-
-    if (verbose) {
-      message("N_environ_variables: ", datlist[["N_environ_variables"]])
-    }
 
     if (datlist[["N_environ_variables"]]) {
       datlist[["envdat"]] <- get.df(dat, ind)
       colnames(datlist[["envdat"]]) <- c("Yr", "Variable", "Value")
-
+      if (verbose) {
+        message("Read environmental variable data.")
+      }
     } else {
       datlist[["envdat"]] <- NULL
     }
 
-    ###############################################################################
     ## Size frequency methods ----
     datlist[["N_sizefreq_methods"]] <- get.val(dat, ind)
     if (datlist[["N_sizefreq_methods"]]) {
@@ -622,17 +596,6 @@ SS_readdat_3.30 <-
       datlist[["scale_per_method"]] <- get.vec(dat, ind)
       datlist[["mincomp_per_method"]] <- get.vec(dat, ind)
       datlist[["Nobs_per_method"]] <- get.vec(dat, ind)
-      if (verbose) {
-        message("Details of generalized size frequency methods:")
-        print(data.frame(
-          method = 1:datlist[["N_sizefreq_methods"]],
-          nbins = datlist[["nbins_per_method"]],
-          units = datlist[["units_per_method"]],
-          scale = datlist[["scale_per_method"]],
-          mincomp = datlist[["mincomp_per_method"]],
-          nobs = datlist[["Nobs_per_method"]]
-        ))
-      }
       ## get list of bin vectors
       datlist[["sizefreq_bins_list"]] <- list()
       for (imethod in seq_len(datlist[["N_sizefreq_methods"]])) {
@@ -671,6 +634,9 @@ SS_readdat_3.30 <-
           )
         }
       }
+      if (verbose) {
+        message("Read size frequency data.")
+      }
     } else {
       datlist[["nbins_per_method"]] <- NULL
       datlist[["units_per_method"]] <- NULL
@@ -681,7 +647,6 @@ SS_readdat_3.30 <-
       datlist[["sizefreq_data_list"]] <- NULL
     }
 
-    ###############################################################################
     ## Tag data ----
     datlist[["do_tags"]] <- get.val(dat, ind)
     if (datlist[["do_tags"]] > 0) {
@@ -709,15 +674,13 @@ SS_readdat_3.30 <-
         datlist[["tag_recaps"]] <- get.df(dat, ind, datlist[["N_recap_events"]])
         colnames(datlist[["tag_recaps"]]) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
         if (verbose) {
-          message("Head of tag recapture data:")
-          print(head(datlist[["tag_recaps"]]))
+          message("Read tag recapture data.")
         }
       } else {
         datlist[["tag_recaps"]] <- NULL
       }
     }
 
-    ###############################################################################
     ## Morphometrics composition data ----
     datlist[["morphcomp_data"]] <- get.val(dat, ind)
     if (datlist[["morphcomp_data"]]) {
@@ -729,11 +692,9 @@ SS_readdat_3.30 <-
       )
     }
 
-    ###############################################################################
     ## Selectivity priors ----
     datlist[["use_selectivity_priors"]] <- get.val(dat, ind)
 
-    ###############################################################################
     ## End of file ----
     eof <- get.val(dat, ind)
     if (verbose) {
@@ -749,8 +710,7 @@ SS_readdat_3.30 <-
     datlist[["eof"]] <- FALSE
     if (eof == 999) datlist[["eof"]] <- TRUE
 
-    ###############################################################################
-    ## Fixes pulled in from SS_readdat wrapper
+    ## Fixes pulled in from SS_readdat wrapper ----
     ##
     ## Note from IGT 27-March-2020:
     ## Many of the list elements created below are related to the format of SSv3.24

--- a/tests/testthat/test-simple.R
+++ b/tests/testthat/test-simple.R
@@ -181,19 +181,9 @@ test_that("SS_readdat and SS_writedat both work for 3.24", {
   SS_writedat(
     datlist = simple3.24_dat,
     outfile = file.path(temp_path, "testdat_3.24.ss"),
-    version = "3.24",
-    faster = FALSE, verbose = FALSE
+    version = "3.24", verbose = FALSE
   )
   expect_true(file.exists(file.path(temp_path, "testdat_3.24.ss")))
-
-  # write data file with faster option
-  suppressWarnings(SS_writedat(
-    datlist = simple3.24_dat,
-    outfile = file.path(temp_path, "fastdat_3.24.ss"),
-    version = "3.24",
-    faster = TRUE, verbose = FALSE
-  ))
-  expect_true(file.exists(file.path(temp_path, "fastdat_3.24.ss")))
 })
 
 ###############################################################################
@@ -213,18 +203,10 @@ test_that("SS_readdat and SS_writedat both work for 3.30.01", {
   SS_writedat(
     datlist = simple3.30.01_dat,
     outfile = file.path(temp_path, "testdat_3.30.01.ss"),
-    faster = FALSE, verbose = FALSE
+    verbose = FALSE
   )
   expect_true(file.exists(file.path(temp_path, "testdat_3.30.01.ss")))
 
-  # write data file with faster option - suppress warnings b/c they can be
-  # safely ignored.
-  suppressWarnings(SS_writedat(
-    datlist = simple3.30.01_dat,
-    outfile = file.path(temp_path, "fastdat_3.30.01.ss"),
-    faster = TRUE, verbose = FALSE
-  ))
-  expect_true(file.exists(file.path(temp_path, "fastdat_3.30.01.ss")))
 })
 
 ###############################################################################
@@ -241,16 +223,9 @@ test_that("SS_readdat and SS_writedat both work for 3.30.12", {
   SS_writedat(
     datlist = simple3.30.12_dat,
     outfile = file.path(temp_path, "testdat_3.30.12.ss"),
-    faster = FALSE, verbose = FALSE
+    verbose = FALSE
   )
   expect_true(file.exists(file.path(temp_path, "testdat_3.30.12.ss")))
-  # write data file with faster option
-  suppressWarnings(SS_writedat(
-    datlist = simple3.30.12_dat,
-    outfile = file.path(temp_path, "fastdat_3.30.12.ss"),
-    faster = TRUE, verbose = FALSE
-  ))
-  expect_true(file.exists(file.path(temp_path, "fastdat_3.30.12.ss")))
 })
 
 ###############################################################################
@@ -267,16 +242,9 @@ test_that("SS_readdat and SS_writedat both work for 3.30.13", {
   SS_writedat(
     datlist = simple3.30.13_dat,
     outfile = file.path(temp_path, "testdat_3.30.13.ss"),
-    faster = FALSE, verbose = FALSE
+    verbose = FALSE
   )
   expect_true(file.exists(file.path(temp_path, "testdat_3.30.13.ss")))
-  # write data file with faster option
-  suppressWarnings(SS_writedat(
-    datlist = simple3.30.13_dat,
-    outfile = file.path(temp_path, "fastdat_3.30.13.ss"),
-    faster = TRUE, verbose = FALSE
-  ))
-  expect_true(file.exists(file.path(temp_path, "fastdat_3.30.13.ss")))
 })
 
 # Note: for blank lines, SS_readdat just warns, while SS_writedat removes.


### PR DESCRIPTION
Addresses #678. Also extends work done in #671, which included deprecating unneeded arguments in the read/write functions. For some reason, the echoall argument was not removed from the SS_readdat* functions, so it is done in this pull request