### PR TITLE
Test readwrite par

### DIFF
--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -21,20 +21,22 @@
 #' The first element is the directory that was provided in the argument `dir`.
 #' The second element is the result of `normalizePath(dir)`,
 #' which gives the full path.
-#' The remaining four elements are list objects from reading in
+#' The remaining four to six elements are list objects from reading in
 #' the following input files:
 #' * data
 #' * control
 #' * starter
 #' * forecast
 #' * wtatage (will be NULL if not required by the model)
+#' * par (will be null if control and par do not match)
 #'
 #' @export
 #' @seealso
 #' * [SS_write()] can be used to write the input files using the list
 #'   created by this function.
 #' * [SS_readstarter()], [SS_readdat()], [SS_readctl()],
-#'   [SS_readforecast()], and [SS_readwtatage()] are used by this
+#'   [SS_readforecast()], [SS_readwtatage()],
+#'   [SS_readpar_3.30()], and [SS_readpar_3.24()] used by this
 #'   function to read in the input files.
 #' * [SS_output()] to read in equivalent SS3 output files.
 #'
@@ -90,10 +92,19 @@ SS_read <- function(dir = NULL,
   par <- NULL
   if(file.exists(file.path(dir, "ss.par"))){
     try(
-      par <- r4ss::SS_readpar_3.30(file.path(dir, "ss.par"),
-                                  datsource = dat,
-                                  ctlsource = ctl,
-                                  verbose = FALSE),
+      {
+        if(ctl[["ReadVersion"]]=="3.24"){
+          par <- r4ss::SS_readpar_3.24(file.path(dir, "ss.par"),
+                                    datsource = dat,
+                                    ctlsource = ctl,
+                                    verbose = verbose)
+        }else{
+          par <- r4ss::SS_readpar_3.30(file.path(dir, "ss.par"),
+                                       datsource = dat,
+                                       ctlsource = ctl,
+                                       verbose = verbose)  
+        }
+      },
       silent = !verbose
     )
   }

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -87,12 +87,15 @@ SS_read <- function(dir = NULL,
     wtatage <- NULL
   }
 
-  par <- r4ss::SS_readpar_3.30(file.path(dir, "ss.par"),
-                         datsource = dat,
-                         ctlsource = ctl,
-                         verbose = FALSE
-  )
-  
+  if(file.exists(file.path(dir, "ss.par"))){
+    par <- r4ss::SS_readpar_3.30(file.path(dir, "ss.par"),
+                           datsource = dat,
+                           ctlsource = ctl,
+                           verbose = FALSE
+    )
+  }else{
+    par <- NULL
+  }
   # return a list of the lists for each file
   invisible(list(
     dir = dir,

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -87,15 +87,18 @@ SS_read <- function(dir = NULL,
     wtatage <- NULL
   }
 
+  par <- NULL
   if(file.exists(file.path(dir, "ss.par"))){
-    par <- r4ss::SS_readpar_3.30(file.path(dir, "ss.par"),
-                           datsource = dat,
-                           ctlsource = ctl,
-                           verbose = FALSE
+    try(
+      par <- r4ss::SS_readpar_3.30(file.path(dir, "ss.par"),
+                                  datsource = dat,
+                                  ctlsource = ctl,
+                                  verbose = FALSE),
+      silent = !verbose
     )
-  }else{
-    par <- NULL
   }
+  
+  
   # return a list of the lists for each file
   invisible(list(
     dir = dir,

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -87,6 +87,12 @@ SS_read <- function(dir = NULL,
     wtatage <- NULL
   }
 
+  par <- r4ss::SS_readpar_3.30(file.path(dir, "ss.par"),
+                         datsource = dat,
+                         ctlsource = ctl,
+                         verbose = FALSE
+  )
+  
   # return a list of the lists for each file
   invisible(list(
     dir = dir,
@@ -95,6 +101,7 @@ SS_read <- function(dir = NULL,
     ctl = ctl,
     start = start,
     fore = fore,
-    wtatage = wtatage
+    wtatage = wtatage,
+    par = par
   ))
 }

--- a/R/SS_readpar_3.30.R
+++ b/R/SS_readpar_3.30.R
@@ -333,6 +333,7 @@ SS_readpar_3.30 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
         dev_parm_labels <- c(dev_parm_labels, paste0(rownames(dev_temp), "_dev_seq"))
       }
     }
+    
     # Add 2DAR selectivity parameters if they exist
     if (!is.null(ctllist[["pars_2D_AR"]])) {
       if (!is.null(parlist[["S_parms"]])) {
@@ -341,6 +342,17 @@ SS_readpar_3.30 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
         parlist[["S_parms"]] <- ctllist[["pars_2D_AR"]][, 3:4]
       }
     }
+    
+    # Add 2DAR devs if they exist
+    if (!is.null(ctllist[["specs_2D_AR"]])) {
+      dev_temp <- ctllist[["specs_2D_AR"]]
+      if (length(dev_temp[, 1]) > 0) {
+        dev_parm_start <- c(dev_parm_start, rep(1,length(dev_temp[, 1])))
+        dev_parm_end <- c(dev_parm_end, (dev_temp[, 3]-dev_temp[, 2] + 1)*(dev_temp[, 5]-dev_temp[, 4] + 1))
+        dev_parm_labels <- c(dev_parm_labels, paste0(rownames(dev_temp), "_dev_seq"))
+      }
+    }
+    
     colnames(parlist[["S_parms"]]) <- c("INIT", "ESTIM")
     # Read in values for selectivity parameters and add to list
     S_seq <- as.numeric(parvals[(grep("selparm", parvals) + 1)])

--- a/R/SS_write.R
+++ b/R/SS_write.R
@@ -3,8 +3,8 @@
 #' Writes all the input files for a Stock Synthesis model using the list
 #' created by [SS_read()]
 #' (presumably after modification of one or more elements)
-#' using the `SS_write*()` functions for the four or
-#' five model input files.
+#' using the `SS_write*()` functions for the four to
+#' six model input files.
 #'
 #' @param inputlist list created by [SS_read()]
 #' @template dir
@@ -17,7 +17,8 @@
 #' @seealso
 #' * [SS_read()] creates the list that is used by this function.
 #' * [SS_writestarter()], [SS_writedat()], [SS_writectl()],
-#' [SS_writeforecast()], and [SS_writewtatage()] are used to write the
+#' [SS_writeforecast()], [SS_writewtatage()], [SS_writepar_3.30()], 
+#' and [SS_writepar_3.24()] are used to write the
 #' input files.
 
 #' @examples
@@ -122,7 +123,17 @@ SS_write <- function(inputlist,
   if ("par" %in% names(inputlist)){
     if(!is.null(inputlist[["par"]])){
       try(
-        r4ss::SS_writepar_3.30(inputlist[["par"]], outfile = file.path(dir, "ss.par"), verbose = FALSE),
+        {
+          if(inputlist[["ctl"]][["ReadVersion"]]=="3.24"){
+            par <- r4ss::SS_writepar_3.24(inputlist[["par"]], 
+                                          outfile = file.path(dir, "ss.par"), 
+                                          verbose = verbose)
+          }else{
+            par <- r4ss::SS_writepar_3.30(inputlist[["par"]], 
+                                          outfile = file.path(dir, "ss.par"), 
+                                          verbose = verbose)  
+          }
+        },
         silent = !verbose
       )
     }

--- a/R/SS_write.R
+++ b/R/SS_write.R
@@ -117,7 +117,11 @@ SS_write <- function(inputlist,
       verbose = verbose
     )
   }
-
+  
+  if ("par" %in% names(inputlist)){
+    r4ss::SS_writepar_3.30(inputlist[["par"]], outfile = file.path(dir, "ss.par"), verbose = FALSE)
+  }
+  
   # message noting that all files have been written
   if (verbose) {
     message("Wrote all input files to ", dir)

--- a/R/SS_write.R
+++ b/R/SS_write.R
@@ -118,9 +118,13 @@ SS_write <- function(inputlist,
     )
   }
   
+  
   if ("par" %in% names(inputlist)){
     if(!is.null(inputlist[["par"]])){
-      r4ss::SS_writepar_3.30(inputlist[["par"]], outfile = file.path(dir, "ss.par"), verbose = FALSE)
+      try(
+        r4ss::SS_writepar_3.30(inputlist[["par"]], outfile = file.path(dir, "ss.par"), verbose = FALSE),
+        silent = !verbose
+      )
     }
   }
   

--- a/R/SS_write.R
+++ b/R/SS_write.R
@@ -119,7 +119,9 @@ SS_write <- function(inputlist,
   }
   
   if ("par" %in% names(inputlist)){
-    r4ss::SS_writepar_3.30(inputlist[["par"]], outfile = file.path(dir, "ss.par"), verbose = FALSE)
+    if(!is.null(inputlist[["par"]])){
+      r4ss::SS_writepar_3.30(inputlist[["par"]], outfile = file.path(dir, "ss.par"), verbose = FALSE)
+    }
   }
   
   # message noting that all files have been written

--- a/man/SS_read.Rd
+++ b/man/SS_read.Rd
@@ -27,7 +27,7 @@ An invisible list is returned.
 The first element is the directory that was provided in the argument \code{dir}.
 The second element is the result of \code{normalizePath(dir)},
 which gives the full path.
-The remaining four elements are list objects from reading in
+The remaining four to six elements are list objects from reading in
 the following input files:
 \itemize{
 \item data
@@ -35,6 +35,7 @@ the following input files:
 \item starter
 \item forecast
 \item wtatage (will be NULL if not required by the model)
+\item par (will be null if control and par do not match)
 }
 }
 \description{
@@ -58,7 +59,8 @@ inputs <- SS_read(
 \item \code{\link[=SS_write]{SS_write()}} can be used to write the input files using the list
 created by this function.
 \item \code{\link[=SS_readstarter]{SS_readstarter()}}, \code{\link[=SS_readdat]{SS_readdat()}}, \code{\link[=SS_readctl]{SS_readctl()}},
-\code{\link[=SS_readforecast]{SS_readforecast()}}, and \code{\link[=SS_readwtatage]{SS_readwtatage()}} are used by this
+\code{\link[=SS_readforecast]{SS_readforecast()}}, \code{\link[=SS_readwtatage]{SS_readwtatage()}},
+\code{\link[=SS_readpar_3.30]{SS_readpar_3.30()}}, and \code{\link[=SS_readpar_3.24]{SS_readpar_3.24()}} used by this
 function to read in the input files.
 \item \code{\link[=SS_output]{SS_output()}} to read in equivalent SS3 output files.
 }

--- a/man/SS_write.Rd
+++ b/man/SS_write.Rd
@@ -27,8 +27,8 @@ to the screen.}
 Writes all the input files for a Stock Synthesis model using the list
 created by \code{\link[=SS_read]{SS_read()}}
 (presumably after modification of one or more elements)
-using the \verb{SS_write*()} functions for the four or
-five model input files.
+using the \verb{SS_write*()} functions for the four to
+six model input files.
 }
 \examples{
 \dontrun{
@@ -60,7 +60,8 @@ SS_write(
 \itemize{
 \item \code{\link[=SS_read]{SS_read()}} creates the list that is used by this function.
 \item \code{\link[=SS_writestarter]{SS_writestarter()}}, \code{\link[=SS_writedat]{SS_writedat()}}, \code{\link[=SS_writectl]{SS_writectl()}},
-\code{\link[=SS_writeforecast]{SS_writeforecast()}}, and \code{\link[=SS_writewtatage]{SS_writewtatage()}} are used to write the
+\code{\link[=SS_writeforecast]{SS_writeforecast()}}, \code{\link[=SS_writewtatage]{SS_writewtatage()}}, \code{\link[=SS_writepar_3.30]{SS_writepar_3.30()}},
+and \code{\link[=SS_writepar_3.24]{SS_writepar_3.24()}} are used to write the
 input files.
 }
 }


### PR DESCRIPTION
This pull request addresses issue #681 and is now passing all tests. Corrections have been made to the read_par function to include 2DAR dev parameters and to the SS_read and SS_write functions to include the ss.par file if it is present.