### PR TITLE
660 use msg warning

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: r4ss
 Type: Package
 Title: R Code for Stock Synthesis
-Version: 1.45.0
+Version: 1.45.2
 Authors@R: c(person(given = "Ian G.", family = "Taylor",
   email = "Ian.Taylor@noaa.gov", role = c("aut","cre")),
   person(given = "Ian J.", family = "Stewart", role = "aut"),

--- a/R/NegLogInt_Fn.R
+++ b/R/NegLogInt_Fn.R
@@ -182,8 +182,6 @@ NegLogInt_Fn <- function(File = NA, Input_SD_Group_Vec,
         Temp <- Temp[-(grep("#", Temp):length(Temp))]
       }
       Temp <- as.numeric(Temp)
-      # print(Temp)
-      # print(CTL_linenum_Type[ParI])
       if (is.na(CTL_linenum_Type[ParI])) {
         if (length(Temp) == 7) {
           CTL_linenum_Type[ParI] <- "Short_Param"

--- a/R/PinerPlot.R
+++ b/R/PinerPlot.R
@@ -186,9 +186,9 @@ PinerPlot <-
       )
     }
     parvec <- as.numeric(pars[pars[["Label"]] == parlabel, models])
-    cat("Parameter matching profile.string='", profile.string, "': '", parlabel, "'\n", sep = "")
-    cat("Parameter values (after subsetting based on input 'models'):\n")
-    print(parvec)
+    message("Parameter matching profile.string = '", profile.string, "': '", 
+    parlabel, "Parameter values (after subsetting based on input 'models'):", 
+    paste0(parvec, collase = ", "))
     if (xlim[1] == "default") xlim <- range(parvec)
 
     # rearange likelihoods to be in columns by type
@@ -236,11 +236,10 @@ PinerPlot <-
     column.max <- apply(data.frame(prof.table[, -c(1:3)]), 2, max, na.rm = TRUE)
     change.fraction <- column.max / max(prof.table[, 3], na.rm = TRUE)
     include <- change.fraction >= minfraction
-    cat("\nFleets-specific likelihoods showing max change as fraction of total change.\n",
-      "To change which components are included, change input 'minfraction'.\n\n",
-      sep = ""
-    )
-    print(data.frame(frac_change = round(change.fraction, 4), include = include))
+    message("Fleets-specific likelihoods showing max change as fraction of total change.\n",
+      "To change which components are included, change input 'minfraction'.")
+    paste0(output.console(data.frame(frac_change = round(change.fraction, 4),
+     include = include)), collapse = ", ")
 
     # subset values and reorder values
     # Note: first 3 columns are "model", "Label", and "ALL", and

--- a/R/RebuildPlot.R
+++ b/R/RebuildPlot.R
@@ -76,7 +76,7 @@ DoProjectPlots <- function(dirn = "C:/myfiles/", fileN = c("res.csv"), Titles = 
   if (pdf) {
     pdffile <- paste(dirn[1], "/rebuild_plots_", format(Sys.time(), "%d-%b-%Y_%H.%M"), ".pdf", sep = "")
     pdf(file = pdffile, width = pwidth, height = pheight)
-    cat("PDF file with plots will be:", pdffile, "\n")
+    message("Name of PDF file with plots: ", pdffile)
   } else {
 
     ### Note: the following line has been commented out because it was identified
@@ -208,7 +208,10 @@ DoProjectPlots <- function(dirn = "C:/myfiles/", fileN = c("res.csv"), Titles = 
     NOpts <- 0
     for (Ifile in 1:length(FileN)) NOpts <- NOpts + length(Options[[Ifile]])
 
-    if (NOpts > 8) cat("WARNING - you have a large number of lines - perhaps create separate plots for subsets\n")
+    if (NOpts > 8) {
+      warning("There are a large number of lines. Consider creating separate", 
+      " plots\nfor subsets.")
+    }
 
     Files <- NULL
     Opts <- NULL
@@ -377,8 +380,8 @@ DoProjectPlots <- function(dirn = "C:/myfiles/", fileN = c("res.csv"), Titles = 
         B0 <- as.double(UUUs[[1]][Jpnt, 1])
         abline(h = 0.4 * B0 / BioScalar, lwd = 1, lty = 2)
         abline(h = 0.25 * B0 / BioScalar, lwd = 1, lty = 2)
-        cat("40% line at", 0.4 * B0 / BioScalar, "\n")
-        cat("25% line at", 0.25 * B0 / BioScalar, "\n")
+        message("40% line at ", 0.4 * B0 / BioScalar)
+        message("25% line at ", 0.25 * B0 / BioScalar)
       }
 
       if (ii == AllTraj[1]) title(Title)
@@ -447,7 +450,7 @@ DoProjectPlots <- function(dirn = "C:/myfiles/", fileN = c("res.csv"), Titles = 
         ind[["sb"]][["B0"]] <- B0 / BioScalar
         abline(h = 0.4 * B0 / BioScalar, lwd = 1, lty = 2)
         abline(h = 0.25 * B0 / BioScalar, lwd = 1, lty = 2)
-        cat("Making spawning biomass plot for run", ii, "\n")
+        message("Making spawning biomass plot for run ", ii)
       }
 
       if (ii == AllInd[1]) title(Title)
@@ -558,7 +561,7 @@ DoProjectPlots <- function(dirn = "C:/myfiles/", fileN = c("res.csv"), Titles = 
   for (Ifile in 1:Nfiles)
   {
     FileName <- file.path(dirn[Ifile], fileN[Ifile])
-    cat("FileName:", FileName, "\n")
+    message("FileName: ", FileName)
     UUU <- read.table(
       file = FileName, col.names = 1:ncols, fill = T,
       colClasses = "character", comment.char = "$", sep = ","
@@ -589,7 +592,7 @@ DoProjectPlots <- function(dirn = "C:/myfiles/", fileN = c("res.csv"), Titles = 
     # Individual plots
     if (6 %in% Plots[[Ifile]]) {
       ind.list[[Ifile]] <- IndividualPlots(UUU, Titles[Ifile], yearmax)
-      cat("Running IndividualPlots for file", Ifile, "\n")
+      message("Running IndividualPlots for file ", Ifile)
     } else {
       ind.list[[Ifile]] <- NULL
     }

--- a/R/SSMethod.Cond.TA1.8.R
+++ b/R/SSMethod.Cond.TA1.8.R
@@ -215,7 +215,7 @@ SSMethod.Cond.TA1.8 <-
           # 0 sample sizes caused problems with ylim, override with wide range
           # plot may not make sense but will help users note that a problem exists
           # (as opposed to skipping the plot)
-          cat("NaN values in Francis calculations, plot may not make sense\n")
+          warning("NaN values in Francis calculations, plot may not make sense")
           ylim <- c(0, fit[["accuage"]])
         }
         # make empty plot (unless adding to existing plot)

--- a/R/SS_RunJitter.R
+++ b/R/SS_RunJitter.R
@@ -91,7 +91,7 @@ SS_RunJitter <- function(mydir,
   if (!is.null(init_values_src)) {
     starter[["init_values_src"]] <- init_values_src
   }
-  r4ss::SS_writestarter(starter, overwrite = TRUE, verbose = FALSE, warn = FALSE)
+  r4ss::SS_writestarter(starter, overwrite = TRUE, verbose = FALSE)
   file_increment(0, verbose = verbose)
 
   # create empty ss.dat file to avoid the ADMB message

--- a/R/SS_changepars.R
+++ b/R/SS_changepars.R
@@ -145,21 +145,16 @@ SS_changepars <-
         }
         goodnames <- unique(unlist(goodnames))
         if (verbose) {
-          cat("parameter names in control file matching input vector 'strings' (n=",
-            length(goodnames), "):\n",
-            sep = ""
+          message("Parameter names in control file matching input vector \n", 
+          "'strings' (n=", length(goodnames), "): ", 
+          paste0(goodnames, collapse = ", ")
           )
-          print(goodnames)
         }
         if (length(goodnames) == 0) {
           stop("No parameters names match input vector 'strings'")
         }
       }
       nvals <- length(goodnames)
-      if (verbose) {
-        cat("These are the ctl file lines as they currently exist:\n")
-        print(ctltable[ctltable[["Label"]] %in% goodnames, ])
-      }
       for (i in 1:nvals) {
         linenums[i] <- ctltable[["Linenum"]][ctltable[["Label"]] == goodnames[i]]
       }
@@ -301,9 +296,7 @@ SS_changepars <-
     newctl <- ctl
     newctl[linenums] <- newctlsubset
     writeLines(newctl, file.path(dir, newctlfile))
-    if (verbose) {
-      cat("\nwrote new file to", newctlfile, "with the following changes:\n")
-    }
+
 
     # if no changed made, repeat old values in output
     if (is.null(newvals)) {
@@ -335,7 +328,8 @@ SS_changepars <-
       newvals <- NA
     }
     if (verbose) {
-      print(results)
+      message("Wrote new file to ", newctlfile, " with the following changes:\n",
+      paste0(capture.output(results), collapse = "\n"))
     }
     return(invisible(results))
   } # end function

--- a/R/SS_doRetro.R
+++ b/R/SS_doRetro.R
@@ -104,8 +104,6 @@ SS_doRetro <- function(masterdir, oldsubdir, newsubdir = "retrospectives",
 
   if (length(startfile) == 0) stop("No starter.ss file found in ", olddir)
 
-  ## print(getwd())
-  ## print(startfile)
   startfile <- file.path(olddir, startfile)
 
   message("Getting input file names from starter file:\n", startfile)

--- a/R/SS_fitbiasramp.R
+++ b/R/SS_fitbiasramp.R
@@ -105,7 +105,7 @@ SS_fitbiasramp <-
         .7
       )
     }
-    if (verbose) cat("startvalues =", paste(startvalues, collapse = ", "), "\n")
+    if (verbose) message("startvalues =", paste(startvalues, collapse = ", "))
 
     makeoffsets <- function(values) {
       # a function to transform parameters into offsets from adjacent values
@@ -131,7 +131,8 @@ SS_fitbiasramp <-
     if (transform) {
       startvalues <- makeoffsets(startvalues)
     }
-    if (verbose & transform) cat("transformed startvalues =", paste(startvalues, collapse = ", "), "\n")
+    if (verbose & transform) message("transformed startvalues =",
+     paste(startvalues, collapse = ", "))
 
     biasadjfit <- function(pars, yr, std, sigmaR, transform,
                            is.forecast, eps = .1) {
@@ -251,7 +252,7 @@ SS_fitbiasramp <-
 
     # test for presence of estimated recruitment deviations
     if (max(val) == 0 | length(val) == 0) {
-      if (verbose) cat("no rec devs estimated in this model\n")
+      if (verbose) message("No rec devs estimated in this model")
       return()
     }
 
@@ -259,7 +260,7 @@ SS_fitbiasramp <-
     recdev_lo <- val - 1.96 * std
 
     ylim <- range(recdev_hi, recdev_lo)
-    if (verbose) cat("Now estimating alternative recruitment bias adjustment fraction...\n")
+    if (verbose) message("Now estimating alternative recruitment bias adjustment fraction...")
     newbias <- optimfun(
       yr = yr, std = std,
       startvalues = startvalues, is.forecast = is.forecast
@@ -315,14 +316,10 @@ SS_fitbiasramp <-
 
     if (verbose) {
       if (newbias[["convergence"]] != 0) {
-        cat("Problem with convergence, here is output from 'optim':\n")
-        cat("##############################\n")
+        warning("Problem with convergence, here is output from 'optim':\n")
         print(newbias)
-        cat("##############################\n")
       }
-
-      cat("Estimated values:\n")
-      print(format(df, justify = "left"), row.names = FALSE)
+      message("Estimated values: \n", paste0(capture.output(df), collpase = "\n"))
     }
 
     if (plot) {
@@ -383,7 +380,7 @@ SS_fitbiasramp <-
       ctlfile[spot1:spot2] <- apply(df, 1, paste, collapse = " ")
       # write new file
       writeLines(ctlfile, newctl)
-      if (verbose) cat("wrote new file to", newctl, "with values", paste(newvals, collapse = " "), "\n")
+      if (verbose) message("wrote new file to ", newctl, " with values", paste(newvals, collapse = ", "))
     }
     if (!is.null(plotinfo)) plotinfo[["category"]] <- "RecDev"
     return(invisible(list(newbias = newbias, df = df, plotinfo = plotinfo)))

--- a/R/SS_html.R
+++ b/R/SS_html.R
@@ -36,7 +36,7 @@ SS_html <- function(replist = NULL,
                     filenotes = NULL,
                     verbose = TRUE) {
   if (verbose) {
-    cat(
+    message(
       "Running 'SS_html':\n",
       "  By default, this function will look in the directory where PNG files were created\n",
       "  for CSV files with the name 'plotInfoTable...' written by 'SS_plots.'\n",
@@ -72,7 +72,7 @@ SS_html <- function(replist = NULL,
             "    Runs:\n"
           )
           for (irun in 1:length(runs)) msg <- c(msg, paste("    ", runs[irun], "\n"))
-          cat(msg)
+          warning(msg)
         } else {
           msg <- c(
             "CSV files with name 'plotInfoTable...' are from multiple model runs.\n",
@@ -88,7 +88,7 @@ SS_html <- function(replist = NULL,
       duplicates <- names(filetable[filetable > 1])
       # loop over duplicates and remove rows for older instance
       if (length(duplicates) > 0) {
-        if (verbose) cat("Removing duplicate rows in combined plotInfoTable based on multiple CSV files\n")
+        if (verbose) message("Removing duplicate rows in combined plotInfoTable based on multiple CSV files")
         for (idup in 1:length(duplicates)) {
           duprows <- grep(duplicates[idup], plotInfoTable[["file"]], fixed = TRUE)
           duptimes <- plotInfoTable[["png_time"]][duprows]
@@ -120,7 +120,7 @@ SS_html <- function(replist = NULL,
       htmlfile <- file.path(plotdir, "_SS_output.html")
       htmlhome <- htmlfile
       if (verbose) {
-        cat("Home HTML file with output will be:\n", htmlhome, "\n")
+        message("Home HTML file with output will be: ", htmlhome)
       }
     } else {
       category <- categories[icat]
@@ -377,7 +377,7 @@ SS_html <- function(replist = NULL,
   # open HTML file automatically:
   # thanks John Wallace for finding the browseURL command
   if (openfile) {
-    if (verbose) cat("Opening HTML file in your default web-browser.\n")
+    if (verbose) message("Opening HTML file in your default web-browser.")
     # check for presence of file
     # alternative location for file in the path is relative to the working directory
     htmlhome2 <- file.path(getwd(), htmlhome)

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -590,8 +590,7 @@ SS_output <-
         }
       } else {
         if (verbose) {
-          message("!warning: temporary files were written in this run:")
-          print(logfile)
+          message("Temporary files were written in this run.")
         }
       }
     } else {

--- a/R/SS_parlines.R
+++ b/R/SS_parlines.R
@@ -63,7 +63,7 @@ SS_parlines <- function(ctlfile = "control.ss_new", dir = NULL,
   rm(raw)
   ctl <- ctl[!grepl("blocks_per_pattern", ctl[, 8]), ]
   nrows <- nrow(ctl)
-  # print(nrows)
+
   ctl_num <- matrix(NA, nrows, ncol(ctl)) # copy of ctl converted to numerical values or NA
   num_cnt <- rep(NA, nrows) # count of number of numerical values in each row
   num_cnt7 <- rep(NA, nrows) # count of number of numerical values in first 7 values of each row

--- a/R/SS_plots.R
+++ b/R/SS_plots.R
@@ -41,8 +41,6 @@
 #'   \item Diagnostic tables
 #' }
 #'
-#' @param print Deprecated input for backward compatibility, now replaced by
-#' `png = TRUE/FALSE`.
 #' @param pdf Send plots to PDF file instead of R GUI?
 #' @param png Send plots to PNG files instead of R GUI?
 #' @param html Run [SS_html()] on completion? By default has same
@@ -221,7 +219,7 @@
 #' dynamics in declining and recovering fish populations. Can. J. Fish. Aquat.
 #' Sci. 65: 2536-2551.
 SS_plots <-
-  function(replist = NULL, plot = 1:26, print = NULL, pdf = FALSE, png = TRUE, html = png,
+  function(replist = NULL, plot = 1:26, pdf = FALSE, png = TRUE, html = png,
            printfolder = "plots", dir = "default", fleets = "all", areas = "all",
            fleetnames = "default", fleetcols = "default", fleetlty = 1, fleetpch = 1,
            lwd = 1, areacols = "default", areanames = "default",
@@ -244,12 +242,7 @@ SS_plots <-
            scalebubbles = FALSE, tslabels = NULL, catlabels = NULL, maxsize = 1.0,
            showmle = TRUE, showpost = TRUE, showprior = TRUE, showinit = TRUE, showdev = FALSE,
            fitrange = FALSE, ...) {
-    if (!is.null(print)) {
-      stop(
-        "The 'print' input has been replaced by 'png = TRUE/FALSE'\n",
-        "  which is combined with the vector of numbers input to 'plot'"
-      )
-    }
+
     flush.console()
 
     # label table is a step toward internationalization of the code

--- a/R/SS_profile.R
+++ b/R/SS_profile.R
@@ -308,15 +308,16 @@ SS_profile <-
         stop("input whichruns should be NULL or a subset of 1:", n, "\n", sep = "")
       }
     }
-    cat("doing runs: ", paste(whichruns, collapse = ","), ",\n  out of n=", n, "\n", sep = "")
+    message("Doing runs: ", paste(whichruns, collapse = ", "), 
+      ",\n  out of n = ", n)
+
 
     converged <- rep(NA, n)
     totallike <- rep(NA, n)
     liketable <- NULL
 
-    cat("changing working directory to ", dir, ",\n",
-      " but will be changed back on exit from function.\n",
-      sep = ""
+    message("Changing working directory to ", dir, ",\n",
+      " but will be changed back on exit from function."
     )
     setwd(dir) # change working directory
     stdfile <- paste(model, ".std", sep = "")
@@ -358,12 +359,11 @@ SS_profile <-
       # then don't bother running anything
       newrepfile <- paste("Report", i, ".sso", sep = "")
       if (!overwrite & file.exists(newrepfile)) {
-        cat("skipping profile i=", i, "/", n, " because overwrite=FALSE\n",
-          "  and file exists: ", newrepfile, "\n",
-          sep = ""
+        message("skipping profile i=", i, "/", n, " because overwrite=FALSE\n",
+          "  and file exists: ", newrepfile
         )
       } else {
-        cat("running profile i=", i, "/", n, "\n", sep = "")
+        message("running profile i=", i, "/", n)
 
         # change initial values in the control file
         # this also sets phase negative which is needed even when par file is used
@@ -446,8 +446,8 @@ SS_profile <-
         # run model
         command <- paste(model, extras)
         if (OS != "windows") command <- paste("./", command, sep = "")
-        cat("Running model in directory:", getwd(), "\n")
-        cat("Using the command: '", command, "'\n", sep = "")
+        message("Running model in directory:", getwd())
+        message("Using the command: ", command)
         if (OS == "windows" & !systemcmd) {
           shell(cmd = command)
         } else {

--- a/R/SS_profile.R
+++ b/R/SS_profile.R
@@ -291,11 +291,11 @@ SS_profile <-
       }
 
       if (verbose) {
-        message("Profiling over ", npars, "parameters")
         if (!is.null(string)) {
           profilevec_df <- data.frame(profilevec)
           names(profilevec_df) <- string
-          print(profilevec_df)
+          message("Profiling over ", npars, " parameters\n", 
+          paste0(profilevec_df, collapse = "\n"))
         }
       }
     }
@@ -431,7 +431,7 @@ SS_profile <-
             paste("# changed from", parval, "to", profilevec[i])
           )
           par <- c(par, "#", note)
-          print(note)
+          message(paste0(note, collapse = "\n"))
           # write new par file
           writeLines(par, paste0(parfile, "_input_", i, ".ss"))
           writeLines(par, parfile)

--- a/R/SS_readctl.R
+++ b/R/SS_readctl.R
@@ -108,9 +108,6 @@ SS_readctl <- function(file,
 
   nver <- as.numeric(substring(version, 1, 4))
 
-  if (verbose) cat("Char version is ", version, "\n")
-  if (verbose) cat("Numeric version is ", nver, "\n")
-
   # call function for SS version 2.00
   if (nver < 3) {
     stop("Function SS_readctl_2.00 has not been written yet")

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -102,8 +102,8 @@ SS_readctl_3.24 <- function(file,
     }
     if (!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
     if (verbose) {
-      message(name, ", i = ", ctllist$".i", "\n")
-      print(ctllist[name])
+      message(name, ", i = ", ctllist$".i", "\n", paste0(ctllist[name], 
+        collapse = "\n"))
     }
     return(ctllist)
   }
@@ -127,8 +127,8 @@ SS_readctl_3.24 <- function(file,
     ctllist$".i" <- i
     if (!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
     if (verbose) {
-      message(name, ", i = ", ctllist$".i", "\n")
-      print(ctllist[[which(names(ctllist) == name)]])
+      message(name, ", i = ", ctllist$".i", "\n", 
+        paste0(ctllist[[which(names(ctllist) == name)]], collapse = "\n"))
     }
     return(ctllist)
   }
@@ -1047,12 +1047,7 @@ SS_readctl_3.24 <- function(file,
       }
   }
   if (verbose) {
-    message("size_selex_Nparms\n")
-    print(size_selex_Nparms)
-  }
-  if (verbose) {
-    message("age_selex_Nparms\n")
-    print(age_selex_Nparms)
+    message("Read size and age selectivity setup")
   }
   # Selex parlines ----
   # _LO HI INIT PRIOR PR_type SD PHASE env-var use_dev dev_minyr dev_maxyr dev_stddev Block Block_Fxn

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -57,7 +57,9 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
 
   # function to read Stock Synthesis data files
 
-  if (verbose) cat("running SS_readctl_3.30\n")
+  if (verbose) {
+    message("running SS_readctl_3.30")
+  }
   dat <- readLines(file, warn = FALSE)
   ctl_with_cmts <- dat # save original read in file with commemts
   Comments <- get_comments(dat)
@@ -100,8 +102,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     }
     if (!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
     if (verbose) {
-      cat(name, ",i=", ctllist$".i", "\n")
-      print(ctllist[name])
+      message(name, ", i=", ctllist$".i")
     }
     return(ctllist)
   }
@@ -158,8 +159,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     ctllist$".i" <- i
     if (!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
     if (verbose) {
-      cat(name, ",i=", ctllist$".i", "\n")
-      print(ctllist[[which(names(ctllist) == name)]])
+      message(name, ",i=", ctllist$".i")
     }
     return(ctllist)
   }
@@ -172,7 +172,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     ctllist[["temp"]] <- dat[i]
     ctllist$".i" <- i + 1
     if (!is.na(name)) names(ctllist)[names(ctllist) == "temp"] <- name
-    if (verbose) cat(name, ",i=", ctllist$".i", " ;", ctllist[[which(names(ctllist) == name)]], "\n")
+    if (verbose) message(name, ",i=", ctllist$".i", " ;", ctllist[[which(names(ctllist) == name)]])
     return(ctllist)
   }
 
@@ -187,7 +187,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     }
     ctllist$".i" <- i
     if (!is.null(name)) names(ctllist)[names(ctllist) == "temp"] <- name
-    if (verbose) cat(name, ",i=", ctllist$".i", "\n")
+    if (verbose) message(name, ",i=", ctllist$".i")
     return(ctllist)
   }
 
@@ -269,7 +269,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
 
   ctllist[["eof"]] <- FALSE
 
-  if (verbose) cat("SS_readctl_3.30 - read version = ", ctllist[["ReadVersion"]], "\n")
+  if (verbose) message("SS_readctl_3.30 - read version = ", ctllist[["ReadVersion"]])
   # beginning of ctl ----
   # weight at age option
   ctllist <- add_elem(ctllist, "EmpiricalWAA")
@@ -727,7 +727,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     # Ricker SRR reparam beta
     c("SR_LN(R0)", "SR_Ricker_re_steep", "SR_Ricker_re_power", "SR_sigmaR", "SR_regime", "SR_autocorr")
   } else {
-    cat("SR_function=", ctllist[["SR_function"]], " is not supported yet.")
+    message("SR_function=", ctllist[["SR_function"]], " is not supported yet.")
     return(ctllist)
   }
 
@@ -1276,9 +1276,9 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     }
   }
   if (verbose) {
-    cat("size_selex_Nparms\n")
+    message("size_selex_Nparms")
     print(unlist(lapply(size_selex_label, function(x) length(x))))
-    cat("age_selex_Nparms\n")
+    message("age_selex_Nparms")
     print(unlist(lapply(age_selex_label, function(x) length(x))))
   }
   # Selex parameters

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1276,10 +1276,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     }
   }
   if (verbose) {
-    message("size_selex_Nparms")
-    print(unlist(lapply(size_selex_label, function(x) length(x))))
-    message("age_selex_Nparms")
-    print(unlist(lapply(age_selex_label, function(x) length(x))))
+    message("Read size and age selectivity setup.")
   }
   # Selex parameters
   if (sum(length(unlist(size_selex_label))) > 0) {

--- a/R/SS_readdat.R
+++ b/R/SS_readdat.R
@@ -44,8 +44,6 @@ SS_readdat <- function(file,
     version <- "3.30"
   }
   nver <- as.numeric(substring(version, 1, 4))
-  if (verbose) cat("Char version is ", version, "\n")
-  if (verbose) cat("Numeric version is ", nver, "\n")
 
   # call function for SS version 2.00 ----
   if (nver < 3) {

--- a/R/SS_readdat_2.00.R
+++ b/R/SS_readdat_2.00.R
@@ -31,7 +31,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
     )
   }
 
-  if (verbose) cat("running SS_readdat_2.00\n")
+  if (verbose) message("running SS_readdat_2.00")
   dat <- readLines(file, warn = FALSE)
 
   # split apart any bootstrap or expected value sections in data.ss_new
@@ -138,7 +138,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   } else {
     fleetnames <- "fleet1"
   }
-  # if(verbose) cat("fleetnames:",fleetnames,'\n')
+
   datlist[["fleetnames"]] <- fleetnames
   datlist[["surveytiming"]] <- surveytiming <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
@@ -146,15 +146,16 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   datlist[["areas"]] <- 1
   areas <- datlist[["areas"]]
   if (verbose) {
-    cat("areas:", areas, "\n")
-    cat("fleet info:\n")
-    print(data.frame(
+    message("areas:", areas)
+    message("fleet info:\n", paste0(capture.output(
+      data.frame(
       fleet = 1:Ntypes,
       name = fleetnames,
       area = areas,
       timing = surveytiming,
       type = c(rep("FISHERY", Nfleet), rep("SURVEY", Nsurveys))
-    ))
+    )), collapse = "\n"))
+
   }
 
   # fleet info
@@ -162,10 +163,6 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   names(fleetinfo1) <- fleetnames
   fleetinfo1[["input"]] <- c("#_surveytiming", "#_areas")
   datlist[["fleetinfo1"]] <- fleetinfo1
-  ## if(verbose){
-  ##   cat("fleetinfo1:\n")
-  ##   print(t(fleetinfo1))
-  ## }
 
   # more dimensions
   datlist[["Nsexes"]] <- allnums[i]
@@ -180,7 +177,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   N_catch <- datlist[["endyr"]] - datlist[["styr"]] + 1
 
   # catch
-  if (verbose) cat("N_catch =", N_catch, "\n")
+  if (verbose) message("N_catch =", N_catch)
   Nvals <- N_catch * (Nfleet)
   catch <- data.frame(matrix(allnums[i:(i + Nvals - 1)],
     nrow = N_catch, ncol = (Nfleet), byrow = TRUE
@@ -199,7 +196,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   # CPUE
   datlist[["N_cpue"]] <- N_cpue <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_cpue =", N_cpue, "\n")
+  if (verbose) message("N_cpue =", N_cpue)
   if (N_cpue > 0) {
     CPUEinfo <- data.frame(matrix(c(1:Ntypes, rep(1, Ntypes), rep(0, Ntypes)),
       nrow = Ntypes, ncol = 3, byrow = FALSE
@@ -230,7 +227,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   datlist[["N_discard"]] <- N_discard <- allnums[i]
   i <- i + 1
 
-  if (verbose) cat("N_discard =", N_discard, "\n")
+  if (verbose) message("N_discard =", N_discard)
   if (N_discard > 0) {
     # discard data
     Ncols <- 5
@@ -262,7 +259,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   # meanbodywt
   datlist[["N_meanbodywt"]] <- N_meanbodywt <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_meanbodywt =", N_meanbodywt, "\n")
+  if (verbose) message("N_meanbodywt =", N_meanbodywt)
 
 
   if (N_meanbodywt > 0) {
@@ -277,7 +274,6 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
     # don't know if this is needed for version 2.00
     # datlist[["DF_for_meanbodywt"]] <- allnums[i]
     # i <- i+1
-    # if(echoall) cat("DF_for_meanbodywt =",datlist[["DF_for_meanbodywt"]],"\n")
     datlist[["DF_for_meanbodywt"]] <- NULL
   } else {
     datlist[["DF_for_meanbodywt"]] <- NULL
@@ -306,8 +302,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   datlist[["N_lencomp"]] <- N_lencomp <- allnums[i]
   i <- i + 1
 
-  # if(verbose) cat(datlist[-15:0 + length(datlist)])
-  if (verbose) cat("N_lencomp =", N_lencomp, "\n")
+  if (verbose) message("N_lencomp =", N_lencomp)
 
   if (N_lencomp > 0) {
     Ncols <- N_lbins * datlist[["Nsexes"]] + 6
@@ -337,7 +332,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   # age data
   datlist[["N_agebins"]] <- N_agebins <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_agebins =", N_agebins, "\n")
+  if (verbose) message("N_agebins =", N_agebins)
   if (N_agebins > 0) {
     agebin_vector <- allnums[i:(i + N_agebins - 1)]
     i <- i + N_agebins
@@ -364,7 +359,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
 
   datlist[["N_agecomp"]] <- N_agecomp <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_agecomp =", N_agecomp, "\n")
+  if (verbose) message("N_agecomp =", N_agecomp)
 
   datlist[["Lbin_method"]] <- NULL
   datlist[["max_combined_lbin"]] <- NULL
@@ -398,7 +393,7 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   # MeanSize_at_Age
   datlist[["N_MeanSize_at_Age_obs"]] <- N_MeanSize_at_Age_obs <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_MeanSize_at_Age_obs =", N_MeanSize_at_Age_obs, "\n")
+  if (verbose) message("N_MeanSize_at_Age_obs =", N_MeanSize_at_Age_obs)
   if (N_MeanSize_at_Age_obs > 0) {
     Ncols <- 2 * N_agebins * datlist[["Nsexes"]] + 7
     MeanSize_at_Age_obs <- data.frame(matrix(
@@ -453,10 +448,10 @@ SS_readdat_2.00 <- function(file, verbose = TRUE,
   datlist[["envdat"]] <- envdat
 
   if (allnums[i] == 999) {
-    if (verbose) cat("read of data file 2.00 complete (final value = 999)\n")
+    if (verbose) message("read of data file 2.00 complete (final value = 999)")
     datlist[["eof"]] <- TRUE
   } else {
-    cat("Error: final value is", allnums[i], " but should be 999\n")
+    stop("final value is", allnums[i], " but should be 999")
     datlist[["eof"]] <- FALSE
   }
 

--- a/R/SS_readdat_3.00.R
+++ b/R/SS_readdat_3.00.R
@@ -31,7 +31,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     )
   }
 
-  if (verbose) cat("running SS_readdat_3.00\n")
+  if (verbose) message("running SS_readdat_3.00")
   dat <- readLines(file, warn = FALSE)
 
   # split apart any bootstrap or expected value sections in data.ss_new
@@ -134,32 +134,28 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     fleetnames <- "fleet1"
   }
 
-  # if(verbose) cat("fleetnames:",fleetnames,'\n')
   datlist[["fleetnames"]] <- fleetnames
   datlist[["surveytiming"]] <- surveytiming <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
   datlist[["areas"]] <- areas <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
   if (verbose) {
-    cat("areas:", areas, "\n")
-    cat("fleet info:\n")
-    print(data.frame(
+    message("areas:", areas)
+    message("fleet info:\n", paste0(capture.output(
+      data.frame(
       fleet = 1:Ntypes,
       name = fleetnames,
       area = areas,
       timing = surveytiming,
       type = c(rep("FISHERY", Nfleet), rep("SURVEY", Nsurveys))
-    ))
+      )), collapse = "\n")
+    )
   }
   # fleet info
   fleetinfo1 <- data.frame(rbind(surveytiming, areas))
   names(fleetinfo1) <- fleetnames
   fleetinfo1[["input"]] <- c("#_surveytiming", "#_areas")
   datlist[["fleetinfo1"]] <- fleetinfo1
-  ## if(verbose){
-  ##   cat("fleetinfo1:\n")
-  ##   print(t(fleetinfo1))
-  ## }
 
   datlist[["units_of_catch"]] <- units_of_catch <- allnums[i:(i + Nfleet - 1)]
   i <- i + Nfleet
@@ -169,10 +165,6 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   names(fleetinfo2) <- fleetnames[1:Nfleet]
   fleetinfo2[["input"]] <- c("#_units_of_catch", "#_se_log_catch")
   datlist[["fleetinfo2"]] <- fleetinfo2
-  ## if(verbose){
-  ##   cat("fleetinfo2:\n")
-  ##   print(t(fleetinfo2))
-  ## }
 
 
   # more dimensions
@@ -187,7 +179,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   # catch
   datlist[["N_catch"]] <- N_catch <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_catch =", N_catch, "\n")
+  if (verbose) message("N_catch =", N_catch)
   Nvals <- N_catch * (Nfleet + 2)
   catch <- data.frame(matrix(allnums[i:(i + Nvals - 1)],
     nrow = N_catch, ncol = (Nfleet + 2), byrow = TRUE
@@ -199,7 +191,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["N_cpue"]] <- N_cpue <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_cpue =", N_cpue, "\n")
+  if (verbose) message("N_cpue =", N_cpue)
   if (N_cpue > 0) {
     CPUEinfo <- data.frame(matrix(c(1:Ntypes, rep(1, Ntypes), rep(0, Ntypes)),
       nrow = Ntypes, ncol = 3, byrow = FALSE
@@ -230,7 +222,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   datlist[["N_discard"]] <- N_discard <- allnums[i]
   i <- i + 1
 
-  if (verbose) cat("N_discard =", N_discard, "\n")
+  if (verbose) message("N_discard =", N_discard)
   if (N_discard > 0) {
     # discard data
     Ncols <- 5
@@ -262,7 +254,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   # meanbodywt
   datlist[["N_meanbodywt"]] <- N_meanbodywt <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_meanbodywt =", N_meanbodywt, "\n")
+  if (verbose) message("N_meanbodywt =", N_meanbodywt, "\n")
 
 
   if (N_meanbodywt > 0) {
@@ -277,7 +269,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     # don't know if this is needed for version 2.00
     # datlist[["DF_for_meanbodywt"]] <- allnums[i]
     # i <- i+1
-    # if(verbose) cat("DF_for_meanbodywt =",datlist[["DF_for_meanbodywt"]],"\n")
+
     datlist[["DF_for_meanbodywt"]] <- NULL
   } else {
     datlist[["DF_for_meanbodywt"]] <- NULL
@@ -288,7 +280,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["lbin_method"]] <- lbin_method <- allnums[i]
   i <- i + 1
-  if (verbose) cat("lbin_method =", lbin_method, "\n")
+  if (verbose) message("lbin_method =", lbin_method)
   if (lbin_method == 2) {
     datlist[["binwidth"]] <- allnums[i]
     i <- i + 1
@@ -296,7 +288,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     i <- i + 1
     datlist[["maximum_size"]] <- allnums[i]
     i <- i + 1
-    if (verbose) cat("bin width, min, max =", datlist[["binwidth"]], ", ", datlist[["minimum_size"]], ", ", datlist[["maximum_size"]], "\n")
+    if (verbose) message("bin width, min, max =", datlist[["binwidth"]], ", ", datlist[["minimum_size"]], ", ", datlist[["maximum_size"]])
   } else {
     datlist[["binwidth"]] <- NA
     datlist[["minimum_size"]] <- NA
@@ -307,7 +299,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     i <- i + 1
     datlist[["lbin_vector_pop"]] <- allnums[i:(i + N_lbinspop - 1)]
     i <- i + N_lbinspop
-    if (verbose) cat("N_lbinspop =", N_lbinspop, "\nlbin_vector_pop:\n")
+    if (verbose) message("N_lbinspop =", N_lbinspop, "\nlbin_vector_pop:\n")
   } else {
     datlist[["N_lbinspop"]] <- NA
     datlist[["lbin_vector_pop"]] <- NA
@@ -331,8 +323,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   datlist[["N_lencomp"]] <- N_lencomp <- allnums[i]
   i <- i + 1
 
-  # if(verbose) cat(datlist[-15:0 + length(datlist)])
-  if (verbose) cat("N_lencomp =", N_lencomp, "\n")
+  if (verbose) message("N_lencomp =", N_lencomp)
 
   if (N_lencomp > 0) {
     Ncols <- N_lbins * datlist[["Nsexes"]] + 6
@@ -362,7 +353,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   # age data
   datlist[["N_agebins"]] <- N_agebins <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_agebins =", N_agebins, "\n")
+  if (verbose) message("N_agebins =", N_agebins, "\n")
   if (N_agebins > 0) {
     agebin_vector <- allnums[i:(i + N_agebins - 1)]
     i <- i + N_agebins
@@ -389,7 +380,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["N_agecomp"]] <- N_agecomp <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_agecomp =", N_agecomp, "\n")
+  if (verbose) message("N_agecomp =", N_agecomp)
 
   datlist[["Lbin_method"]] <- allnums[i]
   i <- i + 1
@@ -424,7 +415,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
   # MeanSize_at_Age
   datlist[["N_MeanSize_at_Age_obs"]] <- N_MeanSize_at_Age_obs <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_MeanSize_at_Age_obs =", N_MeanSize_at_Age_obs, "\n")
+  if (verbose) message("N_MeanSize_at_Age_obs =", N_MeanSize_at_Age_obs)
   if (N_MeanSize_at_Age_obs > 0) {
     Ncols <- 2 * N_agebins * datlist[["Nsexes"]] + 7
     MeanSize_at_Age_obs <- data.frame(matrix(
@@ -480,7 +471,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["N_sizefreq_methods"]] <- N_sizefreq_methods <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_sizefreq_methods =", N_sizefreq_methods, "\n")
+  if (verbose) message("N_sizefreq_methods =", N_sizefreq_methods)
   if (N_sizefreq_methods > 0) {
     # get details of generalized size frequency methods
     datlist[["nbins_per_method"]] <- nbins_per_method <- allnums[i:(i + N_sizefreq_methods - 1)]
@@ -494,15 +485,16 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
     datlist[["Nobs_per_method"]] <- Nobs_per_method <- allnums[i:(i + N_sizefreq_methods - 1)]
     i <- i + N_sizefreq_methods
     if (verbose) {
-      cat("details of generalized size frequency methods:\n")
-      print(data.frame(
-        method = 1:N_sizefreq_methods,
-        nbins = nbins_per_method,
-        units = units_per_method,
-        scale = scale_per_method,
-        mincomp = mincomp_per_method,
-        nobs = Nobs_per_method
-      ))
+      message("details of generalized size frequency methods:\n", 
+        paste0(capture.output(data.frame(
+          method = 1:N_sizefreq_methods,
+          nbins = nbins_per_method,
+          units = units_per_method,
+          scale = scale_per_method,
+          mincomp = mincomp_per_method,
+          nobs = Nobs_per_method
+        )), collapse = "\n")
+      )
     }
     # get list of bin vectors
     sizefreq_bins_list <- list()
@@ -537,7 +529,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
           }
         )
       if (verbose) {
-        cat("Method =", imethod, "  (first two rows, ten columns):\n")
+        message("Method =", imethod, "  (first two rows, ten columns):\n")
         print(sizefreq_data_tmp[1:min(Nrows, 2), 1:min(Ncols, 10)])
       }
       if (any(sizefreq_data_tmp[["Method"]] != imethod)) {
@@ -563,7 +555,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["do_tags"]] <- do_tags <- allnums[i]
   i <- i + 1
-  if (verbose) cat("do_tags =", do_tags, "\n")
+  if (verbose) message("do_tags =", do_tags)
 
   if (do_tags != 0) {
     datlist[["N_tag_groups"]] <- N_tag_groups <- allnums[i]
@@ -582,7 +574,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
       i <- i + N_tag_groups * Ncols
       names(tag_releases) <- c("TG", "Area", "Yr", "Season", "tfill", "Gender", "Age", "Nrelease")
       if (verbose) {
-        cat("Head of tag release data:\n")
+        message("Head of tag release data:\n")
         print(head(tag_releases))
       }
     } else {
@@ -597,7 +589,7 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
       i <- i + N_recap_events * Ncols
       names(tag_recaps) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
       if (verbose) {
-        cat("Head of tag recapture data:\n")
+        message("Head of tag recapture data:\n")
         print(head(tag_recaps))
       }
     } else {
@@ -608,13 +600,13 @@ SS_readdat_3.00 <- function(file, verbose = TRUE,
 
   datlist[["morphcomp_data"]] <- do_morphcomps <- allnums[i]
   i <- i + 1
-  if (verbose) cat("do_morphcomps =", do_morphcomps, "\n")
+  if (verbose) message("do_morphcomps =", do_morphcomps)
 
   if (allnums[i] == 999) {
-    if (verbose) cat("read of data file 3.00 complete (final value = 999)\n")
+    if (verbose) message("read of data file 3.00 complete (final value = 999)\n")
     datlist[["eof"]] <- TRUE
   } else {
-    cat("Error: final value is", allnums[i], " but should be 999\n")
+    message("Error: final value is", allnums[i], " but should be 999\n")
     datlist[["eof"]] <- FALSE
   }
 

--- a/R/SS_readdat_3.24.R
+++ b/R/SS_readdat_3.24.R
@@ -25,7 +25,7 @@
 SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NULL) {
   # function to read Stock Synthesis data files
 
-  if (verbose) cat("running SS_readdat_3.24\n")
+  if (verbose) message("running SS_readdat_3.24")
   dat <- readLines(file, warn = FALSE)
 
   # split apart any bootstrap or expected value sections in data.ss_new
@@ -124,32 +124,29 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   } else {
     fleetnames <- "fleet1"
   }
-  # if(verbose) cat("fleetnames:",fleetnames,'\n')
   datlist[["fleetnames"]] <- fleetnames
   datlist[["surveytiming"]] <- surveytiming <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
   datlist[["areas"]] <- areas <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
   if (verbose) {
-    cat("areas:", areas, "\n")
-    cat("fleet info:\n")
-    print(data.frame(
+    message("areas:", areas)
+    message("fleet info:\n", paste0(capture.output(
+      data.frame(
       fleet = 1:Ntypes,
       name = fleetnames,
       area = areas,
       timing = surveytiming,
       type = c(rep("FISHERY", Nfleet), rep("SURVEY", Nsurveys))
-    ))
+    )
+    ), collapse = "\n"))
   }
   # fleet info
   fleetinfo1 <- data.frame(rbind(surveytiming, areas))
   names(fleetinfo1) <- fleetnames
   fleetinfo1[["input"]] <- c("#_surveytiming", "#_areas")
   datlist[["fleetinfo1"]] <- fleetinfo1
-  ## if(verbose){
-  ##   cat("fleetinfo1:\n")
-  ##   print(t(fleetinfo1))
-  ## }
+
 
   datlist[["units_of_catch"]] <- units_of_catch <- allnums[i:(i + Nfleet - 1)]
   i <- i + Nfleet
@@ -159,10 +156,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   names(fleetinfo2) <- fleetnames[1:Nfleet]
   fleetinfo2[["input"]] <- c("#_units_of_catch", "#_se_log_catch")
   datlist[["fleetinfo2"]] <- fleetinfo2
-  ## if(verbose){
-  ##   cat("fleetinfo2:\n")
-  ##   print(t(fleetinfo2))
-  ## }
+
 
 
   # more dimensions
@@ -176,7 +170,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   # catch
   datlist[["N_catch"]] <- N_catch <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_catch =", N_catch, "\n")
+  if (verbose) message("N_catch =", N_catch)
   Nvals <- N_catch * (Nfleet + 2)
   catch <- data.frame(matrix(allnums[i:(i + Nvals - 1)],
     nrow = N_catch, ncol = (Nfleet + 2), byrow = TRUE
@@ -189,7 +183,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   # CPUE
   datlist[["N_cpue"]] <- N_cpue <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_cpue =", N_cpue, "\n")
+  if (verbose) message("N_cpue =", N_cpue)
   CPUEinfo <- data.frame(matrix(allnums[i:(i + Ntypes * 3 - 1)],
     nrow = Ntypes, ncol = 3, byrow = TRUE
   ))
@@ -216,7 +210,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   # datlist[["discard_units"]] <- discard_units <- allnums[i]; i <- i+1
   datlist[["N_discard_fleets"]] <- N_discard_fleets <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_discard_fleets =", N_discard_fleets, "\n")
+  if (verbose) message("N_discard_fleets =", N_discard_fleets)
   N_discard <- 0 # temporarily set to 0
   if (N_discard_fleets > 0) {
     # fleet info
@@ -232,7 +226,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   }
   datlist[["N_discard"]] <- N_discard <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_discard =", N_discard, "\n")
+  if (verbose) message("N_discard =", N_discard)
   if (N_discard > 0) {
     # discard data
     Ncols <- 5
@@ -251,10 +245,10 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   # meanbodywt
   datlist[["N_meanbodywt"]] <- N_meanbodywt <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_meanbodywt =", N_meanbodywt, "\n")
+  if (verbose) message("N_meanbodywt =", N_meanbodywt)
   datlist[["DF_for_meanbodywt"]] <- allnums[i]
   i <- i + 1
-  if (echoall) cat("DF_for_meanbodywt =", datlist[["DF_for_meanbodywt"]], "\n")
+  if (echoall) message("DF_for_meanbodywt =", datlist[["DF_for_meanbodywt"]])
 
   if (N_meanbodywt > 0) {
     Ncols <- 6
@@ -273,7 +267,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   # length data
   datlist[["lbin_method"]] <- lbin_method <- allnums[i]
   i <- i + 1
-  if (echoall) cat("lbin_method =", lbin_method, "\n")
+  if (echoall) message("lbin_method =", lbin_method)
   if (lbin_method == 2) {
     datlist[["binwidth"]] <- allnums[i]
     i <- i + 1
@@ -281,7 +275,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
     i <- i + 1
     datlist[["maximum_size"]] <- allnums[i]
     i <- i + 1
-    if (echoall) cat("bin width, min, max =", datlist[["binwidth"]], ", ", datlist[["minimum_size"]], ", ", datlist[["maximum_size"]], "\n")
+    if (echoall) message("bin width, min, max =", datlist[["binwidth"]], ", ", datlist[["minimum_size"]], ", ", datlist[["maximum_size"]])
   } else {
     datlist[["binwidth"]] <- NA
     datlist[["minimum_size"]] <- NA
@@ -292,7 +286,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
     i <- i + 1
     datlist[["lbin_vector_pop"]] <- allnums[i:(i + N_lbinspop - 1)]
     i <- i + N_lbinspop
-    if (echoall) cat("N_lbinspop =", N_lbinspop, "\nlbin_vector_pop:\n")
+    if (echoall) message("N_lbinspop =", N_lbinspop, "\nlbin_vector_pop:")
   } else {
     datlist[["N_lbinspop"]] <- NA
     datlist[["lbin_vector_pop"]] <- NA
@@ -313,8 +307,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   datlist[["N_lencomp"]] <- N_lencomp <- allnums[i]
   i <- i + 1
 
-  # if(verbose) cat(datlist[-15:0 + length(datlist)])
-  if (verbose) cat("N_lencomp =", N_lencomp, "\n")
+  if (verbose) message("N_lencomp =", N_lencomp)
 
   if (N_lencomp > 0) {
     Ncols <- N_lbins * datlist[["Nsexes"]] + 6
@@ -344,7 +337,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   # age data
   datlist[["N_agebins"]] <- N_agebins <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_agebins =", N_agebins, "\n")
+  if (verbose) message("N_agebins =", N_agebins, "\n")
   if (N_agebins > 0) {
     agebin_vector <- allnums[i:(i + N_agebins - 1)]
     i <- i + N_agebins
@@ -371,7 +364,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
 
   datlist[["N_agecomp"]] <- N_agecomp <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_agecomp =", N_agecomp, "\n")
+  if (verbose) message("N_agecomp =", N_agecomp)
 
   # note that Lbin_method below is related to the interpretation of
   # conditional age-at-length data and differs from lbin_method for the length
@@ -409,7 +402,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
   # MeanSize_at_Age
   datlist[["N_MeanSize_at_Age_obs"]] <- N_MeanSize_at_Age_obs <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_MeanSize_at_Age_obs =", N_MeanSize_at_Age_obs, "\n")
+  if (verbose) message("N_MeanSize_at_Age_obs =", N_MeanSize_at_Age_obs)
   if (N_MeanSize_at_Age_obs > 0) {
     Ncols <- 2 * N_agebins * datlist[["Nsexes"]] + 7
     MeanSize_at_Age_obs <- data.frame(matrix(
@@ -465,7 +458,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
 
   datlist[["N_sizefreq_methods"]] <- N_sizefreq_methods <- allnums[i]
   i <- i + 1
-  if (verbose) cat("N_sizefreq_methods =", N_sizefreq_methods, "\n")
+  if (verbose) message("N_sizefreq_methods =", N_sizefreq_methods)
   if (N_sizefreq_methods > 0) {
     # get details of generalized size frequency methods
     datlist[["nbins_per_method"]] <- nbins_per_method <- allnums[i:(i + N_sizefreq_methods - 1)]
@@ -479,7 +472,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
     datlist[["Nobs_per_method"]] <- Nobs_per_method <- allnums[i:(i + N_sizefreq_methods - 1)]
     i <- i + N_sizefreq_methods
     if (verbose) {
-      cat("details of generalized size frequency methods:\n")
+      message("details of generalized size frequency methods:\n")
       print(data.frame(
         method = 1:N_sizefreq_methods,
         nbins = nbins_per_method,
@@ -522,7 +515,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
           }
         )
       if (verbose) {
-        cat("Method =", imethod, "  (first two rows, ten columns):\n")
+        message("Method =", imethod, "  (first two rows, ten columns):\n")
         print(sizefreq_data_tmp[1:min(Nrows, 2), 1:min(Ncols, 10)])
       }
       if (any(sizefreq_data_tmp[["Method"]] != imethod)) {
@@ -548,7 +541,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
 
   datlist[["do_tags"]] <- do_tags <- allnums[i]
   i <- i + 1
-  if (verbose) cat("do_tags =", do_tags, "\n")
+  if (verbose) message("do_tags =", do_tags)
 
   if (do_tags != 0) {
     datlist[["N_tag_groups"]] <- N_tag_groups <- allnums[i]
@@ -567,7 +560,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
       i <- i + N_tag_groups * Ncols
       names(tag_releases) <- c("TG", "Area", "Yr", "Season", "tfill", "Gender", "Age", "Nrelease")
       if (verbose) {
-        cat("Head of tag release data:\n")
+        message("Head of tag release data:\n")
         print(head(tag_releases))
       }
     } else {
@@ -582,7 +575,7 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
       i <- i + N_recap_events * Ncols
       names(tag_recaps) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
       if (verbose) {
-        cat("Head of tag recapture data:\n")
+        message("Head of tag recapture data:")
         print(head(tag_recaps))
       }
     } else {
@@ -593,12 +586,12 @@ SS_readdat_3.24 <- function(file, verbose = TRUE, echoall = FALSE, section = NUL
 
   datlist[["morphcomp_data"]] <- do_morphcomps <- allnums[i]
   i <- i + 1
-  if (verbose) cat("do_morphcomps =", do_morphcomps, "\n")
+  if (verbose) message("do_morphcomps =", do_morphcomps)
 
   if (allnums[i] == 999) {
-    if (verbose) cat("read of data file complete (final value = 999)\n")
+    if (verbose) message("read of data file complete (final value = 999)")
   } else {
-    cat("Error: final value is", allnums[i], " but should be 999\n")
+    stop("Final value is", allnums[i], " but should be 999")
   }
 
   # get fleet info

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -433,7 +433,6 @@ SS_readdat_3.30 <-
         print(head(datlist[["lencomp"]], 2))
         message("\nLast 2 rows of lencomp:")
         print(tail(datlist[["lencomp"]], 2))
-        cat("\n")
       }
     }
 
@@ -540,7 +539,6 @@ SS_readdat_3.30 <-
         print(head(datlist[["agecomp"]], 2))
         message("\nLast 2 rows of agecomp:")
         print(tail(datlist[["agecomp"]], 2))
-        cat("\n")
       }
     } else {
       if (verbose) {
@@ -636,7 +634,6 @@ SS_readdat_3.30 <-
         print(head(datlist[["MeanSize_at_Age_obs"]], 2))
         message("\nLast 2 rows of MeanSize_at_Age_obs:")
         print(tail(datlist[["MeanSize_at_Age_obs"]], 2))
-        cat("\n")
       }
       # The formatting of the mean size at age in data.ss_new has sample sizes
       # on a separate line below the mean size values, and this applies to the
@@ -668,7 +665,6 @@ SS_readdat_3.30 <-
         print(head(datlist[["envdat"]], 2))
         message("\nLast 2 rows of envdat:")
         print(tail(datlist[["envdat"]], 2))
-        cat("\n")
       }
     } else {
       datlist[["envdat"]] <- NULL

--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -77,8 +77,8 @@ SS_readforecast <- function(file = "forecast.ss",
     }
     if (!is.na(name)) names(forelist)[names(forelist) == "temp"] <- name
     if (verbose) {
-      message(name, ",i=", forelist$".i")
-      print(forelist[name])
+      message(name, ",i=", forelist$".i", "\n", 
+        paste0(forelist[[name]], collapse = "\n"))
     }
     return(forelist)
   }
@@ -135,8 +135,8 @@ SS_readforecast <- function(file = "forecast.ss",
     forelist$".i" <- i
     if (!is.na(name)) names(forelist)[names(forelist) == "temp"] <- name
     if (verbose) {
-      message(name, ",i=", forelist$".i", "\n")
-      print(forelist[[which(names(forelist) == name)]])
+      message(name, ",i=", forelist$".i", "\n", 
+      paste0(forelist[[which(names(forelist) == name)]], collapse = "\n"))
     }
     return(forelist)
   }

--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -37,7 +37,7 @@ SS_readforecast <- function(file = "forecast.ss",
     }
   }
 
-  if (verbose) cat("running SS_readforecast\n")
+  if (verbose) message("running SS_readforecast")
   dat <- readLines(file, warn = FALSE)
 
   nver <- as.numeric(substring(version, 1, 4))
@@ -77,7 +77,7 @@ SS_readforecast <- function(file = "forecast.ss",
     }
     if (!is.na(name)) names(forelist)[names(forelist) == "temp"] <- name
     if (verbose) {
-      cat(name, ",i=", forelist$".i", "\n")
+      message(name, ",i=", forelist$".i")
       print(forelist[name])
     }
     return(forelist)
@@ -135,7 +135,7 @@ SS_readforecast <- function(file = "forecast.ss",
     forelist$".i" <- i
     if (!is.na(name)) names(forelist)[names(forelist) == "temp"] <- name
     if (verbose) {
-      cat(name, ",i=", forelist$".i", "\n")
+      message(name, ",i=", forelist$".i", "\n")
       print(forelist[[which(names(forelist) == name)]])
     }
     return(forelist)
@@ -149,7 +149,7 @@ SS_readforecast <- function(file = "forecast.ss",
     forelist[["temp"]] <- dat[i]
     forelist$".i" <- i + 1
     if (!is.na(name)) names(forelist)[names(forelist) == "temp"] <- name
-    if (verbose) cat(name, ",i=", forelist$".i", " ;", forelist[[which(names(forelist) == name)]], "\n")
+    if (verbose) message(name, ",i=", forelist$".i", " ;", forelist[[which(names(forelist) == name)]])
     return(forelist)
   }
 
@@ -164,7 +164,7 @@ SS_readforecast <- function(file = "forecast.ss",
     }
     forelist$".i" <- i
     if (!is.null(name)) names(forelist)[names(forelist) == "temp"] <- name
-    if (verbose) cat(name, ",i=", forelist$".i", "\n")
+    if (verbose) message(name, ",i=", forelist$".i")
     return(forelist)
   }
 
@@ -209,7 +209,7 @@ SS_readforecast <- function(file = "forecast.ss",
     forelist <- add_vec(forelist, length = 10, name = "Bmark_years")
   }
   if (verbose) {
-    cat("Benchmark years: ", forelist[["Bmark_years"]], "\n")
+    message("Benchmark years: ", forelist[["Bmark_years"]])
   }
   forelist <- add_elem(forelist, "Bmark_relF_Basis")
   forelist <- add_elem(forelist, "Forecast")
@@ -258,13 +258,13 @@ SS_readforecast <- function(file = "forecast.ss",
       forelist <- add_vec(forelist, length = 6, name = "Fcast_years")
     }
     if (verbose) {
-      cat("Forecast years: ", forelist[["Fcast_years"]], "\n")
+      message("Forecast years: ", forelist[["Fcast_years"]])
     }
 
     if (version == "3.30" | version == 3.3) {
       forelist <- add_elem(forelist, "Fcast_selex")
       if (verbose) {
-        cat("Forecast selectivity option: ", forelist[["Fcast_selex"]], "\n")
+        message("Forecast selectivity option: ", forelist[["Fcast_selex"]])
       }
     } else {
       forelist[["Fcast_selex"]] <- NA

--- a/R/SS_readpar_3.24.R
+++ b/R/SS_readpar_3.24.R
@@ -41,7 +41,7 @@ SS_readpar_3.24 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
   }
 
   # function to read Stock Synthesis parameter files
-  if (verbose) cat("running SS_readpar_3.24\n")
+  if (verbose) message("running SS_readpar_3.24")
   parvals <- readLines(parfile, warn = FALSE)
 
   parlist <- list()

--- a/R/SS_readpar_3.30.R
+++ b/R/SS_readpar_3.30.R
@@ -42,7 +42,7 @@ SS_readpar_3.30 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
   }
 
   # function to read Stock Synthesis parameter files
-  if (verbose) cat("running SS_readpar_3.30\n")
+  if (verbose) message("running SS_readpar_3.30")
   parvals <- readLines(parfile, warn = FALSE)
 
   parlist <- list()

--- a/R/SS_recdevs.R
+++ b/R/SS_recdevs.R
@@ -88,10 +88,14 @@ SS_recdevs <-
     Nrecdevs <- lyr - fyr + 1
     phase <- readfun("recdev phase", maxlen = 1)
     advanced <- readfun("advanced options", maxlen = 1)
-    if (advanced != 1) stop("advanced options must be turned on in control file")
+    if (advanced != 1) {
+      stop("advanced options must be turned on in control file")
+    }
     if (phase > 0) {
       newphase <- -abs(phase)
-      if (verbose) print(paste("making recdev phase to negative:", newphase), quote = FALSE)
+      if (verbose) {
+        message("Changing recdev phase to negative: ", newphase)
+      }
       ctl[grep("recdev phase", ctl)] <- paste(newphase, "#_recdev phase")
     }
 
@@ -102,8 +106,8 @@ SS_recdevs <-
     # check for keyword at start of following section
     key2 <- grep("Fishing Mortality info", ctl)
     if (length(key2) == 0) {
-      print("The phrase 'Fishing Mortality info' does not occur after the recdev section.", quote = FALSE)
-      print("Format of control file may be messy.", quote = FALSE)
+      warning("The phrase 'Fishing Mortality info' does not occur after the\n", 
+      "recdev section; Format of control file may be messy.")
     } else {
       key2 == key2[1]
     }
@@ -125,8 +129,8 @@ SS_recdevs <-
         scaleyrs <- yrs %in% scaleyrs
       }
       if (verbose) {
-        print(paste("rescaling recdevs vector so yrs ", min(yrs[scaleyrs]), ":", max(yrs[scaleyrs]), sep = ""), quote = FALSE)
-        print(paste("have mean 0 and std. dev. = sigmaR = ", sigmaR, sep = ""), quote = FALSE)
+        message("Rescaling recdevs vector so yrs ", min(yrs[scaleyrs]), ":",
+          max(yrs[scaleyrs]), " have mean 0 and std. dev. = sigmaR = ", sigmaR)
       }
       newdevs <- sigmaR * (newdevs - mean(newdevs[scaleyrs])) / sd(newdevs[scaleyrs])
     }
@@ -153,7 +157,9 @@ SS_recdevs <-
     # write and/or return the modified control file
     if (writectl) {
       writeLines(ctl, newctlfile)
-      if (verbose) print(paste("wrote new file:", newctlfile), quote = FALSE)
+      if (verbose) {
+        message("Wrote new file: ", newctlfile)
+      }
     }
     # reset working directory
     setwd(current_wd)

--- a/R/SS_splitdat.R
+++ b/R/SS_splitdat.R
@@ -75,7 +75,7 @@ SS_splitdat <-
       for (i in 1:length(starts)) {
         outfile <- paste(outpath, "/", outpattern, ifelse(number, i, ""), ".ss", sep = "")
         outline <- paste("# Data file created from", infile, "to", outfile)
-        if (verbose) cat(outline, "\n")
+        if (verbose) message(outline)
         writeLines(c(outline, filelines[starts[i]:ends[i]]), outfile)
       }
     } else {
@@ -83,14 +83,14 @@ SS_splitdat <-
         outfile <- paste(outpath, "/", outpattern, ".ss", sep = "")
         if (notes != "") notes <- paste("#C", notes) else notes <- NULL
         notes <- c(notes, paste("#C MLE data file created from", infile, "to", outfile))
-        if (verbose) cat("MLE data file created from", infile, "to", outfile, "\n")
+        if (verbose) message("MLE data file created from", infile, "to", outfile)
         writeLines(c(notes, filelines[MLEstart:MLEend]), outfile)
       }
       if (inputs) {
         outfile <- paste(outpath, "/", outpattern, ".ss", sep = "")
         if (notes != "") notes <- paste("#C", notes) else notes <- NULL
         notes <- c(notes, paste("#C data file created from", infile, "to", outfile))
-        if (verbose) cat("file with copies of input data created from", infile, "to", outfile, "\n")
+        if (verbose) message("file with copies of input data created from ", infile, " to ", outfile)
         writeLines(c(notes, filelines[inputstart:inputend]), outfile)
       }
     }

--- a/R/SS_varadjust.R
+++ b/R/SS_varadjust.R
@@ -144,13 +144,13 @@ SS_varadjust <- function(dir = "C:/myfiles/mymodels/myrun/",
   options(warn = old_warn)
 
   if (verbose) {
-    cat("Existing table of variance adjustments:\n")
-    print(ctl)
+    message("Existing table of variance adjustments:\n", 
+    paste0(capture.output(ctl), collapse = "\n"))
   }
 
   if (is.null(newrow) & is.null(newtable)) {
     if (verbose) {
-      cat("No new adjustments provided, so no file written.\n")
+      message("No new adjustments provided, so no file written.")
     }
     return(invisible(ctl))
   }
@@ -173,8 +173,8 @@ SS_varadjust <- function(dir = "C:/myfiles/mymodels/myrun/",
   }
 
   if (verbose) {
-    cat("New table of variance adjustments:\n")
-    print(ctl)
+    message("New table of variance adjustments:\n", 
+      paste0(capture.output(ctl), collapse = "\n"))
   }
 
   # absolute position of the rows to change
@@ -196,7 +196,7 @@ SS_varadjust <- function(dir = "C:/myfiles/mymodels/myrun/",
   }
 
   # open connection to file
-  if (verbose) cat("opening connection to", newctlfile, "\n")
+  if (verbose) message("opening connection to", newctlfile)
   zz <- file(newctlfile, open = "at")
   sink(zz)
   # change maximum number of columns
@@ -229,7 +229,7 @@ SS_varadjust <- function(dir = "C:/myfiles/mymodels/myrun/",
   sink()
   close(zz)
   if (verbose) {
-    cat("file written to", newctlfile, "\n")
+    message("file written to", newctlfile)
   }
   # return table of values
   return(invisible(ctl))

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -110,20 +110,16 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
         writeLines(paste(names(dataframe), collapse = "\t"), con = zz)
       }
       if (!is.na(headerLine)) xxx <- 2
-      #  print.data.frame(dataframe, row.names=FALSE, strip.white=TRUE,header)
       if (!is.null(rownames(dataframe))) {
         rownames(dataframe) <- sapply(rownames(dataframe), function(z) {
           ifelse(length(grep(x = z, pattern = "^#")) == 1, z, paste0("#_", z))
         })
         dataframe[["comments"]] <- rownames(dataframe)
       }
-      #     write.table(file=zz,x=dataframe,append=TRUE,sep=" ",quote=FALSE,
-      #                 row.names=FALSE,col.names=FALSE)
       write_fwf4(
         file = zz, x = dataframe, append = TRUE, sep = "\t", quote = FALSE,
         rownames = FALSE, colnames = FALSE, digits = 6
       )
-      #  write_delim(path=zz,x=dataframe,append=TRUE,delim=" ",col_names=TRUE)
     }
   }
 
@@ -491,7 +487,7 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   writeComment("#")
   writeLines("999", con = zz)
   options(width = oldwidth, max.print = oldmax.print)
-  # sink()
-  # close(zz)
-  if (verbose) message("File written to", outfile)
+  if (verbose) {
+    message("File written to ", outfile)
+  }
 }

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -19,7 +19,7 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   # these should be removed after 1 release version.
 
   # function to write Stock Synthesis ctl files
-  if (verbose) cat("running SS_writectl\n")
+  if (verbose) message("running SS_writectl")
 
   if (ctllist[["type"]] != "Stock_Synthesis_control_file") {
     stop("input 'ctllist' should be a list with $type=='Stock_Synthesis_control_file'")
@@ -27,7 +27,7 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cat("File exists and input 'overwrite'=FALSE:", outfile, "\n")
+      message("File exists and input 'overwrite'=FALSE: ", outfile)
       return()
     } else {
       file.remove(outfile)
@@ -38,7 +38,7 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   oldmax.print <- options()$max.print
   options(width = 5000, max.print = 9999999)
 
-  if (verbose) cat("opening connection to", outfile, "\n")
+  if (verbose) message("opening connection to", outfile)
   zz <- file(outfile, open = "at")
   #  on.exit({if(sink.number()>0) sink();close(zz)})
   on.exit(close(zz))
@@ -270,7 +270,6 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   # SRR
   writeComment("#_Spawner-Recruitment")
   wl("SR_function", comment = "#_SR_function: 2=Ricker; 3=std_B-H; 4=SCAA; 5=Hockey; 6=B-H_flattop; 7=survival_3Parm; 8=Shepard_3Parm")
-  # writeComment("#_LO HI INIT PRIOR PR_type SD PHASE")
   printdf("SR_parms")
   wl("SR_env_link")
   wl("SR_env_target")
@@ -280,7 +279,6 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   wl("recdev_phase", comment = "recdev phase")
   wl("recdev_adv", comment = "(0/1) to read 13 advanced options")
   if (ctllist[["recdev_adv"]]) {
-    #  cat("writing 13 advanced SRR options\n")
     wl("recdev_early_start", comment = "#_recdev_early_start (0=none; neg value makes relative to recdev_start)")
     wl("recdev_early_phase", comment = "#_recdev_early_phase")
     wl("Fcast_recr_phase", comment = "#_forecast_recruitment phase (incl. late recr) (0 value resets to maxphase+1)")
@@ -352,8 +350,10 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   # Density dependant Q(Q-power)
   if (sum(ctllist[["Q_setup"]][, 1]) > 0) {
     if (any(ctllist[["Q_setup"]][(ctllist[["Q_setup"]][, 1] > 0), 4] < 2)) {
-      cat("must create base Q parm to use Q_power for fleet: ", which(ctllist[["Q_setup"]][(ctllist[["Q_setup"]][, 1] > 0), 4] < 2))
-      stop()
+      prob_flts <- 
+        which(ctllist[["Q_setup"]][(ctllist[["Q_setup"]][, 1] > 0), 4] < 2)
+      stop("must create base Q parm to use Q_power for fleet(s): ", 
+      paste0(prob_flts, collapse = ", "))
     }
     printdf("Q_power", header = header)
     header <- FALSE
@@ -361,8 +361,8 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   # Q-env
   if (sum(ctllist[["Q_setup"]][, 2]) > 0) {
     if (any(ctllist[["Q_setup"]][(ctllist[["Q_setup"]][, 2] > 0), 4] < 2)) {
-      cat("must create base Q parm to use Q_env for fleet: ", which(ctllist[["Q_setup"]][(ctllist[["Q_setup"]][, 2] > 0), 4] < 2))
-      stop()
+      stop("must create base Q parm to use Q_env for fleet: ", 
+        which(ctllist[["Q_setup"]][(ctllist[["Q_setup"]][, 2] > 0), 4] < 2))
     }
     printdf("Q_env", header = header)
     header <- FALSE
@@ -493,5 +493,5 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   options(width = oldwidth, max.print = oldmax.print)
   # sink()
   # close(zz)
-  if (verbose) cat("file written to", outfile, "\n")
+  if (verbose) message("File written to", outfile)
 }

--- a/R/SS_writectl_3.30.R
+++ b/R/SS_writectl_3.30.R
@@ -30,7 +30,7 @@ SS_writectl_3.30 <- function(ctllist, outfile, overwrite = FALSE, verbose = FALS
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cat("File exists and input 'overwrite'=FALSE:", outfile, "\n")
+      message("File exists and input 'overwrite'=FALSE:", outfile)
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writedat_3.24.R
+++ b/R/SS_writedat_3.24.R
@@ -257,8 +257,6 @@ SS_writedat_3.24 <- function(datlist,
   wl("N_agebins")
   if (datlist[["N_agebins"]] > 0) {
     writeComment("#_agebin_vector")
-    # writeLines(paste(datlist[["agebin_vector"]],collapse=" "))
-    #  cat("L232 in SS_writedat\n")
     wl.vector("agebin_vector")
   }
   wl("N_ageerror_definitions")

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -22,7 +22,7 @@
 SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
                              writeAll = FALSE, overwrite = FALSE, verbose = TRUE) {
   # function to write Stock Synthesis forecast files
-  if (verbose) cat("running SS_writeforecast\n")
+  if (verbose) message("running SS_writeforecast")
 
   if (!is.list(mylist) || mylist[["type"]] != "Stock_Synthesis_forecast_file") {
     stop("input 'mylist' should be a list with $type=='Stock_Synthesis_forecast_file'")
@@ -41,18 +41,18 @@ SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
     if (!overwrite) {
       stop(paste("file exists:", outfile, "\n  set overwrite=TRUE to replace\n"))
     } else {
-      if (verbose) cat("overwriting file:", outfile, "\n")
+      if (verbose) message("overwriting file:", outfile)
       file.remove(outfile)
     }
   } else {
-    if (verbose) cat("writing new file:", outfile, "\n")
+    if (verbose) message("writing new file:", outfile)
   }
 
   # preliminary setup
   oldwidth <- options()$width
   options(width = 1000)
 
-  if (verbose) cat("opening connection to", outfile, "\n")
+  if (verbose) message("opening connection to", outfile)
   zz <- file(outfile, open = "at")
   sink(zz)
   wl <- function(name) {
@@ -224,5 +224,5 @@ SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
   options(width = oldwidth)
   sink()
   close(zz)
-  if (verbose) cat("file written to", outfile, "\n")
+  if (verbose) message("file written to", outfile)
 }

--- a/R/SS_writepar_3.24.R
+++ b/R/SS_writepar_3.24.R
@@ -18,11 +18,11 @@
 SS_writepar_3.24 <- function(parlist, outfile, overwrite = TRUE, verbose = FALSE) {
 
   # function to write Stock Synthesis parameter files
-  if (verbose) cat("running SS_writepar_3.24\n")
+  if (verbose) message("running SS_writepar_3.24")
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cat("File exists and input 'overwrite'=FALSE:", outfile, "\n")
+      message("File exists and input 'overwrite'=FALSE:", outfile)
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writepar_3.30.R
+++ b/R/SS_writepar_3.30.R
@@ -18,18 +18,18 @@
 SS_writepar_3.30 <- function(parlist, outfile, overwrite = TRUE, verbose = FALSE) {
 
   # function to write Stock Synthesis parameter files
-  if (verbose) cat("running SS_writepar_3.30\n")
+  if (verbose) message("running SS_writepar_3.30")
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cat("File exists and input 'overwrite'=FALSE:", outfile, "\n")
+      message("File exists and input 'overwrite'=FALSE:", outfile)
       return()
     } else {
       file.remove(outfile)
     }
   }
 
-  if (verbose) message("Opening connection to ", outfile, "\n")
+  if (verbose) message("Opening connection to ", outfile)
   zz <- file(outfile, open = "at") # open = "at" means open for appending in text mode.
   on.exit(close(zz)) # Needed in case the function exits early.
 

--- a/R/SS_writestarter.R
+++ b/R/SS_writestarter.R
@@ -25,7 +25,7 @@ SS_writestarter <- function(mylist, dir = NULL, file = "starter.ss",
       what = "SS_writestarter(warn)"
     )
   }
-  if (verbose) cat("running SS_writestarter\n")
+  if (verbose) message("running SS_writestarter")
   if (mylist[["type"]] != "Stock_Synthesis_starter_file") {
     stop("input 'mylist' should be a list with $type=='Stock_Synthesis_starter_file'\n")
   }
@@ -49,14 +49,14 @@ SS_writestarter <- function(mylist, dir = NULL, file = "starter.ss",
       file.remove(outfile)
     }
   } else {
-    if (verbose) cat("writing new file:", outfile, "\n")
+    if (verbose) message("writing new file:", outfile)
   }
 
   # record current max characters per line and then expand in case of long lines
   oldwidth <- options()$width
   options(width = 1000)
 
-  if (verbose) cat("opening connection to", outfile, "\n")
+  if (verbose) message("opening connection to", outfile)
   zz <- file(outfile, open = "at")
   sink(zz)
 
@@ -150,5 +150,5 @@ SS_writestarter <- function(mylist, dir = NULL, file = "starter.ss",
   options(width = oldwidth)
   sink()
   close(zz)
-  if (verbose) cat("file written to", outfile, "\n")
+  if (verbose) message("file written to", outfile)
 }

--- a/R/SSbootstrap.R
+++ b/R/SSbootstrap.R
@@ -26,7 +26,7 @@ SSbootstrap <- function() {
   # loop over bootstrap files
   for (iboot in 1:N) {
     # note what's happening
-    cat("\n##### Running bootstrap model number", iboot, " #########\n")
+    message("Running bootstrap model number", iboot)
 
     # change data file name in starter file
     starter[["datfile"]] <- paste("BootData", iboot, ".ss", sep = "")

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -34,15 +34,15 @@ SSgetoutput <-
     # a function to run the function SS_output to create a list in the R workspace
     # for a Stock Synthesis model with output filenames ending with the same "key"
 
-    if (!is.null(keyvec) & verbose) cat("length(keyvec) as input to SSgetoutput:", length(keyvec), "\n")
-    if (!is.null(dirvec) & verbose) cat("length(dirvec) as input to SSgetoutput:", length(dirvec), "\n")
+    if (!is.null(keyvec) & verbose) message("length(keyvec) as input to SSgetoutput:", length(keyvec))
+    if (!is.null(dirvec) & verbose) message("length(dirvec) as input to SSgetoutput:", length(dirvec))
 
     # change inputs so that keyvec and dirvec have matching lengths or keyvec=NULL
     if (listlists) biglist <- list()
     n1 <- length(keyvec)
     n2 <- length(dirvec)
     if (n1 > 1 & n2 > 1 & n1 != n2) {
-      cat("inputs 'keyvec' and 'dirvec' have unmatched lengths > 1\n")
+      message("inputs 'keyvec' and 'dirvec' have unmatched lengths > 1")
     } else {
       n <- max(1, n1, n2) # n=1 or n=length of either optional input vector
     }
@@ -66,7 +66,7 @@ SSgetoutput <-
       }
       newobject <- objectnames[i]
 
-      if (verbose & !is.null(key)) cat("getting files with key =", key, "\n")
+      if (verbose & !is.null(key)) message("getting files with key =", key)
 
       repFileName <- paste("Report", key2, ".sso", sep = "")
       covarname <- paste("covar", key2, ".sso", sep = "")
@@ -83,7 +83,7 @@ SSgetoutput <-
       mycovar <- file.exists(file.path(mydir, covarname)) & getcovar
 
       fullfile <- paste(mydir, repFileName, sep = "")
-      if (verbose) cat("reading output from", fullfile, "\n")
+      if (verbose) message("reading output from", fullfile)
       repfilesize <- file.info(fullfile)$size
 
       output <- NA
@@ -96,7 +96,7 @@ SSgetoutput <-
         )
         if (is.null(output)) {
           # for some reason covarfile exists, but is old so SS_output rejects
-          cat("output==NULL so trying again with covar=FALSE\n")
+          message("output==NULL so trying again with covar=FALSE")
           output <- SS_output(
             dir = mydir, repfile = repFileName, covarfile = covarname,
             compfile = compFileName, NoCompOK = NoCompOK, printstats = FALSE,
@@ -105,20 +105,10 @@ SSgetoutput <-
         }
         output[["key"]] <- as.character(key)
       } else {
-        cat("!repfile doesn't exists or is empty\n")
+        message("!repfile doesn't exists or is empty")
       }
-      if (verbose) cat("added element '", newobject, "' to list\n", sep = "")
+      if (verbose) message("added element '", newobject, "' to list")
       if (listlists) biglist[[newobject]] <- output
-      ## if(global)
-      ## {
-      ##   if(exists(newobject) && !is.null(get(newobject)) & !replace)
-      ##   {
-      ##     cat("exists and not replacing:",newobject,"\n")
-      ##   }else{
-      ##     assign(newobject,output,pos=1)
-      ##     cat("created new object:",newobject,"\n")
-      ##   }
-      ## }
 
       if (save.lists) {
         biglist.file <- paste("biglist", i, "_", format(Sys.time(), "%d-%b-%Y_%H.%M"), ".Rdata", sep = "")

--- a/R/SSmakeMmatrix.R
+++ b/R/SSmakeMmatrix.R
@@ -35,7 +35,7 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
   # check for existing file
   if (!is.null(outfile) && file.exists(outfile)) {
     if (!overwrite) {
-      cat("File exists and input 'overwrite'=FALSE:", outfile, "\n")
+      message("File exists and input 'overwrite'=FALSE:", outfile)
       return()
     } else {
       file.remove(outfile)
@@ -55,7 +55,7 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
 
   # open file connection if requested
   if (!is.null(outfile)) {
-    cat("opening connection to", outfile, "\n")
+    message("opening connection to", outfile)
     zz <- file(outfile, open = "at")
     sink(zz)
   }
@@ -66,10 +66,9 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
   maxage <- nrow(mat) - 1 # maximum age (assuming first age=0)
   ages <- 0:maxage # vector of ages
 
-  cat(
-    "#### Calculating inputs to Stock Synthesis for a matrix of natural mortality values",
-    paste("\n#### over the range of ages:", min(ages), "to", maxage, "\n\n")
-  )
+  message(
+    "Calculating inputs to Stock Synthesis for a matrix of natural mortality values",
+    "\n over the range of ages:", min(ages), "to", maxage)
 
   Msetup <- c(
     "# three lines to paste near top of control file:\n",
@@ -78,7 +77,7 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
     paste(paste(ages, collapse = " "), "# NatM_breakages (required when using natM_type=1)\n")
   )
 
-  cat(Msetup)
+  message(Msetup)
 
   # create data frame of parameter lines
   HI <- ceiling(max(mat) * 10) / 10
@@ -107,7 +106,8 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
   Mparams[["comment"]] <- paste("# M parameter for age", ages)
   Mparams[["comment"]][maxage + 1] <- paste(Mparams[["comment"]][maxage + 1], "+", sep = "")
 
-  cat("\n# stuff to paste into the first block of parameter lines\n")
+  message("Mortality params to paste into the first block of parameter lines:\n", 
+  paste0(capture.output(Mparams), collapse = "\n"))
   printdf(Mparams)
 
   # create data frame of environmental link parameters
@@ -128,9 +128,9 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
   # modify final comment to make clear as a plus group
   Mlinks[["comment"]][maxage + 1] <- paste(Mlinks[["comment"]][maxage + 1], "+", sep = "")
 
-  cat("\n# stuff to paste below the line labeled 'CohortGrowDev'\n")
-  cat("1 #_custom mortality/growth environmental setup\n")
-  printdf(Mlinks)
+  message("\n# stuff to paste below the line labeled 'CohortGrowDev'\n", 
+      "1 #_custom mortality/growth environmental setup\n", 
+      paste0(capture.output(Mlinks), collapse = "\n"))
 
   # create a data frame of environmental variables
   Menv <- NULL
@@ -148,12 +148,11 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
     Menv <- rbind(Menv, temp) # paste into data.frame
   }
 
-  cat("\n# Environmental variables to paste into the bottom of the data file\n")
-
-  cat(paste(maxage + 1, "# N environmental variables\n"))
-  cat(paste(nrow(Menv), "# N environmental observations\n"))
-
-  printdf(Menv)
+  message("Environmental variables to paste into the bottom of the data file:\n", 
+   maxage + 1, " # N environmental variables\n", 
+   nrow(Menv), " # N environmental observations\n", 
+   paste0(capture.output(Menv), collapse = "\n")
+  )
 
   # restore things to how they were
   options(width = oldwidth, max.print = oldmax.print)
@@ -161,5 +160,5 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
     sink()
     close(zz)
   }
-  if (!is.null(outfile)) cat("file written to", outfile, "\n")
+  if (!is.null(outfile)) message("file written to", outfile)
 }

--- a/R/SSplotAgeMatrix.R
+++ b/R/SSplotAgeMatrix.R
@@ -207,8 +207,6 @@ SSplotAgeMatrix <- function(replist, option = 1, slices = NULL,
     # grid lines
     abline(h = ybins, v = 0:accuage, col = col.grid, lwd = 0.5)
     for (iage in nages:1) {
-      # print(iage)
-      # print(dim(mat))
       a <- agevec[iage] # actual age
       yvec <- rev(mat[, iage]) # vector of values
       for (iybin in 1:nybins) {

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -276,12 +276,7 @@ SSplotBiology <-
 
 
     if (!seas %in% 1:nseasons) stop("'seas' input should be within 1:nseasons")
-    # trying to fix error when spawning not in season 1:
-    ## if(nrow(growdat[growdat[["Sex"]]==1 & growdat[["Morph"]]==morphs[1],])==0){
-    ##   seas <- replist[["spawnseas"]]
-    ##   growdat      <- replist[["endgrowth"]][replist[["endgrowth"]][["Seas"]]==seas,]
-    ##   cat("Note: growth will be shown for spawning season =",seas,"\n")
-    ## }
+
     if (nseasons > 1) {
       labels[6] <- gsub(
         "beginning of the year",
@@ -359,7 +354,7 @@ SSplotBiology <-
       ## quick function to check for valid wtatage matrix and remove first
       ## redundant row if it's there. Used in weight_plot and maturity_plot.
       if (nrow(x) < 2) {
-        cat("not enough rows in weight-at-age matrix to plot\n")
+        message("Not enough rows in weight-at-age matrix to plot")
         return(NULL)
       }
       if (all(x[1, ] == x[2, ])) {
@@ -938,9 +933,9 @@ SSplotBiology <-
         plotinfo.tmp <- plotinfo.tmp[, c("file", "caption", "alt_text")]
         plotinfo <- rbind(plotinfo, plotinfo.tmp)
       } else {
-        cat(
+        message(
           "Skipped some plots because AGE_LENGTH_KEY unavailable in report file\n",
-          "          because starter file set to produce limited report detail.\n"
+          "because starter file set to produce limited report detail."
         )
       }
     }
@@ -948,7 +943,7 @@ SSplotBiology <-
     # function for illustrating parameterization of growth curves
     growth_curve_labeled_fn <- function(option = 1) { # growth
       if (is.null(Growth_Parameters)) {
-        cat("Need updated SS_output function to get Growth_Parameters output\n")
+        message("Need updated SS_output function to get Growth_Parameters output\n")
         return()
       }
       # save current parameter settings
@@ -1070,7 +1065,7 @@ SSplotBiology <-
     # function for illustrating parameterization of CVs around growth curves
     CV_values_labeled_fn <- function(option = 1) { # growth
       if (is.null(Growth_Parameters)) {
-        cat("Need updated SS_output function to get Growth_Parameters output\n")
+        message("Need updated SS_output function to get Growth_Parameters output")
         return()
       }
       # save current parameter settings
@@ -1483,16 +1478,16 @@ SSplotBiology <-
     # Time-varying growth
     if (is.null(growthvaries)) {
       if (verbose) {
-        cat(
-          "No check for time-varying growth because\n",
-          "     starter file set to produce limited report detail.\n"
+        message(
+          "No check for time-varying growth because starter file set to produce\n", 
+          "limited report detail."
         )
       }
     } else { # temporarily disable multi-season plotting of time-varying growth
       if (is.null(growthseries)) {
-        cat(
-          "! Warning: no time-varying growth info because\n",
-          "     starter file set to produce limited report detail.\n"
+        warning(
+          "No time-varying growth info because starter file set to produce\n",
+          "limited report detail."
         )
       } else {
         # if growth is time varying and weight-at-age not used

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -428,7 +428,6 @@ SSplotBiology <-
           }
         }
       } else {
-        # print(seas)
         # if empirical weight-at-age IS used
         fecmat <- wtatage[wtatage[["Fleet"]] == -2 & wtatage[["Sex"]] == 1, ]
         if (nrow(fecmat) > 1) {
@@ -443,7 +442,6 @@ SSplotBiology <-
               seas_label <- paste("in season", iseas)
             }
             main <- paste("", seas_label)
-            # print(head(fecmat))
             fecmat_seas <- clean_wtatage(fecmat_seas)
             ## persp(x=abs(fecmat_seas[,1]),
             ##       y=0:accuage,

--- a/R/SSplotCohortCatch.R
+++ b/R/SSplotCohortCatch.R
@@ -78,16 +78,15 @@ SSplotCohortCatch <-
     growdat <- replist[["endgrowth"]]
     SS_versionshort <- toupper(substr(replist[["SS_version"]], 1, 8))
 
-    #  if(nfishfleets==1 & verbose) cat("  Note: skipping stacked plots of catch for single-fleet model\n")
     if (is.null(wtatage)) {
-      cat(
-        "Warning: no weight-at-age data in replist[['wtatage']]\n",
-        "        plots of cohort contributions will be in numbers only\n"
+      warning(
+        "Nno weight-at-age data in replist[['wtatage']]\n",
+        "plots of cohort contributions will be in numbers only"
       )
       subplots <- setdiff(subplots, 2) # removing subplot 2 from the list
     } else {
       if (nseasons > 1) {
-        cat("Warning: plots of catch by cohort might not work for seasonal models.\n")
+        warning("Plots of catch by cohort might not work for seasonal models.")
       }
     }
 
@@ -119,8 +118,6 @@ SSplotCohortCatch <-
           for (ifleet in 1:nfishfleets) { # loop over fleets
             f <- ifleet # index = fleet number in current SS but making general
             for (isex in 1:nsexes) { # loop over sexes
-              ### testing:
-              ##   cat('y=',y,' a=',a,' f=',f,' isex=',isex,' cohort=',cohort,'\n',sep='')
 
               # copy values from catage to catcohort_fltsex
               # summation could include multiple seasons or morphs within a year

--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -284,7 +284,7 @@ SSplotComparisons <-
     }
 
     if (png & is.null(plotdir)) {
-      stop("to print PNG files, you must supply a directory as 'plotdir'")
+      stop("To print PNG files, you must supply a directory as 'plotdir'")
     }
 
     # check for internal consistency
@@ -293,7 +293,7 @@ SSplotComparisons <-
     }
     if (pdf) {
       if (is.null(plotdir)) {
-        stop("to write to a PDF, you must supply a directory as 'plotdir'")
+        stop("To write to a PDF, you must supply a directory as 'plotdir'")
       }
       pdffile <- file.path(
         plotdir,
@@ -525,12 +525,8 @@ SSplotComparisons <-
       }
       # check for mismatched lengths of list elements
       if (!length(unique(lapply(indexfleets, FUN = length))) == 1) {
-        message("indexfleets:")
-        print(indexfleets)
-        warning(
-          "Skipping index plots:\n",
-          "Fleets have different numbers of indices listed in 'indexfleets'."
-        )
+        warning("Skipping index plots;\n",
+          "Fleets have different numbers of indices listed in 'indexfleets'.")
         indexfleets <- NULL
       }
 
@@ -1923,15 +1919,13 @@ SSplotComparisons <-
           }
           # warn if too many columns
           if (length(mcmcColumn) > 1) {
-            message(
-              "Too many columns selected from MCMC for model ",
-              imodel, ":"
-            )
-            print(names(mcmc[[imodel]])[mcmcColumn])
             warning(
-              "Please specify a unique label in the mcmc dataframe",
-              "or specify mcmcVec=FALSE for model ",
-              imodel, " (or mcmcVec=FALSE applying to all models)."
+              "Too many columns selected from MCMC for model ",
+              imodel, ":", paste0(names(mcmc[[imodel]])[mcmcColumn], 
+              collapse = ", "), 
+              ". Please specify a unique label in the mcmc dataframe",
+              "or specify mcmcVec = FALSE for model ",
+              imodel, " (or mcmcVec = FALSE applying to all models). "
             )
             good[iline] <- FALSE
           }
@@ -2523,10 +2517,10 @@ SSplotComparisons <-
           expandednames <- c(expandednames, matchingnames)
         }
         if (length(expandednames) == 0) {
-          warning("  No parameter/quantity names matching 'densitynames' input.")
+          warning("No parameter/quantity names matching 'densitynames' input.")
         } else {
-          message("  parameter/quantity names matching 'densitynames' input:")
-          print(expandednames)
+          message("Parameter/quantity names matching 'densitynames' input:\n",
+            paste0(expandednames, collapse = ", "))
           ndensities <- length(expandednames)
           # make a table to store associated x-labels
           densitytable <- data.frame(

--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -450,9 +450,9 @@ SSplotComps <-
     # Add asterix to indicate super periods and then remove rows labeled "skip".
     # It would be better to somehow show the range of years, but that seems difficult.
     if (any(dbase_kind[["SuprPer"]] == "Sup" & dbase_kind[["Used"]] == "skip")) {
-      cat(
-        "Note: removing super-period composition values labeled 'skip'\n",
-        "     and designating super-period values with a '*'\n"
+      message(
+        "Removing super-period composition values labeled 'skip'\n",
+        "and designating super-period values with a '*'"
       )
       dbase_kind <- dbase_kind[dbase_kind[["SuprPer"]] == "No" | dbase_kind[["Used"]] != "skip", ]
       dbase_kind[["YrSeasName"]] <- paste(dbase_kind[["YrSeasName"]], ifelse(dbase_kind[["SuprPer"]] == "Sup", "*", ""), sep = "")
@@ -743,7 +743,7 @@ SSplotComps <-
                 agg <- aggregate(x = df, by = list(bin = dbase[["Bin"]], f = dbase[["Fleet"]], s = dbase[["Seas"]]), FUN = sum)
                 agg <- agg[agg[["f"]] %in% fleets, ]
                 if (any(agg[["s"]] <= 0)) {
-                  cat("super-periods may not work correctly in plots of aggregated comps\n")
+                  message("super-periods may not work correctly in plots of aggregated comps")
                   agg <- agg[agg[["s"]] > 0, ]
                 }
                 agg[["obs"]] <- agg[["obs"]] / agg[["Nsamp_adj"]]
@@ -1101,10 +1101,10 @@ SSplotComps <-
 
             if (max_n_ageerr > 1) {
               if (ageerr_warning) {
-                cat(
-                  "Note: multiple samples with different ageing error types within fleet/year.\n",
-                  "     Plots label '2005a3' indicates ageing error type 3 for 2005 sample.\n",
-                  "     Bubble plots may be misleading with overlapping bubbles.\n"
+                message(
+                  "Multiple samples with different ageing error types within fleet/year.\n",
+                  "Plots label '2005a3' indicates ageing error type 3 for 2005 sample.\n",
+                  "Bubble plots may be misleading with overlapping bubbles.\n"
                 )
                 ageerr_warning <- FALSE
               }
@@ -1180,7 +1180,7 @@ SSplotComps <-
             # add lines for growth of individual cohorts if requested
             if (length(cohortlines) > 0) {
               for (icohort in 1:length(cohortlines)) {
-                cat("  Adding line for", cohortlines[icohort], "cohort\n")
+                message("  Adding line for", cohortlines[icohort], "cohort\n")
                 if (kind == "LEN") {
                   lines(growdatF[["Age"]] + cohortlines[icohort],
                     growdatF[["Len_Mid"]],
@@ -1308,7 +1308,7 @@ SSplotComps <-
 
           if (max_n_ageerr > 1) {
             if (ageerr_warning) {
-              cat(
+              message(
                 "Note: multiple samples with different ageing error types within fleet/year.\n",
                 "     Plots label '2005a3' indicates ageing error type 3 for 2005 sample.\n",
                 "     Bubble plots may be misleading with overlapping bubbles.\n"
@@ -1607,7 +1607,7 @@ SSplotComps <-
               # add lines for growth of individual cohorts if requested
               if (length(cohortlines) > 0) {
                 for (icohort in 1:length(cohortlines)) {
-                  cat("  Adding line for", cohortlines[icohort], "cohort\n")
+                  message("  Adding line for", cohortlines[icohort], "cohort\n")
                   if (kind == "LEN") {
                     if (nsexes > 1) {
                       lines(growdatF[["Age_Mid"]] + cohortlines[icohort],
@@ -1684,9 +1684,9 @@ SSplotComps <-
               if (!datonly && is.logical(effNline) && effNline) {
                 # scaling when displaying both input and effective
                 sampsizeline <- effNline <- max(dbase[["Bin"]]) / max(dbase[["Nsamp_adj"]], dbase[["effN"]], na.rm = TRUE)
-                cat("  Fleet ", f, " ", titlesex, "adj. input & effective N in red & green scaled by ", effNline, "\n", sep = "")
+                message("  Fleet ", f, " ", titlesex, "adj. input & effective N in red & green scaled by ", effNline, "\n", sep = "")
               } else {
-                cat("  Fleet ", f, " ", titlesex, "adj. input N in red scaled by ", sampsizeline, "\n", sep = "")
+                message("  Fleet ", f, " ", titlesex, "adj. input N in red scaled by ", sampsizeline, "\n", sep = "")
               }
             }
             # function to make plots
@@ -1872,7 +1872,7 @@ SSplotComps <-
             goodbins <- intersect(aalbin, dbase[["Lbin_hi"]])
             if (length(goodbins) > 0) {
               if (length(badbins) > 0) {
-                cat(
+                message(
                   "Error! the following inputs for 'aalbin' do not match the Lbin_hi values for the conditional age-at-length data:", badbins, "\n",
                   "       the following inputs for 'aalbin' are fine:", goodbins, "\n"
                 )

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -67,12 +67,6 @@ SSplotData <- function(replist,
   # table to store information on each plot
   plotinfo <- NULL
 
-  ## ### override datasize variable in seasonal models
-  ## if(replist[["nseasons"]] > 1){
-  ##   cat("  Setting datasize to FALSE because not yet implemented for seasonal models.\n")
-  ##   datasize <- FALSE
-  ## }
-
   ### get info from replist
   # dimensions
   startyr <- replist[["startyr"]]

--- a/R/SSplotMnwt.R
+++ b/R/SSplotMnwt.R
@@ -134,9 +134,6 @@ SSplotMnwt <-
           } # end loop over subplots
         } # end loop over market categories
       } # end loop over fleets
-      ##   if(verbose) cat("Finished mean body weight plot\n")
-      ## }else{ # if mean weight data exists
-      ##   if(verbose) cat("No mean body weight data to plot\n")
     }
     if (!is.null(plotinfo)) plotinfo[["category"]] <- "Mnwt"
     return(invisible(plotinfo))

--- a/R/SSplotMovementRates.R
+++ b/R/SSplotMovementRates.R
@@ -42,7 +42,6 @@ SSplotMovementRates <-
            moveseas = "all", min.move.age = 0.5,
            pwidth = 6.5, pheight = 5.0, punits = "in", res = 300, ptsize = 10, cex.main = 1,
            verbose = TRUE) {
-    # if(verbose) cat("Running SSplotMovementRates function\n")
 
     # table to store information on each plot
     plotinfo <- NULL
@@ -66,7 +65,7 @@ SSplotMovementRates <-
 
     # subplot 1: movement in end year
     if (1 %in% subplots) {
-      if (verbose) cat("  running subplot 1: movement rates in final year\n")
+      if (verbose) message("Running subplot 1: movement rates in final year")
 
       if (moveseas[1] == "all") moveseas <- sort(unique(move[["Seas"]]))
       for (iseas in moveseas) {
@@ -74,7 +73,7 @@ SSplotMovementRates <-
           move[["Source_area"]] != move[["Dest_area"]], ]
 
         if (nrow(move2) == 0) {
-          if (verbose) cat("Skipping movement rate plot: no movement in season", moveseas[iseas], "\n")
+          if (verbose) message("Skipping movement rate plot: no movement in season", moveseas[iseas])
         } else {
           move3 <- move2[, -(1:6)]
 
@@ -129,7 +128,7 @@ SSplotMovementRates <-
         if (time) {
           warning("plot of time-varying movement rates not currently working")
           if (FALSE) {
-            if (verbose) cat("  running subplot 2: time-varying movement rates\n")
+            if (verbose) message("Running subplot 2: time-varying movement rates")
             moveinfo <- move[, 1:6]
             moveinfo[["LabelBase2"]] <- paste("seas_", moveinfo[["Seas"]], "_GP_", moveinfo[["GP"]],
               "from_", moveinfo[["Source"]], "to_", moveinfo[["Dest"]],
@@ -138,22 +137,15 @@ SSplotMovementRates <-
             moveinfo <- moveinfo[moveinfo[["LabelBase2"]] %in% substring(movepars[["Label"]], 12), ]
             ## print(moveinfo)
             nmoves <- nrow(moveinfo)
-            if (verbose) cat("  N movement rates:", nmoves, "\n")
+            if (verbose) message("N movement rates:", nmoves)
             if (nareas > 2) {
-              cat(
-                "  WARNING: time-varying movement plots not yet configured",
-                "for models with N areas > 2\n"
+              warning("Time-varying movement plots not yet configured",
+                "for models with N areas > 2"
               )
             } else {
               yrvec <- replist[["startyr"]]:replist[["endyr"]]
               nyrs <- length(yrvec)
 
-              ## if(nmoves*2 != nrow(movepars)){
-              ##   cat("warning!: In SSplotMovementRates function.\n
-              ##                Problem with number of parameters.\n
-              ##                2*nrow(moveinfo)=",2*nrow(moveinfo),"\n,
-              ##                nrow(movepars)  =",nrow(movepars),"\n")
-              ## }
 
               movecalc <- function(min.move.age, accuage, minage, maxage,
                                    valueA, valueB, from, to, seasdur) {
@@ -240,7 +232,6 @@ SSplotMovementRates <-
               } # end loop over years to calculate moveByYr array
 
               # make plots
-              cat("Warning! Time-varying movement plots are experimental and might be totally wrong\n")
               for (imove in 1:nmoves) {
                 Source_area <- moveinfo[["Source_area"]][imove]
                 Dest_area <- moveinfo[["Dest_area"]][imove]

--- a/R/SSplotMovementRates.R
+++ b/R/SSplotMovementRates.R
@@ -135,7 +135,6 @@ SSplotMovementRates <-
               sep = ""
             )
             moveinfo <- moveinfo[moveinfo[["LabelBase2"]] %in% substring(movepars[["Label"]], 12), ]
-            ## print(moveinfo)
             nmoves <- nrow(moveinfo)
             if (verbose) message("N movement rates:", nmoves)
             if (nareas > 2) {

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -159,7 +159,7 @@ SSplotProfile <-
       }
       # create directory if it's missing
       if (!file.exists(plotdir)) {
-        if (verbose) cat("creating directory:", plotdir, "\n")
+        if (verbose) message("creating directory:", plotdir)
         dir.create(plotdir, recursive = TRUE)
       }
     }
@@ -206,9 +206,9 @@ SSplotProfile <-
       )
     }
     parvec <- as.numeric(pars[pars[["Label"]] == parlabel, models])
-    cat("Parameter matching profile.string='", profile.string, "': '", parlabel, "'\n", sep = "")
-    cat("Parameter values (after subsetting based on input 'models'):\n")
-    print(parvec)
+    message("Parameter matching profile.string=", profile.string, ": ", parlabel)
+    message("Parameter values (after subsetting based on input 'models'): ", 
+      paste0(parvec, collapse = ", "))
     if (xlim[1] == "default") xlim <- range(parvec)
 
     # rearange likelihoods to be in columns by type

--- a/R/SSplotRecdevs.R
+++ b/R/SSplotRecdevs.R
@@ -66,7 +66,7 @@ SSplotRecdevs <-
     recdevLate <- parameters[substring(parameters[["Label"]], 1, 12) == "Late_RecrDev", ]
 
     if (nrow(recdev) == 0 || max(recdev[["Value"]]) == 0) {
-      if (verbose) cat("Skipped SSplotrecdevs - no rec devs estimated\n")
+      if (verbose) message("Skipped SSplotrecdevs - no rec devs estimated")
     } else {
       if (nrow(recdev) > 0) {
         # early

--- a/R/SSplotRecdist.R
+++ b/R/SSplotRecdist.R
@@ -85,9 +85,8 @@ SSplotRecdist <-
 
     rownames(recmat) <- areanames
     colnames(recmat) <- seasnames
-    cat("recruitment distribution by area and season:\n")
-    print(recmat)
-
+    message("recruitment distribution by area and season:\n", 
+      paste0(capture.output(recmat), collapse = "\n"))
     if (plot) recdistfun()
     if (print) {
       file <- "recruitment_distribution.png"

--- a/R/SSplotSexRatio.R
+++ b/R/SSplotSexRatio.R
@@ -145,9 +145,9 @@ SSplotSexRatio <-
     ## Add asterix to indicate super periods and then remove rows labeled "skip".
     ## It would be better to somehow show the range of years, but that seems difficult.
     if (any(dbase_kind[["SuprPer"]] == "Sup" & dbase_kind[["Used"]] == "skip")) {
-      cat(
-        "Note: removing super-period composition values labeled 'skip'\n",
-        "     and designating super-period values with a '*'\n"
+      message(
+        "Removing super-period composition values labeled 'skip'\n",
+        "     and designating super-period values with a '*'"
       )
       dbase_kind <- dbase_kind[dbase_kind[["SuprPer"]] == "No" | dbase_kind[["Used"]] != "skip", ]
       dbase_kind[["YrSeasName"]] <- paste(dbase_kind[["YrSeasName"]], ifelse(dbase_kind[["SuprPer"]] == "Sup", "*", ""), sep = "")

--- a/R/SSplotTimeseries.R
+++ b/R/SSplotTimeseries.R
@@ -449,7 +449,7 @@ SSplotTimeseries <-
         file <- paste("ts", subplot, "_", file, ".png", sep = "")
         # replace any spaces with underscores
         file <- gsub(pattern = " ", replacement = "_", x = file, fixed = TRUE)
-        # if(verbose) cat("printing plot to file:", file, "\n")
+
         plotinfo <- save_png(
           plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
           pheight = pheight, punits = punits, res = res, ptsize = ptsize,

--- a/R/SSplotYield.R
+++ b/R/SSplotYield.R
@@ -174,10 +174,10 @@ SSplotYield <-
             }
           }
         } else {
-          cat("Skipped equilibrium yield plots: equil_yield has all NA values\n")
+          message("Skipped equilibrium yield plots: equil_yield has all NA values")
         }
       } else {
-        cat("Skipped equilibrium yield plots: no equil_yield results in this model\n")
+        message("Skipped equilibrium yield plots: no equil_yield results in this model")
       }
     }
 

--- a/R/SStableComparisons.R
+++ b/R/SStableComparisons.R
@@ -55,7 +55,7 @@ SStableComparisons <- function(summaryoutput,
                                csvfile = "parameter_comparison_table.csv",
                                verbose = TRUE,
                                mcmc = FALSE) {
-  if (verbose) cat("running SStableComparisons\n")
+  if (verbose) message("running SStableComparisons")
 
   # get stuff from summary output
   n <- summaryoutput[["n"]]
@@ -91,15 +91,14 @@ SStableComparisons <- function(summaryoutput,
     for (iname in 1:nnames) {
       name <- names[iname]
       if (!is.null(digits)) digit <- digits[iname]
-      if (verbose) cat("name=", name, ": ", sep = "")
+      if (verbose) message("name=", name, ";")
       if (name == "BLANK") {
-        if (verbose) cat("added a blank row to the table\n")
+        if (verbose) message("added a blank row to the table")
         # add to table
         tab <- rbind(tab, " ")
       } else {
         # get values
         vals <- bigtable[grep(name, bigtable[["Label"]], fixed = TRUE), ]
-        #      cat("labels found:\n",bigtable[["Label"]][grep(name, bigtable[["Label"]])],"\n")
         # scale recruits into billions, or millions, or thousands
         if (substring(name, 1, 4) == "Recr" & length(grep("like", name)) == 0) {
           median.value <- median(as.numeric(vals[1, -1]), na.rm = TRUE)
@@ -120,7 +119,6 @@ SStableComparisons <- function(summaryoutput,
 
         if (name %in% c("Q", "Q_calc")) {
           Calc_Q <- aggregate(Calc_Q ~ name + Fleet, data = indices, FUN = mean)
-          cat("\n")
           fleetvec <- sort(as.numeric(unique(Calc_Q[["Fleet"]])))
           vals <- data.frame(matrix(NA, nrow = length(fleetvec), ncol = ncol(bigtable)))
           names(vals) <- names(bigtable)
@@ -130,9 +128,9 @@ SStableComparisons <- function(summaryoutput,
             vals[ifleet, -1] <- Calc_Q[["Calc_Q"]][Calc_Q[["Fleet"]] == f]
           }
         }
-        if (verbose) cat("added ", nrow(vals), " row", ifelse(nrow(vals) != 1, "s", ""), "\n", sep = "")
+        if (verbose) message("added ", nrow(vals), " row", ifelse(nrow(vals) != 1, "s", ""))
         if (!is.null(digits)) {
-          if (verbose) cat("rounded to", digit, "digits\n")
+          if (verbose) message("rounded to", digit, "digits")
           vals[, -1] <- round(vals[, -1], digit)
         }
         # add to table
@@ -147,9 +145,9 @@ SStableComparisons <- function(summaryoutput,
     for (iname in 1:nnames) {
       name <- names[iname]
       if (!is.null(digits)) digit <- digits[iname]
-      if (verbose) cat("name=", name, ": ", sep = "")
+      if (verbose) message("name=", name, "; ", sep = "")
       if (name == "BLANK") {
-        if (verbose) cat("added a blank row to the table\n")
+        if (verbose) message("added a blank row to the table")
         # add to table
         tab <- rbind(tab, " ")
       } else {
@@ -160,7 +158,6 @@ SStableComparisons <- function(summaryoutput,
           # get values
           # for future functionality grabbing more than one column
           tmp <- mcmcTable[, grep(name, names(mcmcTable), fixed = TRUE)]
-          #        cat("labels found: ",names(mcmcTable)[grep(name, names(mcmcTable))],"\n")
           if (!is.null(dim(tmp))) {
             if (ncol(tmp) > 0) {
               stop("This only works with a single column from the mcmc. Use a specific name")
@@ -190,11 +187,11 @@ SStableComparisons <- function(summaryoutput,
           vals[1, 1] <- paste(vals[1, 1], "thousand_mt", sep = "_")
         }
         if (!is.null(digits)) {
-          if (verbose) cat("rounded to", digit, "digits\n")
+          if (verbose) message("rounded to", digit, "digits")
           vals[, -1] <- round(vals[, -1], digit)
         }
 
-        if (verbose) cat("added an mcmc row\n")
+        if (verbose) message("added an mcmc row")
         # add to table
         tab <- rbind(tab, vals)
       } # end if not blank
@@ -213,7 +210,7 @@ SStableComparisons <- function(summaryoutput,
   if (csv) {
     if (csvdir == "workingdirectory") csvdir <- getwd()
     fullpath <- paste(csvdir, csvfile, sep = "/")
-    cat("writing table to:\n  ", fullpath, "\n")
+    message("writing table to: ", fullpath)
     write.csv(tab, fullpath, row.names = FALSE)
   }
   # return table

--- a/R/TSCplot.R
+++ b/R/TSCplot.R
@@ -160,11 +160,11 @@ TSCplot <- function(SSout,
 
   if (!is.null(makePDF)) {
     dev.off()
-    cat("The plot is in pdf file", makePDF, "\n")
+    message("The plot is in pdf file ", makePDF)
   }
   if (!is.null(makePNG)) {
     dev.off()
-    cat("The plot is in png file", makePNG, "\n")
+    message("The plot is in png file", makePNG)
   }
 
   invisible(SP)

--- a/R/make_multifig.R
+++ b/R/make_multifig.R
@@ -677,7 +677,7 @@ make_multifig <-
     # par(mfcol=c(rows,cols), mar=c(5,4,4,2)+.1, oma=rep(0,4))
 
     if (anyscaled) {
-      cat("Note: compositions have been rescaled by dividing by binwidth\n")
+      message("Compositions have been rescaled by dividing by binwidth")
     }
     # return information on what was plotted
     return(list(npages = npages, npanels = npanels, ipage = ipage))

--- a/R/mcmc.nuisance.R
+++ b/R/mcmc.nuisance.R
@@ -83,8 +83,8 @@ mcmc.nuisance <- function(directory = "c:/mydirectory/", # directory to use
     for (istring in 1:length(labelstrings)) {
       labels <- c(labels, names(mcmcdata)[grep(labelstrings[istring], names(mcmcdata))])
     }
-    message("All labels matching the input 'labelstrings':")
-    print(labels)
+    message("All labels matching the input 'labelstrings': " , 
+      paste0(labels, collapse = ", "))
     mcmcdata <- mcmcdata[, names(mcmcdata) %in% labels]
   } else {
     # when "all" are requested, exclude Iter and Objective_function columns

--- a/R/mcmc.out.R
+++ b/R/mcmc.out.R
@@ -121,7 +121,9 @@ mcmc.out <- function(directory = "c:/mydirectory/",
   }
 
   if (!is.null(colNames)) {
-    if (length(colNames) != numparams) cat("numparams argument overidden by length of colNames argument\n")
+    if (length(colNames) != numparams) {
+      warning("numparams argument overidden by length of colNames argument")
+    }
     numparams <- length(colNames)
     mcmcdata <- mcmcdata[, colNames]
     if (length(colNames) == 1) {

--- a/R/mountains.R
+++ b/R/mountains.R
@@ -36,15 +36,10 @@ mountains <- function(zmat, xvec = NULL, yvec = NULL, zscale = 3, rev = TRUE,
   # stock assessment of southern bluefin tuna with temporal changes in selectivity.
   # South African Journal of Marine Science 25:331-362.
 
-  errors <- FALSE
   for (icol in 1:ncol(zmat)) {
     if (!is.numeric(zmat[, icol])) {
-      errors <- TRUE
-      print(paste("error: column", icol, "of zmat is not numeric"))
+      stop("Column", icol, "of zmat is not numeric")
     }
-  }
-  if (errors) {
-    return(invisible())
   }
 
   if (rev) yvec <- -yvec


### PR DESCRIPTION
Resolves #660 . `cat()` and `print()` are replaced with `message()`, `warning()`, and `stop()`, as appropriate. This PR focuses on changing them, and doesn't refine or remove unneeded ones. I was thinking this could maybe be a task for a separate time, but we could make changes in the branch if others think it would be helpful before merging in.