### PR TITLE
Dirichlet-multinomial changes

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -313,48 +313,6 @@ SS_output <-
       message("Report file time:", repfiletime)
     }
 
-    if (covar) {
-      # CoVar.sso file
-      covarfile <- file.path(dir, covarfile)
-      if (!file.exists(covarfile)) {
-        message("covar file not found, input 'covar' changed to FALSE")
-        covar <- FALSE
-      } else {
-
-        # time check for CoVar file
-        covarhead <- readLines(con = covarfile, n = 10)
-        covarskip <- grep("active-i", covarhead) - 1
-        covartime <- findtime(covarhead)
-        # the conversion to R time class below may no longer be necessary as strings should match
-        if (is.null(covartime) || is.null(repfiletime)) {
-          message(
-            "problem comparing the file creation times:\n",
-            "  Report.sso:", repfiletime, "\n",
-            "  covar.sso:", covartime
-          )
-        } else {
-          if (covartime != repfiletime) {
-            message("covar time:", covartime)
-            stop(
-              shortrepfile, " and ", covarfile,
-              " were from different model runs. Change input to covar=FALSE"
-            )
-          }
-        }
-
-        # covar file exists, but has problems
-        nowrite <- grep("do not write", covarhead)
-        if (length(nowrite) > 0) {
-          warning(
-            "covar file contains the warning\n",
-            "     '", covarhead[nowrite], "'\n",
-            "  input 'covar' changed to FALSE.\n"
-          )
-          covar <- FALSE
-        }
-      }
-    }
-
     # time check for CompReport file
     comp <- FALSE
     if (is.null(compfile)) {
@@ -1146,6 +1104,30 @@ SS_output <-
     returndat[["Data_File"]] <- tempfiles[1, 2]
     returndat[["Control_File"]] <- tempfiles[2, 2]
 
+    # log determinant of the Hessian (previously was from ss.cor file)
+    log_det_hessian <- match_report_table("Hessian", 0,
+        "Hessian", 0,
+        cols = 2
+      )
+    if(log_det_hessian == "Not") { # first part of "Not requested."
+      covar <- FALSE
+      log_det_hessian <- NA
+    }
+    # as.numeric() doesn't give warning if value is NA
+    stats[["log_det_hessian"]] <- as.numeric(log_det_hessian)
+    
+    # two additional outputs added in 3.30.20 
+    # (also "total_LogL" which is redundant with value in LIKELIHOOD
+    # table read later)
+    stats[["Final_phase"]] <- match_report_table("Final_phase", 0,
+        "Final_phase", 0,
+        cols = 2
+      )
+    stats[["N_iterations"]] <- match_report_table("N_iterations", 0,
+        "N_iterations", 0,
+        cols = 2
+      )
+    
     # check warnings
     stats[["Nwarnings"]] <- nwarn
     if (length(warn) > 20) {
@@ -1575,6 +1557,49 @@ SS_output <-
       } # end test for whether CompReport.sso info is available
     } # end section related to Dirichlet-Multinomial likelihood
 
+    # check the covar.sso file 
+    # this section moved down within SS_output for 3.30.20 to avoid
+    # reading covar if -nohess used
+    if (covar) {
+      covarfile <- file.path(dir, covarfile)
+      if (!file.exists(covarfile)) {
+        message("covar file not found, input 'covar' changed to FALSE")
+        covar <- FALSE
+      } else {
+
+        # time check for CoVar file
+        covarhead <- readLines(con = covarfile, n = 10)
+        covarskip <- grep("active-i", covarhead) - 1
+        covartime <- findtime(covarhead)
+        # the conversion to R time class below may no longer be necessary as strings should match
+        if (is.null(covartime) || is.null(repfiletime)) {
+          message(
+            "problem comparing the file creation times:\n",
+            "  Report.sso:", repfiletime, "\n",
+            "  covar.sso:", covartime
+          )
+        } else {
+          if (covartime != repfiletime) {
+            message("covar time:", covartime)
+            stop(
+              shortrepfile, " and ", covarfile,
+              " were from different model runs. Change input to covar=FALSE"
+            )
+          }
+        }
+
+        # covar file exists, but has problems
+        nowrite <- grep("do not write", covarhead)
+        if (length(nowrite) > 0) {
+          warning(
+            "covar file contains the warning\n",
+            "     '", covarhead[nowrite], "'\n",
+            "  input 'covar' changed to FALSE.\n"
+          )
+          covar <- FALSE
+        }
+      }
+    }
 
     # read covar.sso file
     if (covar) {
@@ -1889,13 +1914,7 @@ SS_output <-
         )
       }
     }
-
-    # log determinant of the Hessian (previously was from ss.cor file)
-    stats[["log_det_hessian"]] <-
-      as.numeric(match_report_table("Hessian", 0,
-        "Hessian", 0,
-        cols = 2
-      ))
+    
     # max gradient
     stats[["maximum_gradient_component"]] <-
       as.numeric(match_report_table("Convergence_Level", 0,
@@ -2061,11 +2080,12 @@ SS_output <-
       lenntune <- match_report_table("Length_Comp_Fit_Summary", 1, header = TRUE)
       if (!is.null(lenntune)) {
         lenntune <- df.rename(lenntune,
-          oldnames = c("FleetName"),
-          newnames = c("Fleet_name")
+          oldnames = c("FleetName", "Factor"),
+          newnames = c("Fleet_name", "Data_type")
         )
-        if ("Factor" %in% names(lenntune)) {
+      if ("Data_type" %in% names(lenntune)) {
           # format starting with 3.30.12 doesn't need adjustment, just convert to numeric
+          # ("Factor", introduced in 3.30.12, was renamed "Data_type" in 3.30.20)
           lenntune <- type.convert(lenntune, as.is = TRUE)
         } else {
           # process 3.30 versions prior to 3.30.12
@@ -2139,12 +2159,14 @@ SS_output <-
       }
     } # end 3.30 version
     agentune <- df.rename(agentune,
-      oldnames = c("FleetName", "N"),
-      newnames = c("Fleet_name", "Nsamp_adj")
+      oldnames = c("FleetName", "N", "Factor"),
+      newnames = c("Fleet_name", "Nsamp_adj", "Data_type")
     )
 
-    if ("Factor" %in% names(agentune)) {
-      # format starting with 3.30.12 doesn't need adjustment, just convert to numeric
+    if ("Data_type" %in% names(agentune)) {
+      # format starting with 3.30.12 doesn't need adjustment, just
+      # convert to numeric
+      # ("Factor", introduced in 3.30.12, was renamed "Data_type" in 3.30.20)
       agentune <- type.convert(agentune, as.is = TRUE)
     } else {
       if (!is.null(dim(agentune))) {
@@ -2189,8 +2211,7 @@ SS_output <-
     ## FIT_SIZE_COMPS
     fit_size_comps <- NULL
     if (SS_versionNumeric >= 3.30) {
-      # test for SS version 3.30.12 and beyond which doesn't include
-      # the label "Size_Comp_Fit_Summary"
+      # test for SS version 3.30.12 and beyond
       if (!is.na(match_report_line("FIT_SIZE_COMPS"))) {
         # note that there are hashes in between sub-sections,
         # so using rep_blank_lines instead of default
@@ -2211,8 +2232,18 @@ SS_output <-
           fit_size_comps[["Add_to_comp"]] <- NA
           # find the lines with the method-specific info
           method_lines <- grep("#Method:", fit_size_comps[, 1])
+          # method info is table to store info from only those lines
           method_info <- fit_size_comps[method_lines, ]
-          tune_lines <- grep("Factor", fit_size_comps[, 1])
+
+          # find the lines with the fit summary
+          if (any(grepl("Size_Comp_Fit_Summary", fit_size_comps[, 1]))) {
+            # new header line added in version 3.30.20
+            tune_lines <- grep("Size_Comp_Fit_Summary", fit_size_comps[, 1]) + 1
+          } else {
+            tune_lines <- grep("Factor", fit_size_comps[, 1])
+          }
+     
+          # place to store fit summary which is split across methods
           sizentune <- NULL
           # loop over methods to fill in new columns
           for (imethod in seq_along(method_lines)) {
@@ -2226,22 +2257,36 @@ SS_output <-
             fit_size_comps[["Units"]][start:end] <- method_info[imethod, 4]
             fit_size_comps[["Scale"]][start:end] <- method_info[imethod, 6]
             fit_size_comps[["Add_to_comp"]][start:end] <- method_info[imethod, 8]
+            
             # split out rows with info on tuning
             sizentune <- rbind(sizentune, fit_size_comps[tune_lines[imethod]:end, ])
           }
           # format sizentune (info on tuning) has been split into
           # a separate data.frame, needs formatting: remove extra columns, change names
           goodcols <- c(
+            # grab columns up through Fleet_name + added Method column
             1:grep("name", tolower(sizentune[1, ])),
             grep("Method", names(sizentune))
           )
+          # fill in header for Method in first row
           sizentune[1, max(goodcols)] <- "Method"
           sizentune <- sizentune[, goodcols]
+          # use first row for names
           names(sizentune) <- sizentune[1, ]
-          sizentune <- sizentune[sizentune[["Factor"]] == 7, ]
+          # rename Factor to Data_type (changed in 3.30.20)
+          sizentune <- df.rename(sizentune,
+            oldnames = c("Factor"),
+            newnames = c("Data_type")
+          )
+          # subset for rows with single-character value for 
+          # Data_type (should always be 7 but seems to have been
+          # 6 in some earlier models)
+          # this should filter out extra header rows
+          sizentune <- sizentune[nchar(sizentune[["Data_type"]]) == 1, ]
+          # convert to numeric values as needed
           sizentune <- type.convert(sizentune, as.is = TRUE)
           stats[["Size_Comp_Fit_Summary"]] <- sizentune
-          # format fit_size_comps: remove extra rows, make numeric
+          # remove extra summary rows of fit_size_comps 
           fit_size_comps <- fit_size_comps[fit_size_comps[["Fleet_Name"]] %in% FleetNames, ]
         } # end check for non-empty fit_size_comps
       } else {
@@ -2496,14 +2541,19 @@ SS_output <-
       replacement = "\\1",
       x = M_type
     ))
+    
     # in SS 3.30 the number of rows of Natural_Mortality is the product of
     # the number of sexes, growth patterns, settlement events but settlement
     # events didn't exist in 3.24
-    M_Parameters <- match_report_table("Natural_Mortality",
+
+    # this first table includes all time periods as of 3.30.20
+    Natural_Mortality <- match_report_table("Natural_Mortality",
       adjust1 = adjust1,
       header = TRUE,
       type.convert = TRUE
     )
+    # the Bmark and endyr tables have been subsumed into the table above
+    # in 3.30.20
     Natural_Mortality_Bmark <- match_report_table("Natural_Mortality_Bmark",
       adjust1 = 1,
       header = TRUE,
@@ -2515,6 +2565,7 @@ SS_output <-
       type.convert = TRUE
     )
     returndat[["M_type"]] <- M_type
+    returndat[["Natural_Mortality"]] <- Natural_Mortality
     returndat[["Natural_Mortality_Bmark"]] <- Natural_Mortality_Bmark
     returndat[["Natural_Mortality_endyr"]] <- Natural_Mortality_endyr
 

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -2080,8 +2080,8 @@ SS_output <-
       lenntune <- match_report_table("Length_Comp_Fit_Summary", 1, header = TRUE)
       if (!is.null(lenntune)) {
         lenntune <- df.rename(lenntune,
-          oldnames = c("FleetName", "Factor"),
-          newnames = c("Fleet_name", "Data_type")
+          oldnames = c("FleetName", "Factor", "HarMean_effN"),
+          newnames = c("Fleet_name", "Data_type", "HarMean")
         )
       if ("Data_type" %in% names(lenntune)) {
           # format starting with 3.30.12 doesn't need adjustment, just convert to numeric
@@ -2159,8 +2159,8 @@ SS_output <-
       }
     } # end 3.30 version
     agentune <- df.rename(agentune,
-      oldnames = c("FleetName", "N", "Factor"),
-      newnames = c("Fleet_name", "Nsamp_adj", "Data_type")
+      oldnames = c("FleetName", "N", "Factor", "HarMean_effN"),
+      newnames = c("Fleet_name", "Nsamp_adj", "Data_type", "HarMean")
     )
 
     if ("Data_type" %in% names(agentune)) {
@@ -2275,8 +2275,8 @@ SS_output <-
           names(sizentune) <- sizentune[1, ]
           # rename Factor to Data_type (changed in 3.30.20)
           sizentune <- df.rename(sizentune,
-            oldnames = c("Factor"),
-            newnames = c("Data_type")
+            oldnames = c("Factor", "HarMean_effN"),
+            newnames = c("Data_type", "HarMean")
           )
           # subset for rows with single-character value for 
           # Data_type (should always be 7 but seems to have been

--- a/R/SS_plots.R
+++ b/R/SS_plots.R
@@ -25,10 +25,10 @@
 #'   \item Mean weight
 #'   \item Indices
 #'   \item Numbers at age
-#'   \item Length comp data
+#'   \item Length comp data (and generalized size comp data)
 #'   \item Age comp data
 #'   \item Conditional age-at-length data
-#'   \item Length comp fits
+#'   \item Length comp fits (and generalized size comp fits)
 #'   \item Age comp fits
 #'   \item Conditional age-at-length fits
 #'   \item Francis and Punt conditional age-at-length comp fits
@@ -1153,30 +1153,6 @@ SS_plots <-
           )
         if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
 
-        # loop over size methods for generalized size comp data
-        if (nrow(replist[["sizedbase"]]) > 0) {
-          for (sizemethod in sort(unique(replist[["sizedbase"]][["method"]]))) {
-            plotinfo <-
-              SSplotComps(
-                replist = replist, datonly = FALSE, kind = "SIZE", sizemethod = sizemethod,
-                bub = TRUE, verbose = verbose, fleets = fleets, fleetnames = fleetnames,
-                samplesizeplots = samplesizeplots, showsampsize = showsampsize, showeffN = showeffN,
-                minnbubble = minnbubble, pntscalar = pntscalar, cexZ1 = bub.scale.pearson,
-                bublegend = showlegend,
-                maxrows = maxrows, maxcols = maxcols, fixdims = fixdims, rows = rows, cols = cols,
-                plot = !png, print = png, smooth = smooth, plotdir = plotdir,
-                maxneff = maxneff, mainTitle = mainTitle, cex.main = cex.main,
-                cohortlines = cohortlines,
-                sexes = sexes, yupper = comp.yupper,
-                scalebins = scalebins,
-                pwidth = pwidth, pheight = pheight_tall, punits = punits,
-                ptsize = ptsize, res = res,
-                ...
-              )
-            if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
-          }
-        }
-
         # length comp sex ratios (for 2-sex models only)
         if (replist[["nsexes"]] == 2) {
           plotinfo <-
@@ -1200,9 +1176,37 @@ SS_plots <-
             )
           if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
         }
-
+        # assign plots to LenComp tab in HTML view
         if (!is.null(plotInfoTable)) {
           plotInfoTable[["category"]][plotInfoTable[["category"]] == "Comp"] <- "LenComp"
+        }
+
+        # loop over size methods for generalized size comp data
+        if (nrow(replist[["sizedbase"]]) > 0) {
+          for (sizemethod in sort(unique(replist[["sizedbase"]][["method"]]))) {
+            plotinfo <-
+              SSplotComps(
+                replist = replist, datonly = FALSE, kind = "SIZE", sizemethod = sizemethod,
+                bub = TRUE, verbose = verbose, fleets = fleets, fleetnames = fleetnames,
+                samplesizeplots = samplesizeplots, showsampsize = showsampsize, showeffN = showeffN,
+                minnbubble = minnbubble, pntscalar = pntscalar, cexZ1 = bub.scale.pearson,
+                bublegend = showlegend,
+                maxrows = maxrows, maxcols = maxcols, fixdims = fixdims, rows = rows, cols = cols,
+                plot = !png, print = png, smooth = smooth, plotdir = plotdir,
+                maxneff = maxneff, mainTitle = mainTitle, cex.main = cex.main,
+                cohortlines = cohortlines,
+                sexes = sexes, yupper = comp.yupper,
+                scalebins = scalebins,
+                pwidth = pwidth, pheight = pheight_tall, punits = punits,
+                ptsize = ptsize, res = res,
+                ...
+              )
+            if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
+          }
+        }
+        # assign plots to SizeComp tab in HTML view
+        if (!is.null(plotInfoTable)) {
+          plotInfoTable[["category"]][plotInfoTable[["category"]] == "Comp"] <- "SizeComp"
         }
       }
 

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -958,7 +958,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
       )
     }
   }
-  # selecitivty -----
+  # selectivity -----
   # size setup
   # TODO: make sure that this will work when special fleet types are used
   # (e.g., units 30 fleet)
@@ -1274,9 +1274,14 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   # Dirichlet MN pars -----
   # this is turned on in the data file.
   if (use_datlist == TRUE) {
-    if (any(datlist[["len_info"]][["CompError"]] == 1) |
-      any(datlist[["age_info"]][["CompError"]] == 1)) {
-      N_dirichlet_parms <- max(c(datlist[["len_info"]][["ParmSelect"]], datlist[["age_info"]][["ParmSelect"]]))
+    if (any(datlist[["len_info"]][["CompError"]] > 1) |
+      any(datlist[["age_info"]][["CompError"]] > 1) |
+      any(datlist[["CompError_per_method"]] > 1)) {
+      N_dirichlet_parms <- max(
+        datlist[["len_info"]][["ParmSelect"]],
+        datlist[["age_info"]][["ParmSelect"]],
+        datlist[["ParmSelect_per_method"]]
+      )
     }
   }
   if (isTRUE(N_dirichlet_parms > 0)) {
@@ -1421,7 +1426,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   # Create 3.30 variance adjustments and reset DoVar_adjust if true.
   ctllist <- add_df(ctllist,
     name = "Variance_adjustment_list", nrow = NULL, ncol = 3,
-    col.names = c("Factor", "Fleet", "Value")
+    col.names = c("Data_type", "Fleet", "Value")
   )
   if (!is.null(ctllist[["Variance_adjustment_list"]])) ctllist[["DoVar_adjust"]] <- 1
 
@@ -1721,7 +1726,7 @@ translate_3.30_to_3.24_var_adjust <- function(Variance_adjustment_list = NULL,
     if (nrow(Variance_adjustment_list) > 0) {
       for (j in seq_len(nrow(Variance_adjustment_list))) {
         Variance_adjustments[
-          Variance_adjustment_list[j, ][["Factor"]],
+          Variance_adjustment_list[j, ][["Data_type"]],
           Variance_adjustment_list[j, ][["Fleet"]]
         ] <-
           Variance_adjustment_list[j, ][["Value"]]

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1271,12 +1271,17 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
       comments = unlist(age_selex_label)
     )
   }
-  # Dirichlet MN pars -----
+  # Dirichlet-multinomial pars -----
   # this is turned on in the data file.
   if (use_datlist == TRUE) {
-    if (any(datlist[["len_info"]][["CompError"]] > 1) |
-      any(datlist[["age_info"]][["CompError"]] > 1) |
-      any(datlist[["CompError_per_method"]] > 1)) {
+    # first check for CompError > 1
+    # 1 = Dirichlet option 1
+    # 2 = Dirichlet option 2
+    # 3 = MV-Tweedie (not yet implemented here or in SS3)
+    if (any(datlist[["len_info"]][["CompError"]] > 0) |
+      any(datlist[["age_info"]][["CompError"]] > 0) |
+      any(datlist[["CompError_per_method"]] > 0)) {
+      # now get the parameter count
       N_dirichlet_parms <- max(
         datlist[["len_info"]][["ParmSelect"]],
         datlist[["age_info"]][["ParmSelect"]],
@@ -1364,7 +1369,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
     }
     ctllist <- add_2dar(x = ctllist)
   }
-
+  
   # tagging ----
   # TG_custom:  0=no read; 1=read if tags exist
   ctllist <- add_elem(ctllist, name = "TG_custom")

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -591,15 +591,27 @@ SS_readdat_3.30 <-
     }
 
     ## Size frequency methods ----
-    datlist[["N_sizefreq_methods"]] <- get.val(dat, ind)
-    if (datlist[["N_sizefreq_methods"]]) {
+    datlist[["N_sizefreq_methods_rd"]] <- get.val(dat, ind)
+    if (datlist[["N_sizefreq_methods_rd"]] == -1) {
+      # new code added for 3.30.20 to support D-M likelihood
+      datlist[["N_sizefreq_methods"]] <- get.val(dat, ind)
+    } else {
+      # no additional line to read, just copy over value
+      datlist[["N_sizefreq_methods"]] <- datlist[["N_sizefreq_methods_rd"]]
+    }
+    if (datlist[["N_sizefreq_methods"]] > 0) {
       ## Get details of generalized size frequency methods
       datlist[["nbins_per_method"]] <- get.vec(dat, ind)
       datlist[["units_per_method"]] <- get.vec(dat, ind)
       datlist[["scale_per_method"]] <- get.vec(dat, ind)
       datlist[["mincomp_per_method"]] <- get.vec(dat, ind)
       datlist[["Nobs_per_method"]] <- get.vec(dat, ind)
-      ## get list of bin vectors
+      ## Get additional info on composition error distribution (likelihood)
+      if (datlist[["N_sizefreq_methods_rd"]] == -1) {
+        datlist[["Comp_Error_per_method"]] <- get.vec(dat, ind)
+        datlist[["ParmSelect_per_method"]] <- get.vec(dat, ind)
+      }
+      ## Get list of bin vectors
       datlist[["sizefreq_bins_list"]] <- list()
       for (imethod in seq_len(datlist[["N_sizefreq_methods"]])) {
         datlist[["sizefreq_bins_list"]][[imethod]] <- get.vec(dat, ind)

--- a/R/SS_writectl_3.30.R
+++ b/R/SS_writectl_3.30.R
@@ -769,7 +769,7 @@ SS_writectl_3.30 <- function(ctllist, outfile, overwrite = FALSE, verbose = FALS
   writeComment("# Input variance adjustments factors: ")
   if (ctllist[["DoVar_adjust"]] == 0) {
     ctllist[["tmp_var"]] <- c(-9999, 1, 0)
-    writeComment("#_Factor Fleet Value")
+    writeComment("#_Data_type Fleet Value")
     wl.vector("tmp_var", comment = "# terminator")
   } else if (ctllist[["DoVar_adjust"]] == 1) {
     printdf("Variance_adjustment_list", terminate = TRUE)

--- a/R/SS_writedat_3.30.R
+++ b/R/SS_writedat_3.30.R
@@ -393,12 +393,20 @@ SS_writedat_3.30 <- function(datlist,
   if (is.null(d[["N_sizefreq_methods"]])) {
     d[["N_sizefreq_methods"]] <- 0
   }
+  if (d[["N_sizefreq_methods_rd"]] == -1) {
+    wl("N_sizefreq_methods_rd") # conditional code added in 3.30.20
+  }
   wl("N_sizefreq_methods")
   if (d[["N_sizefreq_methods"]] > 0) {
     wl.vector("nbins_per_method", comment = "#_nbins_per_method")
     wl.vector("units_per_method", comment = "#_units_per_method")
     wl.vector("scale_per_method", comment = "#_scale_per_method")
     wl.vector("mincomp_per_method", comment = "#_mincomp_per_method")
+    # Dirichlet-multinomial or MV-Tweedie settings conditioned on code
+    if (d[["N_sizefreq_methods_rd"]] == -1) {
+      wl.vector("Comp_Err_per_method", comment = "#_Comp_Err_per_method")
+      wl.vector("ParmSelect_per_method", comment = "#_ParmSelect_per_method")
+    }
     wl.vector("Nobs_per_method", comment = "#_Nobs_per_method")
     writeComment("#\n#_Sizefreq bins")
     writeComment("#\n#_sizefreq_bins_list")

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -67,6 +67,7 @@ Rebuilder
 ReferencePoints
 Rescale
 Rgui
+RunJitter
 SELEX
 SHA
 SPR
@@ -117,6 +118,7 @@ condbase
 containg
 covar
 cpue
+cran
 csv
 ctl
 ctlfile
@@ -135,6 +137,7 @@ dir
 dirvec
 doesn
 doi
+doRetro
 effN
 effNline
 endyr
@@ -203,6 +206,7 @@ newrow
 newvals
 nlegends
 nlminb
+nmfs
 noaa
 nohess
 nox
@@ -255,6 +259,7 @@ retuning
 reweighting
 r4ss
 rgb
+rstudio
 sampsize
 sampsizeline
 sd
@@ -276,6 +281,7 @@ stackpoly
 staggerpoints
 startyr
 stddev
+subfolder
 subfolders
 subfunctions
 tagdbase

--- a/man/SS_plots.Rd
+++ b/man/SS_plots.Rd
@@ -114,10 +114,10 @@ Current grouping of plots is as follows:
 \item Mean weight
 \item Indices
 \item Numbers at age
-\item Length comp data
+\item Length comp data (and generalized size comp data)
 \item Age comp data
 \item Conditional age-at-length data
-\item Length comp fits
+\item Length comp fits (and generalized size comp fits)
 \item Age comp fits
 \item Conditional age-at-length fits
 \item Francis and Punt conditional age-at-length comp fits

--- a/man/tune_comps.Rd
+++ b/man/tune_comps.Rd
@@ -80,8 +80,8 @@ If \code{write=TRUE} then will write the values to a file
 and called "suggested_tunings.ss").
 }
 \description{
-Creates a table of values that can be copied into the SS control file
-for SS 3.30 models to adjust the input sample sizes for length and age
+Creates a table of values that can be copied into the SS3 control file
+for SS3 3.30 models to adjust the input sample sizes for length and age
 compositions based on either the Francis or McAllister-Ianelli tuning or
 adds the Dirichlet-Multinomial parameters to the necessary files to
 tune the model using an integrated method.
@@ -107,7 +107,7 @@ of the input sample size to the harmonic mean of the effective sample size.
 \subsection{Dirichlet-Multinomial (DM)}{
 
 The Dirichlet-Multinomial likelihood is an alternative approach that allows
-the tuning factor to be estimated rather than iteratively tuned.
+the tuning data type to be estimated rather than iteratively tuned.
 Note that for \code{option = "DM"} a table of tunings is
 not created as the DM is not an iterative reweighting option. Instead, each
 of the fleets with length- and age-composition data will be assigned a DM
@@ -115,26 +115,35 @@ parameter and the model will be rerun.
 }
 }
 
-\section{SS versions}{
+\section{SS3 versions}{
 \subsection{3.30.00-3.30.11}{
 
 Recommended_var_adj and other columns were named differently in these
-early version of SS. Calculations are thus done internally based on
+early version of SS3. Calculations are thus done internally based on
 finding the correct column name.
 }
 
 \subsection{3.30.12-3.30.16}{
 
-Starting with SS version 3.30.12, the "Length_Comp_Fit_Summary"
+Starting with SS3 version 3.30.12, the "Length_Comp_Fit_Summary"
 table in Report.sso is already in the format required to paste into
 the control file to apply the McAllister-Ianelli tuning. However, this
 function provides the additional option of the Francis tuning and the
 ability to compare the two approaches, as well as the functionality to add
 tunings and rerun the model. The "Age_Comp_Fit_Summary" table in Report.sso
 is formatted similarly though, though the Recommended_var_adj was wrongly
-set to 1 for all fleets in SS versions 3.30.12 to 3.30.16. Thus, the
+set to 1 for all fleets in SS3 versions 3.30.12 to 3.30.16. Thus, the
 MI approach is not taken from this recommended column, instead, it is
 calculated from the harmonic mean and input sample sizes.
+}
+
+\subsection{3.30.20}{
+
+Starting with SS3 version 3.30.20, the Dirichlet-multinomial
+likelihood was made available for Generalized Size Comp data. As part
+of this change, the column names were changed for all fit summary
+tables, to both align the notation among them and also facilitate the
+future addition of the Multivariate-Tweedie likelihood.
 }
 }
 


### PR DESCRIPTION
This PR resolves issue #735, where changes in the input and output of the Dirichlet-multinomial setup were required to prepare for the Multivariate-Tweedie distribution and resolve some inconsistencies in the current implementation. DM likelihood is now available for generalized size comp data as well. More detail on the changes is provided in https://github.com/nmfs-stock-synthesis/stock-synthesis/pull/357 and the issues linked from there (associated with the ["Epic: Data weighting improvement" label](https://github.com/nmfs-stock-synthesis/stock-synthesis/labels/Epic%3A%20Data%20weighting%20improvement)).

Changes to `SS_output()` include some re-ordering unrelated to this issue to make things more logical.