### PR TITLE
Ss3 pull request 384 fix

### DIFF
--- a/R/SSplotSpawnrecruit.R
+++ b/R/SSplotSpawnrecruit.R
@@ -107,10 +107,12 @@ SSplotSpawnrecruit <-
     xlab <- labels[1]
     ylab <- labels[2]
     # check if spawning output rather than spawning biomass is plotted
-    if (is.na(replist[["SpawnOutputUnits"]]) ||
+    if (is.null(replist[["SpawnOutputUnits"]]) ||
+      is.na(replist[["SpawnOutputUnits"]]) ||
       replist[["SpawnOutputUnits"]] == "numbers") { # quantity from test in SS_output
       xlab <- labels[3]
     }
+
     if (relative) {
       xlab <- labels[4]
       ylab <- labels[5]


### PR DESCRIPTION
This is in response to the failed checks on [this ss pull request](https://github.com/nmfs-stock-synthesis/stock-synthesis/pull/384). The SSplotSpawnrecruit.R file was changed to add "if (is.null(replist[["SpawnOutputUnits"]]) ||" on line 110. This says that it's 9 commits ahead of main but it's really just one - I was struggling to change the commit message and also changed the name of the branch.