### PR TITLE
change "Ghost" to "Excluded" in legends & captions

### DIFF
--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -301,10 +301,10 @@ SSplotComps <-
       kindlab <- labels[1]
       if (datonly) {
         filenamestart <- "comp_gstlendat_"
-        titledata <- "Ghost length comp data, "
+        titledata <- "Excluded length comp data, "
       } else {
         filenamestart <- "comp_gstlenfit_"
-        titledata <- "Ghost length comps, "
+        titledata <- "Excluded length comps, "
       }
     }
     if (kind == "SIZE") {
@@ -381,10 +381,10 @@ SSplotComps <-
       kindlab <- labels[2]
       if (datonly) {
         filenamestart <- "comp_gstagedat_"
-        titledata <- "Ghost age comp data, "
+        titledata <- "Excluded age comp data, "
       } else {
         filenamestart <- "comp_gstagefit_"
-        titledata <- "Ghost age comps, "
+        titledata <- "Excluded age comps, "
       }
     }
     if (kind == "GSTcond") {
@@ -392,10 +392,10 @@ SSplotComps <-
       kindlab <- labels[2]
       if (datonly) {
         filenamestart <- "comp_gstCAALdat_"
-        titledata <- "Ghost conditional age-at-length data, "
+        titledata <- "Excluded conditional age-at-length data, "
       } else {
         filenamestart <- "comp_gstCAALfit_"
-        titledata <- "Ghost conditional age-at-length comps, "
+        titledata <- "Excluded conditional age-at-length comps, "
       }
     }
     if (kind == "L@A") {
@@ -1271,7 +1271,7 @@ SSplotComps <-
         dbasef <- dbase_kind[dbase_kind[["Fleet"]] == f, ]
         # get mean sample quantities to show in conditional age-at-length figures
         if (kind %in% c("cond", "GSTcond") && f %in% Age_tuning[["Fleet"]]) {
-          #### these values not to be trusted in the presence of ghost data:
+          #### these values not to be trusted in the presence of excluded data:
           ## HarmEffNage <- Age_tuning$"HarMean(effN)"[Age_tuning[["Fleet"]]==f]
           ## MeanNage    <- Age_tuning$"mean(inputN*Adj)"[Age_tuning[["Fleet"]]==f]
           HarmEffNage <- NULL

--- a/R/SSplotData.R
+++ b/R/SSplotData.R
@@ -125,9 +125,9 @@ SSplotData <- function(replist,
     "sizedbase", "Size compositions", # 4
     "agedbase", "Age compositions", # 5
     "condbase", "Conditional age-at-length compositions", # 6
-    "ghostagedbase", "Ghost age compositions", # 7
-    "ghostcondbase", "Ghost conditional age-at-length compositions", # 8
-    "ghostlendbase", "Ghost length compositions", # 9
+    "ghostagedbase", "Excluded age compositions", # 7
+    "ghostcondbase", "Excluded conditional age-at-length compositions", # 8
+    "ghostlendbase", "Excluded length compositions", # 9
     "ladbase", "Mean length-at-age", # 10
     "wadbase", "Mean weight-at-age", # 11
     "mnwgt", "Mean body weight", # 12
@@ -462,7 +462,7 @@ SSplotData <- function(replist,
         "total catch for catches; to precision for indices, discards, and <br> ",
         "mean body weight observations; and to total sample size for <br>",
         "compositions and mean weight- or length-at-age observations. <br>",
-        "'Ghost' observations (not included in the likelihood) have <br>",
+        "Observations excluded from the likelihood have <br>",
         "equal size for all years. <br>",
         "Note that since the circles are are scaled relative <br> ",
         "to maximum within each type, the scaling within separate plots <br> ",


### PR DESCRIPTION
Simple change to avoid confusion with ghost gear (https://oceanservice.noaa.gov/facts/ghostfishing.html) or IUU fishing as discussed by NWFSC and SWFSC assessment teams here: https://github.com/pfmc-assessments/PEPtools/issues/26.