### PR TITLE
support new forecast averaging option in SS3, fixes bugs related to output of time-varying M

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -1584,12 +1584,11 @@ SS_output <-
         if (stats[["N_estimated_parameters"]] != N_estimated_parameters2) {
           warning(
             stats[["N_estimated_parameters"]],
-            "estimated parameters indicated by", parfile, "\n",
+            " estimated parameters indicated by the par file\n  ",
             N_estimated_parameters2,
-            "estimated parameters shown in", covarfile, "\n",
-            "returning the first value:", stats[["N_estimated_parameters"]]
+            " estimated parameters shown in the covar file\n  ",
+            "Returning the par file value: ", stats[["N_estimated_parameters"]]
           )
-          stats[["N_estimated_parameters"]] <- stats[["N_estimated_parameters"]]
         }
       }
       Nstd <- sum(stdtable[["std"]] > 0)
@@ -3611,14 +3610,21 @@ SS_output <-
     }
     returndat[["Z_at_age"]] <- Z_at_age
 
-    # M at age table ends with comments
-    #   Note:  Z calculated as -ln(Nt+1 / Nt)
-    #   Note:  Z calculation for maxage not possible, for maxage-1 includes numbers at maxage, so is approximate
-    M_at_age <- match_report_table("Z_AT_AGE_Annual_1", 1,
-      "-ln(Nt+1", -1,
-      matchcol2 = 5,
-      header = TRUE
-    )
+    if (!is.na(match_report_line("Report_Z_by_area_morph_platoon"))) {
+      # from 3.30.16.03 onward the old end of the Z_AT_AGE_Annual 1 table 
+      # doesn't work so should just use the blank line 
+      # (not available in early versions)
+      M_at_age <- match_report_table("Z_AT_AGE_Annual_1", 1, header = TRUE)
+    } else {
+      # In earlier versions the M at age table ended with comments
+      #   Note:  Z calculated as -ln(Nt+1 / Nt)
+      #   Note:  Z calculation for maxage not possible, for maxage-1 includes numbers at maxage, so is approximate
+      M_at_age <- match_report_table("Z_AT_AGE_Annual_1", 1,
+        "-ln(Nt+1", -1,
+        matchcol2 = 5,
+        header = TRUE
+      )
+    }
     if (!is.null(M_at_age)) {
       M_at_age[M_at_age == "_"] <- NA
       # if birth season is not season 1, you can get infinite values
@@ -3641,6 +3647,7 @@ SS_output <-
         )
         M_by_area <- match_report_table("Report_Z_by_area_morph_platoon_1",
           adjust1 = 1,
+          adjust2 = -3, # remove 2 lines at end ("Note:  Z calculated as -ln(Nt+1 / Nt)")
           header = TRUE,
           type.convert = TRUE
         )

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -3611,8 +3611,8 @@ SS_output <-
     returndat[["Z_at_age"]] <- Z_at_age
 
     if (!is.na(match_report_line("Report_Z_by_area_morph_platoon"))) {
-      # from 3.30.16.03 onward the old end of the Z_AT_AGE_Annual 1 table 
-      # doesn't work so should just use the blank line 
+      # from 3.30.16.03 onward the old end of the Z_AT_AGE_Annual 1 table
+      # doesn't work so should just use the blank line
       # (not available in early versions)
       M_at_age <- match_report_table("Z_AT_AGE_Annual_1", 1, header = TRUE)
     } else {

--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -284,7 +284,17 @@ SS_readforecast <- function(file = "forecast.ss",
     forelist <- add_elem(forelist, "First_forecast_loop_with_stochastic_recruitment")
     forelist <- add_elem(forelist, "fcast_rec_option")
     forelist <- add_elem(forelist, "fcast_rec_val")
-    forelist <- add_elem(forelist, "Forecast_loop_control_5")
+    forelist <- add_elem(forelist, "Fcast_MGparm_averaging") # 0 = not, 1 = do
+
+    # new option added in 3.30.22 to forecast using average values
+    if (forelist[["Fcast_MGparm_averaging"]] == 1) {
+      forelist <- add_df(forelist,
+        ncol = 4,
+        col.names = c("MG_type", "method", "st_year", "end_year"),
+        name = "Fcast_MGparm_averaging_info"
+      )
+    }
+
     forelist <- add_elem(forelist, "FirstYear_for_caps_and_allocations")
     forelist <- add_elem(forelist, "stddev_of_log_catch_ratio")
     forelist <- add_elem(forelist, "Do_West_Coast_gfish_rebuilder_output")

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -136,7 +136,18 @@ SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
       }
       wl("fcast_rec_option")
       wl("fcast_rec_val")
-      wl("Forecast_loop_control_5")
+      # new option added in 3.30.22 to forecast using average values
+      if (!is.null(mylist[["Forecast_loop_control_5"]])) {
+        warning(
+          "Forecast_loop_control_5 has been renamed to Fcast_MGparm_averaging\n",
+          " so only Fcast_MGparm_averaging will be written to the file."
+        )
+      }
+      wl("Fcast_MGparm_averaging")
+      if (mylist[["Fcast_MGparm_averaging"]] == 1) {
+        printdf("Fcast_MGparm_averaging_info")
+        writeLines("-9999 0 0 0")
+      }
       wl("FirstYear_for_caps_and_allocations")
       wl("stddev_of_log_catch_ratio")
       wl("Do_West_Coast_gfish_rebuilder_output")

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -1601,7 +1601,7 @@ SSplotBiology <-
               # check for changes
               if (length(unique(parmvals[MGparmAdj[["Yr"]] <= endyr])) > 1) {
                 # make plot
-                if (plot) timeVaryingParmFunc(parmlabel)
+                if (plot) timeVaryingParmFunc(parmlabel, forecast = forecast)
                 if (print) {
                   file <- paste0("bio24_time-varying_", parmlabel, ".png")
                   # replace % sign which cause problems for filename
@@ -1615,7 +1615,7 @@ SSplotBiology <-
                     pheight = pheight, punits = punits, res = res, ptsize = ptsize,
                     caption = caption
                   )
-                  timeVaryingParmFunc(parmlabel)
+                  timeVaryingParmFunc(parmlabel, forecast = forecast)
                   dev.off()
                 }
               }


### PR DESCRIPTION
Resolves issue #789.

* Fixes issue in `SS_output()` related to parsing the tables of M at age by year
* Allows plots of time-varying mortality and growth parameters to extend into the forecast
* Adds new forecast option to `SS_readforecast()` and `SS_writeforecast()`
