### PR TITLE
Invisible return of logical from `copy_SS_inputs()`

### DIFF
--- a/R/copy_SS_inputs.R
+++ b/R/copy_SS_inputs.R
@@ -18,7 +18,9 @@
 #' @param copy_par Copy any .par files found in dir.old to dir.new?
 #' @param dir.exe Path to executable to copy instead of any in dir.old
 #' @template verbose
-#' @return Logical indicating whether all input files were copied successfully.
+#' @return
+#' A logical value is invisibly returned, indicating whether all input files
+#' were copied successfully.
 #' @author Ian G. Taylor
 #' @export
 #' @family run functions
@@ -66,13 +68,13 @@ copy_SS_inputs <- function(dir.old = NULL,
     starter <- SS_readstarter(starter_file, verbose = FALSE)
   } else {
     warning("file not found: ", file.path(starter_file))
-    return(FALSE)
+    return(invisible(FALSE))
   }
 
   # check for starter file in new location
   if (!overwrite && file.exists(file.path(dir.new, "starter.ss"))) {
     warning("overwrite = FALSE and starter.ss exists in ", dir.new)
-    return(FALSE)
+    return(invisible(FALSE))
   }
 
   if (verbose) {
@@ -193,7 +195,7 @@ copy_SS_inputs <- function(dir.old = NULL,
     if (verbose) {
       message("copying complete")
     }
-    return(TRUE)
+    return(invisible(TRUE))
   } else {
     if (verbose) {
       if (overwrite) {
@@ -202,6 +204,6 @@ copy_SS_inputs <- function(dir.old = NULL,
         warning("at least 1 file failed to copy, try 'overwrite = TRUE'")
       }
     }
-    return(FALSE)
+    return(invisible(FALSE))
   }
 }

--- a/R/copy_SS_inputs.R
+++ b/R/copy_SS_inputs.R
@@ -26,10 +26,18 @@
 #' @family run functions
 #' @examples
 #' \dontrun{
+#' # A theoretical example if "old_model" was present
+#' # but expect an error
 #' copy_SS_inputs(
 #'   dir.old = "c:/SS/old_model",
 #'   dir.new = "c:/SS/new_model"
 #' )
+#' # A working example using files stored in {r4ss}
+#' copy_SS_inputs(
+#'   dir.old = system.file("extdata", "simple_small", package = "r4ss"),
+#'   dir.new = "test"
+#' )
+#' unlink(test, recursive = TRUE)
 #' }
 #'
 copy_SS_inputs <- function(dir.old = NULL,

--- a/R/copy_SS_inputs.R
+++ b/R/copy_SS_inputs.R
@@ -8,15 +8,16 @@
 #' path or relative to the working directory.
 #' @param dir.new New location to which the files should be copied,
 #' either an absolute path or relative to the working directory.
-#' @param create.dir Create dir.new directory if it doesn't exist already?
+#' @param create.dir Create `dir.new` directory if it doesn't exist already?
 #' @template overwrite
-#' @param recursive logical. Should elements of the path other than the last be
-#'        created?
+#' @param recursive A logical value passed to the `recursive` argument of
+#' [dir.create()] that specifies if elements of the path other than the last
+#' be created?
 #' @param use_ss_new Use .ss_new files instead of original inputs?
-#' @param copy_exe Copy any executables found in dir.old to dir.new or
+#' @param copy_exe Copy any executables found in `dir.old` to `dir.new` or
 #' dir.exe (if provided)?
-#' @param copy_par Copy any .par files found in dir.old to dir.new?
-#' @param dir.exe Path to executable to copy instead of any in dir.old
+#' @param copy_par Copy any .par files found in `dir.old` to `dir.new`?
+#' @param dir.exe Path to executable to copy instead of any in `dir.old`.
 #' @template verbose
 #' @return
 #' A logical value is invisibly returned, indicating whether all input files

--- a/man/copy_SS_inputs.Rd
+++ b/man/copy_SS_inputs.Rd
@@ -24,28 +24,30 @@ path or relative to the working directory.}
 \item{dir.new}{New location to which the files should be copied,
 either an absolute path or relative to the working directory.}
 
-\item{create.dir}{Create dir.new directory if it doesn't exist already?}
+\item{create.dir}{Create \code{dir.new} directory if it doesn't exist already?}
 
 \item{overwrite}{A logical value specifying if the existing file(s)
 should be overwritten. The default value is \code{overwrite = FALSE}.}
 
-\item{recursive}{logical. Should elements of the path other than the last be
-created?}
+\item{recursive}{A logical value passed to the \code{recursive} argument of
+\code{\link[=dir.create]{dir.create()}} that specifies if elements of the path other than the last
+be created?}
 
 \item{use_ss_new}{Use .ss_new files instead of original inputs?}
 
-\item{copy_exe}{Copy any executables found in dir.old to dir.new or
+\item{copy_exe}{Copy any executables found in \code{dir.old} to \code{dir.new} or
 dir.exe (if provided)?}
 
-\item{copy_par}{Copy any .par files found in dir.old to dir.new?}
+\item{copy_par}{Copy any .par files found in \code{dir.old} to \code{dir.new}?}
 
-\item{dir.exe}{Path to executable to copy instead of any in dir.old}
+\item{dir.exe}{Path to executable to copy instead of any in \code{dir.old}.}
 
 \item{verbose}{A logical value specifying if output should be printed
 to the screen.}
 }
 \value{
-Logical indicating whether all input files were copied successfully.
+A logical value is invisibly returned, indicating whether all input files
+were copied successfully.
 }
 \description{
 Reads the starter.ss file to figure out the names of the control and
@@ -54,10 +56,18 @@ and wtatage.ss (if present) to a new directory, as specified.
 }
 \examples{
 \dontrun{
+# A theoretical example if "old_model" was present
+# but expect an error
 copy_SS_inputs(
   dir.old = "c:/SS/old_model",
   dir.new = "c:/SS/new_model"
 )
+# A working example using files stored in {r4ss}
+copy_SS_inputs(
+  dir.old = system.file("extdata", "simple_small", package = "r4ss"),
+  dir.new = "test"
+)
+unlink(test, recursive = TRUE)
 }
 
 }


### PR DESCRIPTION
Small trivial changes to copy_SS_inputs where
* return of logical, TRUE or FALSE, is now invisible so users do not have to assign the function call to a dummy object to suppress the output 
* updated some documentation spacing and added a full stop to the end of an explanation
* updated the documentation for the recursive argument because I didn't understand what it was doing
* added an example that all users can run on their machine

@iantaylor-NOAA I added you as a reviewer to merge this in but you shouldn't actually have to review anything, pretty simple changes I mainly just wanted GitHub actions to run through the checks first before bringing it in to main.