### PR TITLE
add "Total without prior" line to profile plots

### DIFF
--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -283,7 +283,7 @@ SSplotProfile <-
     if (add_no_prior_line) {
       component.labels.used <- c(component.labels.used, "Total without prior")
     }
-    
+
     # define colors and line types
     if (col[1] == "default") {
       col <- rich.colors.short(nlines)
@@ -300,7 +300,7 @@ SSplotProfile <-
     lwd <- c(lwd.total, rep(lwd, nlines - 1), ifelse(add_no_prior_line, lwd, NULL))
     cex <- c(cex.total, rep(cex, nlines - 1), ifelse(add_no_prior_line, cex.total, NULL))
     lty <- c(lty.total, rep(lty, nlines - 1), ifelse(add_no_prior_line, 2, NULL))
-    
+
     # make plot
     plotprofile <- function() {
       plot(0,
@@ -313,7 +313,8 @@ SSplotProfile <-
       if (add_cutoff) {
         abline(h = 0.5 * qchisq(p = cutoff_prob, df = 1), lty = 2)
       }
-      matplot(x = parvec, 
+      matplot(
+        x = parvec,
         y = prof.table,
         type = type,
         pch = pch, col = col,

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -225,9 +225,14 @@ SSplotProfile <-
     par_prior_like_vec <- as.numeric(par_prior_likes[par_prior_likes[["Label"]] == parlabel, models])
     # turn off addition of "Total without prior" line if there is no prior
     # on the parameter being profiled over
-    if (all(par_prior_like_vec) == 0) {
+    if (all(is.na(par_prior_like_vec))) {
       add_no_prior_line <- FALSE
     }
+    par_prior_like_vec[is.na(par_prior_like_vec)] <- 0
+    if (all(par_prior_like_vec == 0)) {
+      add_no_prior_line <- FALSE
+    }
+
     if (verbose & add_no_prior_line) {
       message(
         "Parameter prior likelihoods: ",
@@ -252,7 +257,6 @@ SSplotProfile <-
     }
 
     # calculate total likelihood without any prior on the profiled parameter
-    par_prior_like_vec[is.na(par_prior_like_vec)] <- 0
     TOTAL_no_prior <- prof.table[["TOTAL"]] - par_prior_like_vec
 
     # subtract minimum value from each likelihood component (over requested parameter range)
@@ -321,10 +325,12 @@ SSplotProfile <-
       col <- c(col, col[1])
       pch <- c(pch, NA)
     }
+
     # make total line wider with bigger points (or whatever user chooses)
-    lwd <- c(lwd.total, rep(lwd, nlines - 1), ifelse(add_no_prior_line, lwd, NULL))
-    cex <- c(cex.total, rep(cex, nlines - 1), ifelse(add_no_prior_line, cex.total, NULL))
-    lty <- c(lty.total, rep(lty, nlines - 1), ifelse(add_no_prior_line, 2, NULL))
+    # uses switch() instead of ifelse() because ifelse() doesn't return NULL
+    lwd <- c(lwd.total, rep(lwd, nlines - 1), switch(add_no_prior_line + 1, NULL, lwd))
+    cex <- c(cex.total, rep(cex, nlines - 1), switch(add_no_prior_line + 1, NULL, cex.total))
+    lty <- c(lty.total, rep(lty, nlines - 1), switch(add_no_prior_line + 1, NULL, 2))
 
     # make plot
     plotprofile <- function() {

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -220,10 +220,10 @@ SSplotProfile <-
         paste0(parvec, collapse = ", ")
       )
     }
-    
+
     # get vector of prior likelihoods for this parameter
     par_prior_like_vec <- as.numeric(par_prior_likes[par_prior_likes[["Label"]] == parlabel, models])
-    # turn off addition of "Total without prior" line if there is no prior 
+    # turn off addition of "Total without prior" line if there is no prior
     # on the parameter being profiled over
     if (all(par_prior_like_vec) == 0) {
       add_no_prior_line <- FALSE
@@ -289,7 +289,7 @@ SSplotProfile <-
     prof.table <- prof.table[order(parvec), include]
     TOTAL_no_prior <- TOTAL_no_prior[order(parvec)]
     parvec <- parvec[order(parvec)]
-    
+
     # reorder columns by largest change (if requested, and more than 1 line)
     change.fraction <- change.fraction[include]
     if (nlines > 1) {
@@ -302,7 +302,7 @@ SSplotProfile <-
 
     # add TOTAL_no_prior to table
     # Note: this is done at this stage rather than when first calculated
-    # to avoid dealing with this column while filtering and reordering 
+    # to avoid dealing with this column while filtering and reordering
     # the other columns
     prof.table <- data.frame(prof.table, TOTAL_no_prior)
     if (add_no_prior_line) {

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -90,7 +90,7 @@ SSsummarize <- function(biglist,
   allyears <- sort(allyears) # not actually getting any timeseries stuff yet
 
   # objects to store quantities
-  pars <- parsSD <- parphases <- par_prior_likes <- 
+  pars <- parsSD <- parphases <- par_prior_likes <-
     as.data.frame(matrix(NA, nrow = length(parnames), ncol = n))
   quants <- quantsSD <- as.data.frame(matrix(NA, nrow = length(dernames), ncol = n))
   maxgrad <- NULL
@@ -346,12 +346,12 @@ SSsummarize <- function(biglist,
 
 
   ### format and process info from the models
-  names(pars) <- names(parsSD) <- names(parphases) <- names(par_prior_likes) <- 
+  names(pars) <- names(parsSD) <- names(parphases) <- names(par_prior_likes) <-
     modelnames
   names(quants) <- names(quantsSD) <- modelnames
   names(likelihoods) <- names(likelambdas) <- modelnames
 
-  pars[["Label"]] <- parsSD[["Label"]] <- parphases[["Label"]] <- 
+  pars[["Label"]] <- parsSD[["Label"]] <- parphases[["Label"]] <-
     par_prior_likes[["Label"]] <- parnames
   quants[["Label"]] <- quantsSD[["Label"]] <- dernames
   likelihoods[["Label"]] <- likelambdas[["Label"]] <- likenames

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -90,7 +90,8 @@ SSsummarize <- function(biglist,
   allyears <- sort(allyears) # not actually getting any timeseries stuff yet
 
   # objects to store quantities
-  pars <- parsSD <- parphases <- as.data.frame(matrix(NA, nrow = length(parnames), ncol = n))
+  pars <- parsSD <- parphases <- par_prior_likes <- 
+    as.data.frame(matrix(NA, nrow = length(parnames), ncol = n))
   quants <- quantsSD <- as.data.frame(matrix(NA, nrow = length(dernames), ncol = n))
   maxgrad <- NULL
   nsexes <- NULL
@@ -272,6 +273,7 @@ SSsummarize <- function(biglist,
       pars[parnames == parstemp[["Label"]][ipar], imodel] <- parstemp[["Value"]][ipar]
       parsSD[parnames == parstemp[["Label"]][ipar], imodel] <- parstemp[["Parm_StDev"]][ipar]
       parphases[parnames == parstemp[["Label"]][ipar], imodel] <- parstemp[["Phase"]][ipar]
+      par_prior_likes[parnames == parstemp[["Label"]][ipar], imodel] <- parstemp[["Pr_Like"]][ipar]
     }
     if (verbose) {
       message("  N active pars = ", sum(!is.na(parstemp[["Active_Cnt"]])))
@@ -344,11 +346,13 @@ SSsummarize <- function(biglist,
 
 
   ### format and process info from the models
-  names(pars) <- names(parsSD) <- names(parphases) <- modelnames
+  names(pars) <- names(parsSD) <- names(parphases) <- names(par_prior_likes) <- 
+    modelnames
   names(quants) <- names(quantsSD) <- modelnames
   names(likelihoods) <- names(likelambdas) <- modelnames
 
-  pars[["Label"]] <- parsSD[["Label"]] <- parphases[["Label"]] <- parnames
+  pars[["Label"]] <- parsSD[["Label"]] <- parphases[["Label"]] <- 
+    par_prior_likes[["Label"]] <- parnames
   quants[["Label"]] <- quantsSD[["Label"]] <- dernames
   likelihoods[["Label"]] <- likelambdas[["Label"]] <- likenames
   # extract year values from labels for some parameters associated with years
@@ -616,7 +620,7 @@ SSsummarize <- function(biglist,
       deparse(substitute(data)) == "pars") {
       message(
         "For model(s) ", paste(fix, collapse = ", "),
-        ", values in 'pars', 'parsSD', and 'parphases' for\n",
+        ", values in 'pars', 'parsSD', 'parphases', and 'par_prior_likes' for\n",
         paste(data[oldrows, "Label"], data[newrows, "Label"],
           sep = " -> ", collapse = ", "
         ),
@@ -647,6 +651,7 @@ SSsummarize <- function(biglist,
   mylist[["pars"]] <- copy.dm(pars)
   mylist[["parsSD"]] <- copy.dm(parsSD)
   mylist[["parphases"]] <- copy.dm(parphases)
+  mylist[["par_prior_likes"]] <- copy.dm(par_prior_likes)
   mylist[["quants"]] <- quants
   mylist[["quantsSD"]] <- quantsSD
   mylist[["likelihoods"]] <- likelihoods

--- a/R/profile.R
+++ b/R/profile.R
@@ -85,8 +85,7 @@ SS_profile <- function(...) {
 #' # example profile
 #' # (assumes you have an SS3 exe called "ss.exe" or "ss" in your PATH)
 #' ###########################################################################
-#' }
-
+#'
 #' # directory for "simple_small" example model included with r4ss
 #' dir_simple_small <- file.path(
 #'   path.package("r4ss"),

--- a/R/profile.R
+++ b/R/profile.R
@@ -80,48 +80,66 @@ SS_profile <- function(...) {
 #' @family profile functions
 #' @examples
 #' \dontrun{
-#' # note: don't run this in your main directory
-#' # make a copy in case something goes wrong
-#' mydir <- "C:/ss/Simple - Copy"
+#'
+#' ###########################################################################
+#' # example profile
+#' # (assumes you have an SS3 exe called "ss.exe" or "ss" in your PATH)
+#' ###########################################################################
+#' }
+
+#' # directory for "simple_small" example model included with r4ss
+#' dir_simple_small <- file.path(
+#'   path.package("r4ss"),
+#'   file.path("extdata", "simple_small")
+#' )
+#'
+#' # create temporary directory and copy files into it
+#' dir_prof <- file.path(tempdir(), "profile")
+#' copy_SS_inputs(
+#'   dir.old = dir_simple_small,
+#'   dir.new = dir_prof,
+#'   create.dir = TRUE,
+#'   overwrite = TRUE,
+#'   copy_par = TRUE,
+#'   verbose = TRUE
+#' )
 #'
 #' # the following commands related to starter.ss could be done by hand
 #' # read starter file
-#' starter <- SS_readstarter(file.path(mydir, "starter.ss"))
+#' starter <- SS_readstarter(file.path(dir_prof, "starter.ss"))
 #' # change control file name in the starter file
 #' starter[["ctlfile"]] <- "control_modified.ss"
 #' # make sure the prior likelihood is calculated
 #' # for non-estimated quantities
 #' starter[["prior_like"]] <- 1
 #' # write modified starter file
-#' SS_writestarter(starter, dir = mydir, overwrite = TRUE)
-#'
+#' SS_writestarter(starter, dir = dir_prof, overwrite = TRUE)
 #' # vector of values to profile over
 #' h.vec <- seq(0.3, 0.9, .1)
 #' Nprofile <- length(h.vec)
-#'
 #' # run profile command
 #' profile <- profile(
-#'   dir = mydir,
-#'   oldctlfile = "control.ss_new",
+#'   dir = dir_prof,
+#'   oldctlfile = "control.ss",
 #'   newctlfile = "control_modified.ss",
 #'   string = "steep", # subset of parameter label
 #'   profilevec = h.vec
 #' )
-#'
-#'
 #' # read the output files (with names like Report1.sso, Report2.sso, etc.)
-#' profilemodels <- SSgetoutput(dirvec = mydir, keyvec = 1:Nprofile)
+#' profilemodels <- SSgetoutput(dirvec = dir_prof, keyvec = 1:Nprofile)
 #' # summarize output
 #' profilesummary <- SSsummarize(profilemodels)
 #'
 #' # OPTIONAL COMMANDS TO ADD MODEL WITH PROFILE PARAMETER ESTIMATED
-#' MLEmodel <- SS_output("C:/ss/SSv3.24l_Dec5/Simple")
+#' # (in the "simple_small" example, steepness is fixed so it doesn't
+#' # have any impact)
+#' MLEmodel <- SS_output(dir_simple_small, verbose = FALSE, printstats = FALSE)
 #' profilemodels[["MLE"]] <- MLEmodel
 #' profilesummary <- SSsummarize(profilemodels)
 #' # END OPTIONAL COMMANDS
 #'
 #' # plot profile using summary created above
-#' SSplotProfile(profilesummary, # summary object
+#' results <- SSplotProfile(profilesummary, # summary object
 #'   profile.string = "steep", # substring of profile parameter
 #'   profile.label = "Stock-recruit steepness (h)"
 #' ) # axis label
@@ -129,61 +147,76 @@ SS_profile <- function(...) {
 #' # make timeseries plots comparing models in profile
 #' SSplotComparisons(profilesummary, legendlabels = paste("h =", h.vec))
 #'
-#'
+#' ###########################################################################
+#' # example two-dimensional profile
+#' # (assumes you have an SS3 exe called "ss.exe" or "ss" in your PATH)
 #' ###########################################################################
 #'
-#' # example two-dimensional profile
-#' # (e.g. over 2 of the parameters in the low-fecundity stock-recruit function)
-#' base_dir <- "c:/mymodel"
+#' dir_simple_small <- file.path(
+#'   path.package("r4ss"),
+#'   file.path("extdata", "simple_small")
+#' )
 #'
-#' dir_profile_SR <- file.path(base_dir, "Profiles/Zfrac_and_Beta")
+#' # create temporary directory and copy files into it
+#' dir_prof <- file.path(tempdir(), "profile_2D")
+#' copy_SS_inputs(
+#'   dir.old = dir_simple_small,
+#'   dir.new = dir_prof,
+#'   create.dir = TRUE,
+#'   overwrite = TRUE,
+#'   copy_par = TRUE,
+#'   verbose = TRUE
+#' )
 #'
-#' # make a grid of values in both dimensions Zfrac and Beta
-#' # vector of values to profile over
-#' Zfrac_vec <- seq(from = 0.2, to = 0.6, by = 0.1)
-#' Beta_vec <- c(0.5, 0.75, 1.0, 1.5, 2.0)
-#' par_table <- expand.grid(Zfrac = Zfrac_vec, Beta = Beta_vec)
-#' nrow(par_table)
-#' ## [1] 25
-#' head(par_table)
-#' ##   Zfrac Beta
-#' ## 1   0.2 0.50
-#' ## 2   0.3 0.50
-#' ## 3   0.4 0.50
-#' ## 4   0.5 0.50
-#' ## 5   0.6 0.50
-#' ## 6   0.2 0.75
 #'
-#' # run profile command
-#' profile <- profile(
-#'   dir = dir_profile_SR, # directory
+#' # create table of M values for females and males
+#' par_table <- expand.grid(
+#'   M1vec = c(0.05, 0.10, 0.15),
+#'   M2vec = c(0.05, 0.10, 0.15)
+#' )
+#'
+#' # run model once to create control.ss_new with
+#' # good starting parameter values
+#' # exe is assumed to be in PATH, add "exe" argument if needed
+#' run(dir_prof, extras = "-nohess")
+#'
+#' # run profile using ss_new file as parameter source and
+#' # overwriting original control file with new values
+#' prof.table <- profile(
+#'   dir = dir_prof,
 #'   oldctlfile = "control.ss_new",
-#'   newctlfile = "control_modified.ss",
-#'   string = c("Zfrac", "Beta"),
+#'   newctlfile = "control.ss",
+#'   string = c("NatM_uniform_Fem_GP_1", "NatM_uniform_Mal_GP_1"),
 #'   profilevec = par_table,
-#'   extras = "-nohess" # argument passed to run()
+#'   extras = "-nohess"
 #' )
 #'
 #' # get model output
 #' profilemodels <- SSgetoutput(
-#'   dirvec = dir_profile_SR,
+#'   dirvec = dir_prof,
 #'   keyvec = 1:nrow(par_table), getcovar = FALSE
 #' )
 #' n <- length(profilemodels)
 #' profilesummary <- SSsummarize(profilemodels)
 #'
 #' # add total likelihood (row 1) to table created above
-#' par_table[["like"]] <- as.numeric(profilesummary[["likelihoods"]][1, 1:n])
+#' par_table$like <- as.numeric(profilesummary$likelihoods[1, 1:n])
 #'
 #' # reshape data frame into a matrix for use with contour
-#' like_matrix <- reshape2::acast(par_table, Zfrac ~ Beta, value.var = "like")
-#'
-#' # make contour plot
-#' contour(
-#'   x = as.numeric(rownames(like_matrix)),
-#'   y = as.numeric(colnames(like_matrix)),
-#'   z = like_matrix
+#' like_matrix <- reshape2::acast(
+#'   data = par_table,
+#'   formula = M1vec ~ M2vec,
+#'   value.var = "like"
 #' )
+#'
+#' # look at change relative to the minimum
+#' # (shows small change when female and male M are equal,
+#' # big change when they are different)
+#' like_matrix - min(like_matrix)
+#' #         0.05    0.1    0.15
+#' # 0.05   6.938 32.710 121.959
+#' # 0.1   49.706  0.000  27.678
+#' # 0.15 154.897 44.768   5.366
 #' }
 #'
 profile <- function(dir,

--- a/man/SSplotProfile.Rd
+++ b/man/SSplotProfile.Rd
@@ -49,6 +49,7 @@ SSplotProfile(
   plotdir = NULL,
   add_cutoff = FALSE,
   cutoff_prob = 0.95,
+  add_no_prior_line = TRUE,
   verbose = TRUE,
   ...
 )
@@ -162,6 +163,9 @@ freedom: \code{0.5*qchisq(p=cutoff_prob, df=1)}. The probability value
 can be adjusted using the \code{cutoff_prob} below.}
 
 \item{cutoff_prob}{Probability associated with \code{add_cutoff} above.}
+
+\item{add_no_prior_line}{Add line showing total likelihood without
+the prior (only appears when profiled parameter that includes a prior)}
 
 \item{verbose}{A logical value specifying if output should be printed
 to the screen.}

--- a/man/profile.Rd
+++ b/man/profile.Rd
@@ -112,48 +112,65 @@ be read using \code{\link[=SSgetoutput]{SSgetoutput()}} or by multiple calls to
 }
 \examples{
 \dontrun{
-# note: don't run this in your main directory
-# make a copy in case something goes wrong
-mydir <- "C:/ss/Simple - Copy"
+
+###########################################################################
+# example profile
+# (assumes you have an SS3 exe called "ss.exe" or "ss" in your PATH)
+###########################################################################
+
+# directory for "simple_small" example model included with r4ss
+dir_simple_small <- file.path(
+  path.package("r4ss"),
+  file.path("extdata", "simple_small")
+)
+
+# create temporary directory and copy files into it
+dir_prof <- file.path(tempdir(), "profile")
+copy_SS_inputs(
+  dir.old = dir_simple_small,
+  dir.new = dir_prof,
+  create.dir = TRUE,
+  overwrite = TRUE,
+  copy_par = TRUE,
+  verbose = TRUE
+)
 
 # the following commands related to starter.ss could be done by hand
 # read starter file
-starter <- SS_readstarter(file.path(mydir, "starter.ss"))
+starter <- SS_readstarter(file.path(dir_prof, "starter.ss"))
 # change control file name in the starter file
 starter[["ctlfile"]] <- "control_modified.ss"
 # make sure the prior likelihood is calculated
 # for non-estimated quantities
 starter[["prior_like"]] <- 1
 # write modified starter file
-SS_writestarter(starter, dir = mydir, overwrite = TRUE)
-
+SS_writestarter(starter, dir = dir_prof, overwrite = TRUE)
 # vector of values to profile over
 h.vec <- seq(0.3, 0.9, .1)
 Nprofile <- length(h.vec)
-
 # run profile command
 profile <- profile(
-  dir = mydir,
-  oldctlfile = "control.ss_new",
+  dir = dir_prof,
+  oldctlfile = "control.ss",
   newctlfile = "control_modified.ss",
   string = "steep", # subset of parameter label
   profilevec = h.vec
 )
-
-
 # read the output files (with names like Report1.sso, Report2.sso, etc.)
-profilemodels <- SSgetoutput(dirvec = mydir, keyvec = 1:Nprofile)
+profilemodels <- SSgetoutput(dirvec = dir_prof, keyvec = 1:Nprofile)
 # summarize output
 profilesummary <- SSsummarize(profilemodels)
 
 # OPTIONAL COMMANDS TO ADD MODEL WITH PROFILE PARAMETER ESTIMATED
-MLEmodel <- SS_output("C:/ss/SSv3.24l_Dec5/Simple")
+# (in the "simple_small" example, steepness is fixed so it doesn't
+# have any impact)
+MLEmodel <- SS_output(dir_simple_small, verbose = FALSE, printstats = FALSE)
 profilemodels[["MLE"]] <- MLEmodel
 profilesummary <- SSsummarize(profilemodels)
 # END OPTIONAL COMMANDS
 
 # plot profile using summary created above
-SSplotProfile(profilesummary, # summary object
+results <- SSplotProfile(profilesummary, # summary object
   profile.string = "steep", # substring of profile parameter
   profile.label = "Stock-recruit steepness (h)"
 ) # axis label
@@ -161,61 +178,76 @@ SSplotProfile(profilesummary, # summary object
 # make timeseries plots comparing models in profile
 SSplotComparisons(profilesummary, legendlabels = paste("h =", h.vec))
 
-
+###########################################################################
+# example two-dimensional profile
+# (assumes you have an SS3 exe called "ss.exe" or "ss" in your PATH)
 ###########################################################################
 
-# example two-dimensional profile
-# (e.g. over 2 of the parameters in the low-fecundity stock-recruit function)
-base_dir <- "c:/mymodel"
+dir_simple_small <- file.path(
+  path.package("r4ss"),
+  file.path("extdata", "simple_small")
+)
 
-dir_profile_SR <- file.path(base_dir, "Profiles/Zfrac_and_Beta")
+# create temporary directory and copy files into it
+dir_prof <- file.path(tempdir(), "profile_2D")
+copy_SS_inputs(
+  dir.old = dir_simple_small,
+  dir.new = dir_prof,
+  create.dir = TRUE,
+  overwrite = TRUE,
+  copy_par = TRUE,
+  verbose = TRUE
+)
 
-# make a grid of values in both dimensions Zfrac and Beta
-# vector of values to profile over
-Zfrac_vec <- seq(from = 0.2, to = 0.6, by = 0.1)
-Beta_vec <- c(0.5, 0.75, 1.0, 1.5, 2.0)
-par_table <- expand.grid(Zfrac = Zfrac_vec, Beta = Beta_vec)
-nrow(par_table)
-## [1] 25
-head(par_table)
-##   Zfrac Beta
-## 1   0.2 0.50
-## 2   0.3 0.50
-## 3   0.4 0.50
-## 4   0.5 0.50
-## 5   0.6 0.50
-## 6   0.2 0.75
 
-# run profile command
-profile <- profile(
-  dir = dir_profile_SR, # directory
+# create table of M values for females and males
+par_table <- expand.grid(
+  M1vec = c(0.05, 0.10, 0.15),
+  M2vec = c(0.05, 0.10, 0.15)
+)
+
+# run model once to create control.ss_new with
+# good starting parameter values
+# exe is assumed to be in PATH, add "exe" argument if needed
+run(dir_prof, extras = "-nohess")
+
+# run profile using ss_new file as parameter source and
+# overwriting original control file with new values
+prof.table <- profile(
+  dir = dir_prof,
   oldctlfile = "control.ss_new",
-  newctlfile = "control_modified.ss",
-  string = c("Zfrac", "Beta"),
+  newctlfile = "control.ss",
+  string = c("NatM_uniform_Fem_GP_1", "NatM_uniform_Mal_GP_1"),
   profilevec = par_table,
-  extras = "-nohess" # argument passed to run()
+  extras = "-nohess"
 )
 
 # get model output
 profilemodels <- SSgetoutput(
-  dirvec = dir_profile_SR,
+  dirvec = dir_prof,
   keyvec = 1:nrow(par_table), getcovar = FALSE
 )
 n <- length(profilemodels)
 profilesummary <- SSsummarize(profilemodels)
 
 # add total likelihood (row 1) to table created above
-par_table[["like"]] <- as.numeric(profilesummary[["likelihoods"]][1, 1:n])
+par_table$like <- as.numeric(profilesummary$likelihoods[1, 1:n])
 
 # reshape data frame into a matrix for use with contour
-like_matrix <- reshape2::acast(par_table, Zfrac ~ Beta, value.var = "like")
-
-# make contour plot
-contour(
-  x = as.numeric(rownames(like_matrix)),
-  y = as.numeric(colnames(like_matrix)),
-  z = like_matrix
+like_matrix <- reshape2::acast(
+  data = par_table,
+  formula = M1vec ~ M2vec,
+  value.var = "like"
 )
+
+# look at change relative to the minimum
+# (shows small change when female and male M are equal,
+# big change when they are different)
+like_matrix - min(like_matrix)
+#         0.05    0.1    0.15
+# 0.05   6.938 32.710 121.959
+# 0.1   49.706  0.000  27.678
+# 0.15 154.897 44.768   5.366
 }
 
 }


### PR DESCRIPTION
For profiles over parameters which have a prior, this adds a line to the profile plot showing the total likelihood without the contribution of the prior (fixes #750 and eventually can resolve https://github.com/pfmc-assessments/nwfscDiag/issues/6).

For parameters with no prior or with the prior for fixed parameters excluded via starter file settings, it should have no impact.

Changes include
* `SSsummarize()` now includes a `par_prior_likes` table in the list it returns
* `SSplotProfile()` uses that information to add a line when it sees non-zero/non-NA values for the parameter being profiled
* Users can turn off the line by using `SSplotProfile(..., add_no_prior_line = FALSE)` but the default is TRUE.
* There is no change to the `PinerPlot()` because it is focused on the fleet-specific likelihood contributions to a single data type and that data type will never be the priors (because they are not generally fleet-specific).

Example result shown in figure below (showing that for an in-process Petrale Sole model, all sources except the prior point to higher steepness).
![profile_plot_likelihood](https://github.com/r4ss/r4ss/assets/4992918/2cee6e53-2aae-4ce3-a07e-ecebb074759b)
