### PR TITLE
Fix retro to use endyr + 1 for biomass-based quantities

### DIFF
--- a/R/SSmohnsrho.R
+++ b/R/SSmohnsrho.R
@@ -26,7 +26,7 @@
 #'   is to use the `startyr` of the reference model.
 #' @template verbose
 #'
-#' @author Chantel R. Wetzel and Carey R. McGilliard
+#' @author Chantel R. Wetzel, Carey R. McGilliard, and Kelli F. Johnson
 #' @references
 #' * Hurtado-Ferro et al. 2015. Looking in the rear-view mirror: bias and
 #'   retrospective patterns in integrated, age-structured stock assessment

--- a/R/SSmohnsrho.R
+++ b/R/SSmohnsrho.R
@@ -1,33 +1,35 @@
-#' Calculate Mohn's Rho values for select quantities
+#' Calculate Mohn's rho values for select quantities
 #'
 #' Function calculates:
-#' (1) a rho value for the ending year for each retrospective relative to the reference model
-#' as in Mohn (1999),
-#' (2) a "Wood's Hole Mohn's Rho", which is a rho value averaged across all years for each
-#' retrospective relative to the reference model, and
-#' (3) an "Alaska Fisheries Science Center and Hurtado-Ferro et al. (2015) Mohn's rho,
-#' which is the average rho per retrospective "peel".
+#' 1. a rho value for the ending year for each retrospective relative to the
+#'    reference model as in Mohn (1999);
+#' 1. a ``Wood's Hole Mohn's rho'', which is a rho value averaged across all
+#'    years for each retrospective relative to the reference model; and
+#' 1. an Alaska Fisheries Science Center and Hurtado-Ferro et al. (2015) Mohn's
+#'    rho, which is the average rho per retrospective ``peel''.
 #'
-#'
-#' @param summaryoutput List created by `SSsummarize`. The expected order for the
-#' models are the full reference model, the retro -1, retro -2, and so forth.
-#' @param endyrvec Single year or vector of years representing the
-#' final year of values to show for each model.
+#' @param summaryoutput List created by [SSsummarize()]. The expected order for
+#'   the models are the full reference model, the retro -1, retro -2, and so
+#'   forth.
+#' @param endyrvec Single year or vector of years representing the final year of
+#'   values to show for each model.
 #' @param startyr Single year used to calculate the start of the Wood's Hole
-#' Mohn's Rho value across all years. Defaults to startyr of reference model.
+#'   Mohn's rho value across all years. Defaults to `startyr` of reference
+#'   model.
 #' @template verbose
 #'
-#' @author Chantel R. Wetzel and Carey McGilliard
-#' @references Hurtado-Ferro et al. 2015. Looking in the rear-view mirror: bias
-#' and retrospective patterns in integrated, age-structured stock assessment
-#' models. ICES J. Mar. Sci Volume 72, Issue 1, 1 January 2015,
-#' Pages 99-110, https://doi.org/10.1093/icesjms/fsu198
-#' Mohn, R. 1999. The retrospective problem in sequential population analysis:
-#' An investigation using cod fishery and simulated data. ICES J. Mar. Sci
-#' Volume 56, Pages 473-488
-#'
+#' @author Chantel R. Wetzel and Carey R. McGilliard
+#' @references
+#' * Hurtado-Ferro et al. 2015. Looking in the rear-view mirror: bias and
+#'   retrospective patterns in integrated, age-structured stock assessment
+#'   models. ICES J. Mar. Sci. 72(1), 99--110.
+#'   https://doi.org/10.1093/icesjms/fsu198.
+#' * Mohn, R. 1999. The retrospective problem in sequential population analysis:
+#'   an investigation using cod fishery and simulated data. ICES J. Mar. Sci.
+#'   56, 473--488. https://doi.org/10.1006/jmsc.1999.0481.
+#' @return
+#' A list.
 #' @export
-
 SSmohnsrho <-
   function(summaryoutput,
            endyrvec,
@@ -53,9 +55,9 @@ SSmohnsrho <-
     mohnSSB <- mohnRec <- mohnBratio <- mohnF <- numeric()
     mohnSSB.all <- mohnRec.all <- mohnBratio.all <- mohnF.all <- numeric()
 
-    # Mohn's Rho Calculation for the terminal year for each of
+    # Mohn's rho Calculation for the terminal year for each of
     # the retrospectives relative to the reference model
-    # Rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
+    # rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
     for (i in 1:(N - 1)) {
       ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
       mohnSSB[i] <- (summaryoutput[["SpawnBio"]][ind, i + 1] -
@@ -78,12 +80,12 @@ SSmohnsrho <-
         summaryoutput[["Fvalue"]][ind, 1]
     }
 
-    # Wood's Hole Mohn's Rho Calculation for all years for each of the
+    # Wood's Hole Mohn's rho Calculation for all years for each of the
     # retrospectives relative to the reference model
-    # Rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
+    # rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
     # This rho value is then scaled according to the number of model years
     # for comparison between the one year and all year calculation
-    # Rho <- Rho / Number of Years
+    # rho <- rho / Number of Years
     for (i in 1:(N - 1)) {
       ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == startyr):which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
       mohnSSB.all[i] <-
@@ -99,7 +101,7 @@ SSmohnsrho <-
           sum((summaryoutput[["Bratio"]][ind, i + 1] - summaryoutput[["Bratio"]][ind, 1]) /
             summaryoutput[["Bratio"]][ind, 1]) / length(ind)
       } else {
-        warning("Skipping Wood's Hole Mohns Rho on Bratio, as Bratio is not available for year after the first model year.")
+        warning("Skipping Wood's Hole Mohns rho on Bratio, as Bratio is not available for year after the first model year.")
         mohnBratio.all[i] <- NA
       }
       if (length(which(summaryoutput[["Fvalue"]][["Yr"]] == startyr)) != 0) {
@@ -108,7 +110,7 @@ SSmohnsrho <-
           sum((summaryoutput[["Fvalue"]][ind, i + 1] - summaryoutput[["Fvalue"]][ind, 1]) /
             summaryoutput[["Fvalue"]][ind, 1]) / length(ind)
       } else {
-        warning("Skipping Wood's Hole Mohn's Rho on Fvalue, ecause Fvalue is not available for first model year.")
+        warning("Skipping Wood's Hole Mohn's rho on Fvalue, ecause Fvalue is not available for first model year.")
         mohnF.all[i] <- NA
       }
     }
@@ -126,7 +128,7 @@ SSmohnsrho <-
 
     # Alaska Fisheries Science Center and Hurtado-Ferro et al. (2015) Mohn's rho
     # https://www.afsc.noaa.gov/REFM/stocks/Plan_Team/2013/Sept/Retrospectives_2013_final3.pdf
-    # Equation 1:  Rho <- (sum over p [ (X_y-p,p -X_y-p,0) / X_y-p,0]) / P
+    # Equation 1:  rho <- (sum over p [ (X_y-p,p -X_y-p,0) / X_y-p,0]) / P
     mohn.out[["AFSC_Hurtado_SSB"]] <- sum(mohnSSB) / length(mohnSSB)
     mohn.out[["AFSC_Hurtado_Rec"]] <- sum(mohnRec) / length(mohnRec)
     mohn.out[["AFSC_Hurtado_F"]] <- sum(mohnF) / length(mohnF)

--- a/R/SSmohnsrho.R
+++ b/R/SSmohnsrho.R
@@ -30,108 +30,132 @@
 #' @return
 #' A list.
 #' @export
-SSmohnsrho <-
-  function(summaryoutput,
-           endyrvec,
-           startyr,
-           verbose = TRUE) {
-    if (verbose) {
-      message(
-        "The expected order of models in the summary output are the\n",
-        "reference model followed by retro -1, retro -2, and so forth."
-      )
-    }
-
-    N <- summaryoutput[["n"]]
-    if (missing(endyrvec)) {
-      endyrvec <- rev((summaryoutput[["endyrs"]][N] - N + 1):summaryoutput[["endyrs"]][N])
-    }
-
-    if (missing(startyr)) {
-      startyr <- summaryoutput[["startyrs"]][1]
-    }
-
-
-    mohnSSB <- mohnRec <- mohnBratio <- mohnF <- numeric()
-    mohnSSB.all <- mohnRec.all <- mohnBratio.all <- mohnF.all <- numeric()
-
-    # Mohn's rho Calculation for the terminal year for each of
-    # the retrospectives relative to the reference model
-    # rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
-    for (i in 1:(N - 1)) {
-      ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
-      mohnSSB[i] <- (summaryoutput[["SpawnBio"]][ind, i + 1] -
-        summaryoutput[["SpawnBio"]][ind, 1]) /
-        summaryoutput[["SpawnBio"]][ind, 1]
-
-      ind <- which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1])
-      mohnRec[i] <- (summaryoutput[["recruits"]][ind, i + 1] -
-        summaryoutput[["recruits"]][ind, 1]) /
-        summaryoutput[["recruits"]][ind, 1]
-
-      ind <- which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1])
-      mohnBratio[i] <- (summaryoutput[["Bratio"]][ind, i + 1] -
-        summaryoutput[["Bratio"]][ind, 1]) /
-        summaryoutput[["Bratio"]][ind, 1]
-
-      ind <- which(summaryoutput[["Fvalue"]][["Yr"]] == endyrvec[i + 1])
-      mohnF[i] <- (summaryoutput[["Fvalue"]][ind, i + 1] -
-        summaryoutput[["Fvalue"]][ind, 1]) /
-        summaryoutput[["Fvalue"]][ind, 1]
-    }
-
-    # Wood's Hole Mohn's rho Calculation for all years for each of the
-    # retrospectives relative to the reference model
-    # rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
-    # This rho value is then scaled according to the number of model years
-    # for comparison between the one year and all year calculation
-    # rho <- rho / Number of Years
-    for (i in 1:(N - 1)) {
-      ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == startyr):which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
-      mohnSSB.all[i] <-
-        sum((summaryoutput[["SpawnBio"]][ind, i + 1] - summaryoutput[["SpawnBio"]][ind, 1]) /
-          summaryoutput[["SpawnBio"]][ind, 1]) / length(ind)
-      ind <- which(summaryoutput[["recruits"]][["Yr"]] == startyr):which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1])
-      mohnRec.all[i] <-
-        sum((summaryoutput[["recruits"]][ind, i + 1] - summaryoutput[["recruits"]][ind, 1]) /
-          summaryoutput[["recruits"]][ind, 1]) / length(ind)
-      if (length(which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1)) != 0) {
-        ind <- which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1):which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1])
-        mohnBratio.all[i] <-
-          sum((summaryoutput[["Bratio"]][ind, i + 1] - summaryoutput[["Bratio"]][ind, 1]) /
-            summaryoutput[["Bratio"]][ind, 1]) / length(ind)
-      } else {
-        warning("Skipping Wood's Hole Mohns rho on Bratio, as Bratio is not available for year after the first model year.")
-        mohnBratio.all[i] <- NA
-      }
-      if (length(which(summaryoutput[["Fvalue"]][["Yr"]] == startyr)) != 0) {
-        ind <- which(summaryoutput[["Fvalue"]][["Yr"]] == startyr):which(summaryoutput[["Fvalue"]][["Yr"]] == endyrvec[i + 1])
-        mohnF.all[i] <-
-          sum((summaryoutput[["Fvalue"]][ind, i + 1] - summaryoutput[["Fvalue"]][ind, 1]) /
-            summaryoutput[["Fvalue"]][ind, 1]) / length(ind)
-      } else {
-        warning("Skipping Wood's Hole Mohn's rho on Fvalue, ecause Fvalue is not available for first model year.")
-        mohnF.all[i] <- NA
-      }
-    }
-
-    mohn.out <- list()
-    mohn.out[["SSB"]] <- sum(mohnSSB)
-    mohn.out[["Rec"]] <- sum(mohnRec)
-    mohn.out[["Bratio"]] <- sum(mohnBratio)
-    mohn.out[["F"]] <- sum(mohnF)
-
-    mohn.out[["WoodHole_SSB.all"]] <- sum(mohnSSB.all)
-    mohn.out[["WoodHole_Rec.all"]] <- sum(mohnRec.all)
-    mohn.out[["WoodHole_Bratio.all"]] <- sum(mohnBratio.all)
-    mohn.out[["WoodHole_F.all"]] <- sum(mohnF.all)
-
-    # Alaska Fisheries Science Center and Hurtado-Ferro et al. (2015) Mohn's rho
-    # https://www.afsc.noaa.gov/REFM/stocks/Plan_Team/2013/Sept/Retrospectives_2013_final3.pdf
-    # Equation 1:  rho <- (sum over p [ (X_y-p,p -X_y-p,0) / X_y-p,0]) / P
-    mohn.out[["AFSC_Hurtado_SSB"]] <- sum(mohnSSB) / length(mohnSSB)
-    mohn.out[["AFSC_Hurtado_Rec"]] <- sum(mohnRec) / length(mohnRec)
-    mohn.out[["AFSC_Hurtado_F"]] <- sum(mohnF) / length(mohnF)
-    mohn.out[["AFSC_Hurtado_Bratio"]] <- sum(mohnBratio) / length(mohnBratio)
-    return(mohn.out)
+SSmohnsrho <- function(summaryoutput,
+                       endyrvec,
+                       startyr,
+                       verbose = TRUE) {
+  if (verbose) {
+    message(
+      "The expected order of models in the summary output are the\n",
+      "reference model followed by retro -1, retro -2, and so forth."
+    )
   }
+
+  N <- summaryoutput[["n"]]
+  if (missing(endyrvec)) {
+    endyrvec <- rev(
+      (summaryoutput[["endyrs"]][N] - N + 1):summaryoutput[["endyrs"]][N]
+    )
+  }
+
+  if (missing(startyr)) {
+    startyr <- summaryoutput[["startyrs"]][1]
+  }
+
+
+  mohnSSB <- mohnRec <- mohnBratio <- mohnF <- numeric()
+  mohnSSB.all <- mohnRec.all <- mohnBratio.all <- mohnF.all <- numeric()
+
+  # Mohn's rho Calculation for the terminal year for each of
+  # the retrospectives relative to the reference model
+  # rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
+  for (i in 1:(N - 1)) {
+    ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
+    mohnSSB[i] <- (summaryoutput[["SpawnBio"]][ind, i + 1] -
+      summaryoutput[["SpawnBio"]][ind, 1]) /
+      summaryoutput[["SpawnBio"]][ind, 1]
+
+    ind <- which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1])
+    mohnRec[i] <- (summaryoutput[["recruits"]][ind, i + 1] -
+      summaryoutput[["recruits"]][ind, 1]) /
+      summaryoutput[["recruits"]][ind, 1]
+
+    ind <- which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1])
+    mohnBratio[i] <- (summaryoutput[["Bratio"]][ind, i + 1] -
+      summaryoutput[["Bratio"]][ind, 1]) /
+      summaryoutput[["Bratio"]][ind, 1]
+
+    ind <- which(summaryoutput[["Fvalue"]][["Yr"]] == endyrvec[i + 1])
+    mohnF[i] <- (summaryoutput[["Fvalue"]][ind, i + 1] -
+      summaryoutput[["Fvalue"]][ind, 1]) /
+      summaryoutput[["Fvalue"]][ind, 1]
+  }
+
+  # Wood's Hole Mohn's rho Calculation for all years for each of the
+  # retrospectives relative to the reference model
+  # rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
+  # This rho value is then scaled according to the number of model years
+  # for comparison between the one year and all year calculation
+  # rho <- rho / Number of Years
+  for (i in 1:(N - 1)) {
+    ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == startyr):
+      which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
+    mohnSSB.all[i] <- sum(
+      (summaryoutput[["SpawnBio"]][ind, i + 1] -
+       summaryoutput[["SpawnBio"]][ind, 1]
+      ) /
+      summaryoutput[["SpawnBio"]][ind, 1]
+    ) / length(ind)
+    ind <- which(summaryoutput[["recruits"]][["Yr"]] == startyr):
+      which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1])
+    mohnRec.all[i] <- sum(
+      (summaryoutput[["recruits"]][ind, i + 1] -
+       summaryoutput[["recruits"]][ind, 1]
+      ) /
+      summaryoutput[["recruits"]][ind, 1]
+    ) / length(ind)
+    if (length(which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1)) != 0) {
+      ind <- which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1):
+        which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1])
+      mohnBratio.all[i] <- sum(
+        (summaryoutput[["Bratio"]][ind, i + 1] -
+         summaryoutput[["Bratio"]][ind, 1]
+        ) /
+        summaryoutput[["Bratio"]][ind, 1]
+      ) / length(ind)
+    } else {
+      warning(
+        "Skipping Wood's Hole Mohn's rho on Bratio, ",
+        "as Bratio is not available for year after the first model year."
+      )
+      mohnBratio.all[i] <- NA
+    }
+    if (length(which(summaryoutput[["Fvalue"]][["Yr"]] == startyr)) != 0) {
+      ind <- which(summaryoutput[["Fvalue"]][["Yr"]] == startyr):
+        which(summaryoutput[["Fvalue"]][["Yr"]] == endyrvec[i + 1])
+      mohnF.all[i] <- sum(
+        (summaryoutput[["Fvalue"]][ind, i + 1] -
+         summaryoutput[["Fvalue"]][ind, 1]
+        ) /
+        summaryoutput[["Fvalue"]][ind, 1]
+      ) / length(ind)
+    } else {
+      warning(
+        "Skipping Wood's Hole Mohn's rho on Fvalue, ",
+        "because Fvalue is not available for first model year."
+      )
+      mohnF.all[i] <- NA
+    }
+  }
+
+  mohn.out <- list()
+  mohn.out[["SSB"]] <- sum(mohnSSB)
+  mohn.out[["Rec"]] <- sum(mohnRec)
+  mohn.out[["Bratio"]] <- sum(mohnBratio)
+  mohn.out[["F"]] <- sum(mohnF)
+
+  mohn.out[["WoodHole_SSB.all"]] <- sum(mohnSSB.all)
+  mohn.out[["WoodHole_Rec.all"]] <- sum(mohnRec.all)
+  mohn.out[["WoodHole_Bratio.all"]] <- sum(mohnBratio.all)
+  mohn.out[["WoodHole_F.all"]] <- sum(mohnF.all)
+
+  # Alaska Fisheries Science Center and Hurtado-Ferro et al. (2015) Mohn's rho
+  # https://www.afsc.noaa.gov/REFM/stocks/Plan_Team/2013/Sept/Retrospectives_2013_final3.pdf
+  # Equation 1:  rho <- (sum over p [ (X_y-p,p -X_y-p,0) / X_y-p,0]) / P
+  mohn.out[["AFSC_Hurtado_SSB"]] <- sum(mohnSSB) / length(mohnSSB)
+  mohn.out[["AFSC_Hurtado_Rec"]] <- sum(mohnRec) / length(mohnRec)
+  mohn.out[["AFSC_Hurtado_F"]] <- sum(mohnF) / length(mohnF)
+  mohn.out[["AFSC_Hurtado_Bratio"]] <- sum(mohnBratio) / length(mohnBratio)
+
+  return(mohn.out)
+}

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -171,6 +171,7 @@ io
 iteratively
 ith
 jitter
+jmsc
 jstor
 keyvec
 lables

--- a/man/SSmohnsrho.Rd
+++ b/man/SSmohnsrho.Rd
@@ -2,41 +2,70 @@
 % Please edit documentation in R/SSmohnsrho.R
 \name{SSmohnsrho}
 \alias{SSmohnsrho}
-\title{Calculate Mohn's Rho values for select quantities}
+\title{Calculate Mohn's rho values for select quantities}
 \usage{
 SSmohnsrho(summaryoutput, endyrvec, startyr, verbose = TRUE)
 }
 \arguments{
-\item{summaryoutput}{List created by \code{SSsummarize}. The expected order for the
-models are the full reference model, the retro -1, retro -2, and so forth.}
+\item{summaryoutput}{List created by \code{\link[=SSsummarize]{SSsummarize()}}. The expected order for
+the models are the full reference model, the retro -1, retro -2, and so
+forth. Order matters for the calculations.}
 
-\item{endyrvec}{Single year or vector of years representing the
-final year of values to show for each model.}
+\item{endyrvec}{Integer vector of years that should be used as the final year
+for each model in \code{summaryoutput}. The default, which happens if \code{endyrvec}
+is missing, is based on information in \code{summaryoutput}, i.e.,
+\code{summaryoutput[["endyrs"]][summaryoutput[["n"]]]: (summaryoutput[["endyrs"]][summaryoutput[["n"]]] - summaryoutput[["n"]] + 1)}. This parameter will be used to extract estimates of fishing mortality
+for each year in \code{endyrvec} and estimates of biomass-based quantities for
+each year in \code{endyrvec + 1} because Stock Synthesis reports beginning of
+the year biomass, which we use here as a proxy for end of the year biomass.}
 
-\item{startyr}{Single year used to calculate the start of the Wood's Hole
-Mohn's Rho value across all years. Defaults to startyr of reference model.}
+\item{startyr}{Single year used to calculate the start year for the
+calculation of the Wood's Hole Mohn's rho value, which is computed across
+the range of years in the model. If this parameter is missing, the default
+is to use the \code{startyr} of the reference model.}
 
 \item{verbose}{A logical value specifying if output should be printed
 to the screen.}
 }
+\value{
+A list with the following 12 entries:
+\itemize{
+\item \code{"SSB"}
+\item \code{"Rec"}
+\item \code{"Bratio"}
+\item \code{"F"}
+\item \code{"WoodHole_SSB.all"}
+\item \code{"WoodHole_Rec.all"}
+\item \code{"WoodHole_Bratio.all"}
+\item \code{"WoodHole_F.all"}
+\item \code{"AFSC_Hurtado_SSB"}
+\item \code{"AFSC_Hurtado_Rec"}
+\item \code{"AFSC_Hurtado_F"}
+\item \code{"AFSC_Hurtado_Bratio"}
+}
+}
 \description{
 Function calculates:
-(1) a rho value for the ending year for each retrospective relative to the reference model
-as in Mohn (1999),
-(2) a "Wood's Hole Mohn's Rho", which is a rho value averaged across all years for each
-retrospective relative to the reference model, and
-(3) an "Alaska Fisheries Science Center and Hurtado-Ferro et al. (2015) Mohn's rho,
-which is the average rho per retrospective "peel".
+\enumerate{
+\item a rho value for the ending year for each retrospective relative to the
+reference model as in Mohn (1999);
+\item a ``Wood's Hole Mohn's rho'', which is a rho value averaged across all
+years for each retrospective relative to the reference model; and
+\item an Alaska Fisheries Science Center and Hurtado-Ferro et al. (2015) Mohn's
+rho, which is the average rho per retrospective ``peel''.
+}
 }
 \references{
-Hurtado-Ferro et al. 2015. Looking in the rear-view mirror: bias
-and retrospective patterns in integrated, age-structured stock assessment
-models. ICES J. Mar. Sci Volume 72, Issue 1, 1 January 2015,
-Pages 99-110, https://doi.org/10.1093/icesjms/fsu198
-Mohn, R. 1999. The retrospective problem in sequential population analysis:
-An investigation using cod fishery and simulated data. ICES J. Mar. Sci
-Volume 56, Pages 473-488
+\itemize{
+\item Hurtado-Ferro et al. 2015. Looking in the rear-view mirror: bias and
+retrospective patterns in integrated, age-structured stock assessment
+models. ICES J. Mar. Sci. 72(1), 99--110.
+https://doi.org/10.1093/icesjms/fsu198.
+\item Mohn, R. 1999. The retrospective problem in sequential population analysis:
+an investigation using cod fishery and simulated data. ICES J. Mar. Sci.
+56, 473--488. https://doi.org/10.1006/jmsc.1999.0481.
+}
 }
 \author{
-Chantel R. Wetzel and Carey McGilliard
+Chantel R. Wetzel and Carey R. McGilliard
 }

--- a/man/SSmohnsrho.Rd
+++ b/man/SSmohnsrho.Rd
@@ -67,5 +67,5 @@ an investigation using cod fishery and simulated data. ICES J. Mar. Sci.
 }
 }
 \author{
-Chantel R. Wetzel and Carey R. McGilliard
+Chantel R. Wetzel, Carey R. McGilliard, and Kelli F. Johnson
 }


### PR DESCRIPTION
Thanks to @chantelwetzel-noaa for noticing that the {r4ss} end year of the model is really the end year of the data and that we need to have retrospective calculations related to biomass be end year of the model + 1 because we want to report end of year biomass, where Stock Synthesis calculates beginning of the year biomass. Fishing mortality ($F$) is still based on the end year of the model but all other quantities are now end year + 1. {nwfscDiags} will work just fine as is with these changes. If users actually want to compare the "updated" output with previous calculations they could run the function twice with different inputs to endyrvec.
Commit summary that I believe should be brought in as three separate commits rather than squashed and merged:
1. Reformatted old documentation
2. Styled the file, i.e., wrapped at 80 characters
3. Actually made changes (including adding a test to ensure the length of `endyrvec` is the same as the number of models in `summaryoutput`.

I tested this with the retrospective runs on the server available for the northern copper model.
```
runs <- purrr::map(
  c("../../6.8", paste0("retro-", 1:20)),
  SS_output,
  verbose = FALSE, printstats = FALSE
)
aa <- SSmohnsrho(SSsummarize(runs, verbose = FALSE))
bb <- SSmohnsrho(SSsummarize(runs, verbose = FALSE), endyrvec = 2021:2000)
```
all values in `bb` matched the version of the output currently found in main and the values of F found in main matched the values of F in `aa`.