### PR TITLE
Assorted cleanup

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,3 +84,4 @@ BugReports: https://github.com/r4ss/r4ss/issues
 RoxygenNote: 7.2.3
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
+Language: en-US

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -884,11 +884,14 @@ SS_output <-
         duplicates <- compdbase %>%
           dplyr::select(-Cum_obs, -Cum_exp) %>%
           duplicated()
-        message(
-          "Removing ", sum(duplicates), " out of ", nrow(compdbase),
-          " rows in CompReport.sso which are duplicates."
-        )
+        if (verbose) {
+          message(
+            "Removing ", sum(duplicates), " out of ", nrow(compdbase),
+            " rows in CompReport.sso which are duplicates."
+          )
+        }
         compdbase <- compdbase[!duplicates, ]
+        # done removing duplicates
 
         # "Sexes" (formerly "Pick_sex" or "Pick_gender"):
         #         0 (unknown), 1 (female), 2 (male), or 3 (females and then males)

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -3899,6 +3899,11 @@ SS_output <-
       sigma_R_info[["SD_of_devs_over_sigma_R"]] <- sigma_R_info[["SD_of_devs"]] / sigma_R_in
       sigma_R_info[["sqrt_sum_over_sigma_R"]] <- sigma_R_info[["sqrt_sum_of_components"]] / sigma_R_in
       sigma_R_info[["alternative_sigma_R"]] <- sigma_R_in * sigma_R_info[["sqrt_sum_over_sigma_R"]]
+
+      # if there's no uncertainty in the recdevs (probably because of -nohess)
+      # then don't report alternative sigma R values
+      # could also use [["log_det_hessian"]] as the filter
+      sigma_R_info[["alternative_sigma_R"]][sigma_R_info[["mean_SE"]] == 0] <- "needs_Hessian"
     }
     stats[["sigma_R_in"]] <- sigma_R_in
     stats[["sigma_R_info"]] <- sigma_R_info

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -37,11 +37,19 @@ SSgetoutput <-
       )
     }
 
-    if (!is.null(keyvec) & verbose) message("length(keyvec) as input to SSgetoutput:", length(keyvec))
-    if (!is.null(dirvec) & verbose) message("length(dirvec) as input to SSgetoutput:", length(dirvec))
+    if (verbose) {
+      if (!is.null(keyvec)) {
+        message("length(keyvec) as input to SSgetoutput: ", length(keyvec))
+      }
+      if (!is.null(dirvec)) {
+        message("length(dirvec) as input to SSgetoutput: ", length(dirvec))
+      }
+    }
 
     # change inputs so that keyvec and dirvec have matching lengths or keyvec=NULL
-    if (listlists) biglist <- list()
+    if (listlists) {
+      biglist <- list()
+    }
     n1 <- length(keyvec)
     n2 <- length(dirvec)
     if (n1 > 1 & n2 > 1 & n1 != n2) {
@@ -49,12 +57,20 @@ SSgetoutput <-
     } else {
       n <- max(1, n1, n2) # n=1 or n=length of either optional input vector
     }
-    if (n1 == 1) keyvec <- rep(keyvec, n)
+    if (n1 == 1) {
+      keyvec <- rep(keyvec, n)
+    }
     objectnames <- paste("replist", keyvec, sep = "")
-    if (n1 == 0) objectnames <- paste("replist", 1:n, sep = "")
+    if (n1 == 0) {
+      objectnames <- paste("replist", 1:n, sep = "")
+    }
 
-    if (n2 == 0) dirvec <- getwd()
-    if (length(dirvec) == 1) dirvec <- rep(dirvec, n)
+    if (n2 == 0) {
+      dirvec <- getwd()
+    }
+    if (length(dirvec) == 1) {
+      dirvec <- rep(dirvec, n)
+    }
     dirvec <- paste(dirvec, "/", sep = "")
 
     # loop over directories or key strings
@@ -69,7 +85,9 @@ SSgetoutput <-
       }
       newobject <- objectnames[i]
 
-      if (verbose & !is.null(key)) message("getting files with key =", key)
+      if (verbose & !is.null(key)) {
+        message("getting files with key =", key)
+      }
 
       repFileName <- paste("Report", key2, ".sso", sep = "")
       covarname <- paste("covar", key2, ".sso", sep = "")
@@ -86,7 +104,9 @@ SSgetoutput <-
       mycovar <- file.exists(file.path(mydir, covarname)) & getcovar
 
       fullfile <- paste(mydir, repFileName, sep = "")
-      if (verbose) message("reading output from", fullfile)
+      if (verbose) {
+        message("reading output from ", fullfile)
+      }
       repfilesize <- file.info(fullfile)$size
 
       output <- NA
@@ -110,8 +130,12 @@ SSgetoutput <-
       } else {
         message("!repfile doesn't exists or is empty")
       }
-      if (verbose) message("added element '", newobject, "' to list")
-      if (listlists) biglist[[newobject]] <- output
+      if (verbose) {
+        message("added element '", newobject, "' to list")
+      }
+      if (listlists) {
+        biglist[[newobject]] <- output
+      }
 
       if (save.lists) {
         biglist.file <- paste("biglist", i, "_", format(Sys.time(), "%d-%b-%Y_%H.%M"), ".Rdata", sep = "")

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -833,7 +833,7 @@ SSplotBiology <-
       }
       if (option == 2) {
         # maturity curve is product of age-based and length-based factors
-        lines(growdatF[["Age_Beg"]], growdatF[["Len_Mat"]] * growdatF[["Age_Mat"]],
+        lines(growdatF[["Age_Beg"]], growdatF[["Len_Mat"]] * abs(growdatF[["Age_Mat"]]),
           col = colvec[col_index1], lwd = 1, lty = "12"
         )
       }

--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -75,7 +75,7 @@
 #' @param colvec Vector of length 3 with colors for females, males, unsexed fish
 #' @param linescol Color for lines on top of polygons
 #' @param xlas label style (las) input for x-axis. Default 0 has horizontal
-#' labels, input 2 would provide vertical lables.
+#' labels, input 2 would provide vertical labels.
 #' @param ylas label style (las) input for y-axis. Default NULL has horizontal
 #' labels when all labels have fewer than 6 characters and vertical otherwise.
 #' Input 0 would force vertical labels, and 1 would force horizontal.

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -159,7 +159,7 @@ jitter <- function(dir = getwd(),
       if (is.null(rep)) {
         report <- SS_output(
           dir = getwd(), forecast = FALSE,
-          covar = FALSE, checkcor = FALSE, NoCompOK = TRUE,
+          covar = FALSE, NoCompOK = TRUE,
           verbose = verbose, warn = verbose, hidewarn = !verbose, printstats = verbose
         )
         like <- report[["likelihoods_used"]][row.names(report[["likelihoods_used"]]) == "TOTAL", "values"]

--- a/R/make_multifig.R
+++ b/R/make_multifig.R
@@ -46,7 +46,7 @@
 #' @param yupper upper limit on ymax (applied before addition of ybuffer)
 #' @param ymin0 fix minimum y-value at 0?
 #' @param xlas label style (las) input for x-axis. Default 0 has horizontal
-#' labels, input 2 would provide vertical lables.
+#' labels, input 2 would provide vertical labels.
 #' @param ylas label style (las) input for y-axis. Default NULL has horizontal
 #' labels when all labels have fewer than 6 characters and vertical otherwise.
 #' Input 0 would force vertical labels, and 1 would force horizontal.

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -173,7 +173,6 @@ ith
 jitter
 jstor
 keyvec
-lables
 ladbase
 las
 legx

--- a/man/SSplotComps.Rd
+++ b/man/SSplotComps.Rd
@@ -179,7 +179,7 @@ proportion within sample? Default=FALSE.}
 \item{linescol}{Color for lines on top of polygons}
 
 \item{xlas}{label style (las) input for x-axis. Default 0 has horizontal
-labels, input 2 would provide vertical lables.}
+labels, input 2 would provide vertical labels.}
 
 \item{ylas}{label style (las) input for y-axis. Default NULL has horizontal
 labels when all labels have fewer than 6 characters and vertical otherwise.

--- a/man/make_multifig.Rd
+++ b/man/make_multifig.Rd
@@ -154,7 +154,7 @@ of total height of plot}
 \item{ymin0}{fix minimum y-value at 0?}
 
 \item{xlas}{label style (las) input for x-axis. Default 0 has horizontal
-labels, input 2 would provide vertical lables.}
+labels, input 2 would provide vertical labels.}
 
 \item{ylas}{label style (las) input for y-axis. Default NULL has horizontal
 labels when all labels have fewer than 6 characters and vertical otherwise.


### PR DESCRIPTION
- Avoids bad sigmaR tuning value (#823) (now reports "needs_Hessian" instead of misleading value).
- Fixes issue with plot of length-based maturity option 6 converted to age (line was missing from biology plots)
- Applies `verbose` argument to recently-added message about duplicated samples
- Fixes spelling error
- Improves code formatting
