### PR TITLE
fix for aggregated plots in alphabetical rather than numeric order

### DIFF
--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -545,7 +545,7 @@ SSplotComps <-
                   if ("Nsamp_DM" %in% names(agg) && any(!is.na(agg[["Nsamp_DM"]]))) {
                     # Dirichlet-Multinomial likelihood
                     make_multifig(
-                      ptsx = agg[["bin"]], ptsy = agg[["obs"]], yr = paste(agg[["f"]], agg[["mkt"]]),
+                      ptsx = agg[["bin"]], ptsy = agg[["obs"]], yr = agg[["f"]] + agg[["mkt"]]/10,
                       linesx = agg[["bin"]], linesy = agg[["exp"]],
                       sampsize = agg[["Nsamp_adj"]],
                       effN = agg[["Nsamp_DM"]],
@@ -566,7 +566,7 @@ SSplotComps <-
                   } else {
                     # standard multinomial likelihood
                     make_multifig(
-                      ptsx = agg[["bin"]], ptsy = agg[["obs"]], yr = paste(agg[["f"]], agg[["mkt"]]),
+                      ptsx = agg[["bin"]], ptsy = agg[["obs"]], yr = agg[["f"]] + agg[["mkt"]]/10,
                       linesx = agg[["bin"]], linesy = agg[["exp"]],
                       sampsize = agg[["Nsamp_adj"]], effN = agg[["effN"]],
                       showsampsize = showsampsize, showeffN = showeffN,


### PR DESCRIPTION
- fleet 10 came before fleet 2 in models with more than 9 fleets with comp data, now fixed
- thanks @brianlangseth-NOAA for flagging this