### PR TITLE
Use return instead of message for get_ss3_exe

### DIFF
--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -66,7 +66,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       )
       utils::download.file(url, destfile = file.path(dir, "ss3.exe"), mode = "wb")
       download_location <- file.path(dir, "ss3.exe")
-      message(paste0(
+      return(paste0(
         "The stock synthesis executable for Windows ", tag, " was downloaded to: ",
         download_location
       ))
@@ -78,7 +78,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
       download_location <- file.path(dir, "ss3")
 
-      message(paste0(
+      return(paste0(
         "The stock synthesis executable for Mac ", tag, " was downloaded to: ",
         download_location
       ))
@@ -88,7 +88,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
         utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
         Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
         download_location <- file.path(dir, "ss3")
-        message(paste0(
+        return(paste0(
           "The stock synthesis executable for Linux ", tag, " was downloaded to: ",
           download_location
         ))

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -66,10 +66,11 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       )
       utils::download.file(url, destfile = file.path(dir, "ss3.exe"), mode = "wb")
       download_location <- file.path(dir, "ss3.exe")
-      return(paste0(
+      message(paste0(
         "The stock synthesis executable for Windows ", tag, " was downloaded to: ",
         download_location
       ))
+      return(invisible(download_location))
     }
   } else {
     if (substr(R.version[["os"]], 1, 6) == "darwin") {
@@ -78,20 +79,22 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
       download_location <- file.path(dir, "ss3")
 
-      return(paste0(
+      message(paste0(
         "The stock synthesis executable for Mac ", tag, " was downloaded to: ",
         download_location
       ))
+      return(invisible(download_location))
     } else {
       if (R.version[["os"]] == "linux-gnu") {
         url <- paste0("https://github.com/nmfs-stock-synthesis/stock-synthesis/releases/download/", tag, "/ss_linux")
         utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
         Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
         download_location <- file.path(dir, "ss3")
-        return(paste0(
+        message(paste0(
           "The stock synthesis executable for Linux ", tag, " was downloaded to: ",
           download_location
         ))
+        return(invisible(download_location))
       } else {
         warning(
           "The Stock Synthesis executable is not available for ", R.version[["os"]], "."

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -7,7 +7,7 @@
 #' @param version A character string of the executable version tag to download
 #' (e.g.'v3.30.20' or 'v3.30.18'). A list of tags is available at
 #' https://github.com/nmfs-stock-synthesis/stock-synthesis/tags
-#' @return A string of the full file path to the downloaded executable
+#' @return A string of the file path to the downloaded executable
 #' @author Elizabeth F. Gugliotti
 #' @export
 #' @import gh
@@ -45,8 +45,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
 
   if (is.null(dir)) {
     dir <- getwd()
-    message("No directory provided, the executable will be downloaded to the
-            working directory")
+    message("No directory provided, the executable will be downloaded to the working directory")
   }
 
   if (!dir.exists(dir)) {

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -70,7 +70,6 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
         "The stock synthesis executable for Windows ", tag, " was downloaded to: ",
         download_location
       ))
-      return(invisible(download_location))
     }
   } else {
     if (substr(R.version[["os"]], 1, 6) == "darwin") {
@@ -83,7 +82,6 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
         "The stock synthesis executable for Mac ", tag, " was downloaded to: ",
         download_location
       ))
-      return(invisible(download_location))
     } else {
       if (R.version[["os"]] == "linux-gnu") {
         url <- paste0("https://github.com/nmfs-stock-synthesis/stock-synthesis/releases/download/", tag, "/ss_linux")
@@ -94,12 +92,12 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
           "The stock synthesis executable for Linux ", tag, " was downloaded to: ",
           download_location
         ))
-        return(invisible(download_location))
       } else {
-        warning(
+        stop(
           "The Stock Synthesis executable is not available for ", R.version[["os"]], "."
         )
       }
     }
   }
+  return(invisible(download_location))
 }

--- a/man/SSplotSPR.Rd
+++ b/man/SSplotSPR.Rd
@@ -23,6 +23,7 @@ SSplotSPR(
     "Relative spawning output"),
   pwidth = 6.5,
   pheight = 5,
+  pheight_tall = 5,
   punits = "in",
   res = 300,
   ptsize = 10,
@@ -85,6 +86,10 @@ based on model output.}
 \item{pheight}{Height of plots printed to png files in units of \code{punits}.
 Default is designed to allow two plots per page, with \code{pheight_tall} used
 for plots that work best with a taller format and a single plot per page.}
+
+\item{pheight_tall}{Height of tall plots printed to png files in units of
+\code{punits}, where the tall plots are a subset of the plots which typically
+work best in a taller format.}
 
 \item{punits}{Units for \code{pwidth} and \code{pheight}. Can be "px"
 (pixels), "in" (inches), "cm" (centimeters), or "mm" (millimeters).

--- a/man/get_ss3_exe.Rd
+++ b/man/get_ss3_exe.Rd
@@ -14,7 +14,7 @@ get_ss3_exe(dir = NULL, version = NULL)
 https://github.com/nmfs-stock-synthesis/stock-synthesis/tags}
 }
 \value{
-A string of the full file path to the downloaded executable
+A string of the file path to the downloaded executable
 }
 \description{
 The \code{get_ss3_exe()} function uses the {gh} package to get either


### PR DESCRIPTION
Go back to return() instead of message() for where exe is downloaded.

@iantaylor-NOAA I ran devtools::document() and the man/SSplotSPR.Rd changed, I guess you did updates to the R file recently? Can you double check that this is right?

Resolves #852 