### PR TITLE
fix error when comparing EWAA models with no comps

### DIFF
--- a/R/SStableComparisons.R
+++ b/R/SStableComparisons.R
@@ -117,6 +117,7 @@ SStableComparisons <- function(summaryoutput,
           vals[1, 1] <- paste0(vals[1, 1], "_thousand_mt")
         }
         if (substring(name, 1, 3) %in% c("SPB", "SSB") &
+          all(!is.na(summaryoutput[["SpawnOutputUnits"]])) &&
           all(summaryoutput[["SpawnOutputUnits"]] == "biomass")) {
           vals[1, -1] <- round(vals[1, -1] / 1e3, 3)
           vals[1, 1] <- paste0(vals[1, 1], "_thousand_mt")
@@ -192,6 +193,7 @@ SStableComparisons <- function(summaryoutput,
           vals[1, 1] <- paste0(vals[1, 1], "_thousand_mt")
         }
         if (substring(name, 1, 3) %in% c("SPB", "SSB") &
+          all(!is.na(summaryoutput[["SpawnOutputUnits"]])) &&
           all(summaryoutput[["SpawnOutputUnits"]] == "biomass")) {
           vals[1, -1] <- round(vals[1, -1] / 1e3, 3)
           vals[1, 1] <- paste0(vals[1, 1], "_thousand_mt")


### PR DESCRIPTION
There was an error related to missing `SpawnOutputUnits` when comparing models which used empirical weight-at-age but had no comp data. This should allow the comparisons to go forward.