### PR TITLE
Fix future_map call to use ... arguments to iterate_jitter

### DIFF
--- a/R/jitter.R
+++ b/R/jitter.R
@@ -169,7 +169,7 @@ jitter <- function(dir = getwd(),
     Njitter <- 1:Njitter
   }
 
-  likesaved <- furrr::future_map_dbl(Njitter, ~ iterate_jitter(
+  likesaved <- furrr::future_map_dbl(Njitter, function(.x) iterate_jitter(
     i = .x,
     dir = dir,
     printlikes = printlikes,

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -161,7 +161,7 @@ jitter <- function(dir = getwd(),
   }
   r4ss::SS_writestarter(starter, overwrite = TRUE, verbose = FALSE)
 
-  # This is not necessary, but maintaining for back compatibility
+  # I'm not sure if this is necessary anymore
   file_increment(0, verbose = verbose)
 
   # check length of Njitter input
@@ -175,11 +175,39 @@ jitter <- function(dir = getwd(),
     printlikes = printlikes,
     exe = exe,
     verbose = verbose,
-    init_values_src = starter[["init_values_src"]],
+    init_values_src = starter[["init_values_src"]], 
     ...
   ))
-
-  # Move original files back (also maintaining for back compatibility)
+  
+  # rename output files and move them to base model directory
+  to_copy <- purrr::map(Njitter, ~ list.files(
+    path = file.path(dir, paste0('jitter', .x)),
+    pattern = "^[CcPRw][a-zA-Z]+\\.sso|summary\\.sso|\\.par$"
+  ))
+  
+  new_name <- purrr::imap(to_copy, ~ gsub(
+    pattern = "par",
+    replacement = "par_",
+    x = gsub(
+      pattern = "\\.sso|(\\.par)",
+      replacement = paste0("\\1", .y, ".sso"),
+      x = .x
+    )
+  ))
+  
+  purrr::pwalk(list(Njitter, to_copy, new_name), 
+               function(.i, .x, .y) 
+                 file.copy(
+                   from = file.path(paste0('jitter', .i), .x),
+                   to = .y,
+                   overwrite = TRUE
+                 )
+               )
+  
+  # delete jitter model directory
+  purrr::walk(Njitter, ~ unlink(paste0('jitter', .x), recursive = TRUE))
+  
+  # only necessary if the file_increment line is maintained. 
   pattern0 <- list.files(pattern = "[a-z_]0\\.sso")
   file.copy(
     from = pattern0,
@@ -242,27 +270,6 @@ iterate_jitter <- function(i,
     if (printlikes) {
       message("Likelihood for jitter ", i, " = ", like)
     }
-    # rename output files and move them to base model directory
-    to_copy <- list.files(
-      path = jitter_dir,
-      pattern = "^[CcPRw][a-zA-Z]+\\.sso|summary\\.sso|\\.par$"
-    )
-    new_name <- gsub(
-      pattern = "par",
-      replacement = "par_",
-      x = gsub(
-        pattern = "\\.sso|(\\.par)",
-        replacement = paste0("\\1", i, ".sso"),
-        x = to_copy
-      )
-    )
-    file.copy(
-      from = to_copy,
-      to = file.path(dir, new_name),
-      overwrite = TRUE
-    )
-    # delete jitter model directory
-    unlink(jitter_dir, recursive = TRUE)
     return(like)
   } else {
     unlink(jitter_dir, recursive = TRUE)

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -151,6 +151,12 @@ test_that("jitter runs on simple_small model", {
     # confirm starter file change
     starter <- SS_readstarter(file.path(dir.jit, "starter.ss"), verbose = FALSE)
     expect_equal(starter$jitter_fraction, 0.1)
+    
+    # check jitter output
+    jitter_output <- SSgetoutput(dir.jit, keyvec = c(1:2))
+    jitter_summary <- SSsummarize(jitter_output)
+    expect_equal(length(grep("replist", colnames(jitter_summary[["likelihoods"]][1, ]))), 2)
+    expect_equal(length(grep("replist", colnames(jitter_summary[["pars"]]))), 2)
   }
   expect_equal(starter$init_values_src, 0)
   unlink(dir.jit, recursive = TRUE)


### PR DESCRIPTION
It turns out that
```
future_map(x, ~my_func(.x, ...))
```

Is not the same as:
```
future_map(x, function(.x) my_func(.x, ...))
```

The former will not make use of the `...` arguments.
