### PR TITLE
fix: update nmfs-stock-synthesis links to nmfs-ost

### DIFF
--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -13,5 +13,5 @@ jobs:
   call-workflow-extra:
     # this step runs the r4ss tests again, after downloading ss3 exes and the
     # nmfs-ost/ss3-test-models repo.
-    uses: r4ss/r4ss/.github/workflows/r4ss-extra-tests.yml@main
+    uses: r4ss/r4ss/.github/workflows/r4ss-extra-tests.yml@nmfs-ost
 

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -13,5 +13,5 @@ jobs:
   call-workflow-extra:
     # this step runs the r4ss tests again, after downloading ss3 exes and the
     # nmfs-ost/ss3-test-models repo.
-    uses: r4ss/r4ss/.github/workflows/r4ss-extra-tests.yml@nmfs-ost
+    uses: r4ss/r4ss/.github/workflows/r4ss-extra-tests.yml@main
 

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -12,6 +12,6 @@ jobs:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
   call-workflow-extra:
     # this step runs the r4ss tests again, after downloading ss3 exes and the
-    # nmfs-stock-synthesis/ss-test-models repo.
+    # nmfs-ost/ss3-test-models repo.
     uses: r4ss/r4ss/.github/workflows/r4ss-extra-tests.yml@main
 

--- a/.github/workflows/r4ss-extra-tests.yml
+++ b/.github/workflows/r4ss-extra-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Get repository of SS3 models
         uses: actions/checkout@v3
         with:
-          repository: 'nmfs-stock-synthesis/test-models'
+          repository: 'nmfs-ost/ss3-test-models'
           path: test-models-repo
 
       - name: move the models to the desired location
@@ -63,7 +63,7 @@ jobs:
 
       - name: Get the latest SS3 executable and move to expected location
         run: |
-          curl https://api.github.com/repos/nmfs-stock-synthesis/stock-synthesis/releases/latest | grep "browser_download_url" | grep -Eo 'https://[^\"]*' | grep "ss_linux" | xargs wget
+          curl https://api.github.com/repos/nmfs-ost/ss3-source-code/releases/latest | grep "browser_download_url" | grep -Eo 'https://[^\"]*' | grep "ss_linux" | xargs wget
           mv ss_linux ss3
           sudo chmod a+x ss3
           cp ss3 inst/extdata/simple_small/ss3

--- a/.github/workflows/r4ss-extra-tests.yml
+++ b/.github/workflows/r4ss-extra-tests.yml
@@ -63,8 +63,7 @@ jobs:
 
       - name: Get the latest SS3 executable and move to expected location
         run: |
-          curl https://api.github.com/repos/nmfs-ost/ss3-source-code/releases/latest | grep "browser_download_url" | grep -Eo 'https://[^\"]*' | grep "ss_linux" | xargs wget
-          mv ss_linux ss3
+          wget -O ss3 https://github.com/nmfs-ost/ss3-source-code/releases/latest/download/ss_linux
           sudo chmod a+x ss3
           cp ss3 inst/extdata/simple_small/ss3
           rm ss3

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -2565,7 +2565,7 @@ SS_output <-
       header = TRUE, type.convert = TRUE
     )
     # updated BIOLOGY table names based on change July 2022 change
-    # https://github.com/nmfs-stock-synthesis/stock-synthesis/issues/348
+    # https://github.com/nmfs-ost/ss3-source-code/issues/348
     biology <- df.rename(biology,
       oldnames = c("Low", "Mean_Size", "Wt_len", "Wt_len_F", "Mat_len", "Spawn", "Wt_len_M", "Fecundity"),
       newnames = c("Len_lo", "Len_mean", "Wt_F", "Wt_F", "Mat", "Mat*Fec", "Wt_M", "Fec")
@@ -3376,7 +3376,7 @@ SS_output <-
       }
 
       # work-around for missing SE_input values 3.30.16
-      # https://github.com/nmfs-stock-synthesis/stock-synthesis/issues/169
+      # https://github.com/nmfs-ost/ss3-source-code/issues/169
       # https://github.com/r4ss/r4ss/issues/324
       badrows <- which(cpue[["Use"]] == "")
       if (length(badrows) > 0) {

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -39,13 +39,13 @@
 #' inputs <- SS_read(
 #'   dir = system.file("extdata", "simple_small", package = "r4ss")
 #' )
-#' # Read in an example from GitHub stored in user-examples,
+#' # Read in an example from GitHub stored in ss3-user-examples,
 #' # wrapped in `dontrun` because it requires an Internet connection
 #' \dontrun{
 #' webexample <- SS_read(dir = file.path(
 #'   "https://raw.githubusercontent.com",
-#'   "nmfs-stock-synthesis",
-#'   "user-examples",
+#'   "nmfs-ost",
+#'   "ss3-user-examples",
 #'   "main",
 #'   "model_files",
 #'   "simple_long_wtatage"

--- a/R/download_models.R
+++ b/R/download_models.R
@@ -58,12 +58,12 @@ download_models <- function(dir = file.path("inst", "extdata"),
   }
   dir.create(file.path(dir, "models"), showWarnings = FALSE)
   copy_status <- file.copy(
-    from = file.path(dir, paste0("test-models-", branch), "models"),
+    from = file.path(dir, paste0("ss3-test-models-", branch), "models"),
     to = file.path(dir), recursive = TRUE, overwrite = overwrite
   )
   # clean up
   unlink(zip_file_path)
-  unlink(file.path(dir, paste0("test-models-", branch)),
+  unlink(file.path(dir, paste0("ss3-test-models-", branch)),
     recursive = TRUE
   )
   invisible(copy_status)

--- a/R/download_models.R
+++ b/R/download_models.R
@@ -1,10 +1,10 @@
 #' Download SS3 test models
 #'
 #' Download and unzip the models folder stored on GitHub within the
-#' nmfs-stock-synthesis/test-models repository.
+#' nmfs-ost/ss3-test-models repository.
 #' @param dir A file path where the downloaded `"models"` subfolder will be written to.
 #' @param branch A string specifying the desired branch of
-#' [nmfs-stock-synthesis/test-models repository](https://github.com/nmfs-stock-synthesis/test-models#test-models)
+#' [nmfs-ost/ss3-test-models repository](https://github.com/nmfs-ost/ss3-test-models#test-models)
 #' that you want to download. The default is `"main"`, which is the
 #' stable/default branch.
 #' @template overwrite
@@ -17,7 +17,7 @@
 #' # remove files
 #' unlink(file.path("models"), recursive = TRUE)
 #' @author Kathryn Doering
-#' @references [nmfs-stock-synthesis/test-models repository](https://github.com/nmfs-stock-synthesis/test-models#test-models)
+#' @references [nmfs-ost/ss3-test-models repository](https://github.com/nmfs-ost/ss3-test-models#test-models)
 #' @export
 download_models <- function(dir = file.path("inst", "extdata"),
                             branch = "main",
@@ -30,7 +30,7 @@ download_models <- function(dir = file.path("inst", "extdata"),
   result <- tryCatch(
     utils::download.file(
       url = paste0(
-        "https://github.com/nmfs-stock-synthesis/test-models/archive/",
+        "https://github.com/nmfs-ost/ss3-test-models/archive/",
         branch,
         ".zip"
       ),

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -6,7 +6,7 @@
 #' @param dir The directory that you would like the executable downloaded to.
 #' @param version A character string of the executable version tag to download
 #' (e.g.'v3.30.20' or 'v3.30.18'). A list of tags is available at
-#' https://github.com/nmfs-stock-synthesis/stock-synthesis/tags
+#' https://github.com/nmfs-ost/ss3-source-code/tags
 #' @return A string of the file path to the downloaded executable
 #' @author Elizabeth F. Gugliotti
 #' @export
@@ -21,22 +21,22 @@
 #' Synthesis executable for the appropriate operating system to the directory `dir`
 #' (if dir = NULL, then the executable is downloaded to the working directory).
 #' To view the version tags available go to
-#' https://github.com/nmfs-stock-synthesis/stock-synthesis/tags
+#' https://github.com/nmfs-ost/ss3-source-code/tags
 
 get_ss3_exe <- function(dir = NULL, version = NULL) {
   # Get latest release if version not specified
   if (is.null(version)) {
-    latest_release <- gh::gh("GET /repos/nmfs-stock-synthesis/stock-synthesis/releases/latest", page = 1)
+    latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1)
     tag <- latest_release[["tag_name"]]
   } else {
     # Otherwise get specified version
-    all_tags <- gh::gh("GET /repos/nmfs-stock-synthesis/stock-synthesis/tags")
+    all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags")
     df_tags <- as.data.frame(do.call(rbind, all_tags))
     tags <- unlist(df_tags[["name"]])
 
     if (!version %in% tags) {
       warning("The version tag that you entered is invalid or not in the right format,
-              please go to https://github.com/nmfs-stock-synthesis/stock-synthesis/tags
+              please go to https://github.com/nmfs-ost/ss3-source-code/tags
               to get a correct version tag or version tag format")
     } else {
       tag <- version
@@ -60,7 +60,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       )
     } else {
       url <- paste0(
-        "https://github.com/nmfs-stock-synthesis/stock-synthesis/releases/download/",
+        "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
         tag, "/ss_win.exe"
       )
       utils::download.file(url, destfile = file.path(dir, "ss3.exe"), mode = "wb")
@@ -72,7 +72,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     }
   } else {
     if (substr(R.version[["os"]], 1, 6) == "darwin") {
-      url <- paste0("https://github.com/nmfs-stock-synthesis/stock-synthesis/releases/download/", tag, "/ss_osx")
+      url <- paste0("https://github.com/nmfs-ost/ss3-source-code/releases/download/", tag, "/ss_osx")
       utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
       Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
       download_location <- file.path(dir, "ss3")
@@ -84,7 +84,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       ))
     } else {
       if (R.version[["os"]] == "linux-gnu") {
-        url <- paste0("https://github.com/nmfs-stock-synthesis/stock-synthesis/releases/download/", tag, "/ss_linux")
+        url <- paste0("https://github.com/nmfs-ost/ss3-source-code/releases/download/", tag, "/ss_linux")
         utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
         Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
         Sys.chmod(paths = dir, mode = "0777")

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Stock Synthesis is a fisheries stock assessment model written in ADMB by
 Rick Methot. The Stock Synthesis software and many other associated
-materials are available in the [Stock Synthesis GitHub repository](https://github.com/nmfs-stock-synthesis/stock-synthesis) and other repositories under the [nmfs-stock-synthesis organization](https://github.com/nmfs-stock-synthesis).
+materials are available in the [Stock Synthesis GitHub repository](https://github.com/nmfs-ost/ss3-source-code) and other repositories under the [nmfs-ost organization](https://github.com/nmfs-ost).
 The r4ss package is a collection of R functions for interacting with
 Stock Synthesis. It is based on the original work of Ian Stewart begun
 around 2005 and released as an open source R package in 2009. The
@@ -55,7 +55,7 @@ library(r4ss)
 ```
 
 To get notifications about r4ss, you can watch this GitHub project or
-follow issues and discussions in the [Stock Synthesis GitHub repository](https://github.com/nmfs-stock-synthesis/stock-synthesis).
+follow issues and discussions in the [Stock Synthesis GitHub repository](https://github.com/nmfs-ost/ss3-source-code).
 Additionally, you can follow messages on the [forums on Stock Synthesis
 VLab](https://vlab.noaa.gov/web/stock-synthesis/public-forums), however, 
 most communications about Stock Synthesis are distributed via GitHub rather than VLab. 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -37,7 +37,6 @@ Iteratively
 Jeffreys
 Jolla
 Kiva
-LaTex
 LaTreese
 Legault
 Lsel
@@ -63,7 +62,6 @@ Piner's
 README
 Rdata
 Rebuilder
-ReferencePoints
 Rescale
 RunJitter
 SELEX
@@ -87,8 +85,6 @@ Venables
 Watal
 Xxis
 YYYY
-abc
-acl
 admodel
 agedbase
 agefactors
@@ -143,7 +139,6 @@ filenaming
 fishres
 fleetnames
 forecastplot
-formatting
 fsu
 fwf
 gdata
@@ -205,9 +200,9 @@ nmfs
 noaa
 nohess
 num
-ofl
 ogive
 optim
+ost
 outfile
 overfished
 overfishing

--- a/man/SS_read.Rd
+++ b/man/SS_read.Rd
@@ -48,13 +48,13 @@ the control and data files.
 inputs <- SS_read(
   dir = system.file("extdata", "simple_small", package = "r4ss")
 )
-# Read in an example from GitHub stored in user-examples,
+# Read in an example from GitHub stored in ss3-user-examples,
 # wrapped in `dontrun` because it requires an Internet connection
 \dontrun{
 webexample <- SS_read(dir = file.path(
   "https://raw.githubusercontent.com",
-  "nmfs-stock-synthesis",
-  "user-examples",
+  "nmfs-ost",
+  "ss3-user-examples",
   "main",
   "model_files",
   "simple_long_wtatage"

--- a/man/download_models.Rd
+++ b/man/download_models.Rd
@@ -14,7 +14,7 @@ download_models(
 \item{dir}{A file path where the downloaded \code{"models"} subfolder will be written to.}
 
 \item{branch}{A string specifying the desired branch of
-\href{https://github.com/nmfs-stock-synthesis/test-models#test-models}{nmfs-stock-synthesis/test-models repository}
+\href{https://github.com/nmfs-ost/ss3-test-models#test-models}{nmfs-ost/ss3-test-models repository}
 that you want to download. The default is \code{"main"}, which is the
 stable/default branch.}
 
@@ -28,7 +28,7 @@ downloading SS3 test models.
 }
 \description{
 Download and unzip the models folder stored on GitHub within the
-nmfs-stock-synthesis/test-models repository.
+nmfs-ost/ss3-test-models repository.
 }
 \examples{
 download_models(dir = getwd())
@@ -37,7 +37,7 @@ model_name <- list.files("models") # see the model names
 unlink(file.path("models"), recursive = TRUE)
 }
 \references{
-\href{https://github.com/nmfs-stock-synthesis/test-models#test-models}{nmfs-stock-synthesis/test-models repository}
+\href{https://github.com/nmfs-ost/ss3-test-models#test-models}{nmfs-ost/ss3-test-models repository}
 }
 \author{
 Kathryn Doering

--- a/man/get_ss3_exe.Rd
+++ b/man/get_ss3_exe.Rd
@@ -11,7 +11,7 @@ get_ss3_exe(dir = NULL, version = NULL)
 
 \item{version}{A character string of the executable version tag to download
 (e.g.'v3.30.20' or 'v3.30.18'). A list of tags is available at
-https://github.com/nmfs-stock-synthesis/stock-synthesis/tags}
+https://github.com/nmfs-ost/ss3-source-code/tags}
 }
 \value{
 A string of the file path to the downloaded executable
@@ -22,7 +22,7 @@ the latest release (if version = NULL) or the specified version of the Stock
 Synthesis executable for the appropriate operating system to the directory \code{dir}
 (if dir = NULL, then the executable is downloaded to the working directory).
 To view the version tags available go to
-https://github.com/nmfs-stock-synthesis/stock-synthesis/tags
+https://github.com/nmfs-ost/ss3-source-code/tags
 }
 \details{
 Downloads the SS3 executable according to specified version and the user

--- a/tests/testthat/test-readwrite.R
+++ b/tests/testthat/test-readwrite.R
@@ -95,7 +95,7 @@ test_that("ss_read works with a raw github URL", {
   skip_if_offline(host = "github.com")
   list_objs <- SS_read(
     dir =
-      "https://raw.githubusercontent.com/nmfs-stock-synthesis/test-models/main/models/Simple"
+      "https://raw.githubusercontent.com/nmfs-ost/ss3-test-models/main/models/Simple"
   )
   expect_true(is.list(list_objs))
   expect_equal(names(list_objs), c(

--- a/vignettes/r4ss-intro-vignette.Rmd
+++ b/vignettes/r4ss-intro-vignette.Rmd
@@ -235,9 +235,9 @@ associated functions for each model file, or would like to report a bug,
 please [post an issue in the r4ss repository](https://github.com/r4ss/r4ss/issues).
 
 ### Download the Stock Synthesis executable from GitHub
-The [latest release of the Stock Synthesis executable](https://github.com/nmfs-stock-synthesis/stock-synthesis/releases/latest) 
+The [latest release of the Stock Synthesis executable](https://github.com/nmfs-ost/ss3-source-code/releases/latest) 
 or other releases found by entering a character string of a version tag (list of 
-tags is available [here](https://github.com/nmfs-stock-synthesis/stock-synthesis/tags)) 
+tags is available [here](https://github.com/nmfs-ost/ss3-source-code/tags)) 
 can be downloaded from the Stock Synthesis GitHub page using the function:
 ```{r, eval = FALSE}
 # Default with no version downloads the latest release


### PR DESCRIPTION
The nmfs-stock-synthesis organization has been brought into the NMFS GitHub Enterprise and folded into the nmfs-ost organization as discussed in https://github.com/nmfs-ost/ss3-source-code/issues/524.

This PR updates the all links I can find within r4ss to the new locations. There remain comments in the simple_small input files but those files will be updated soon via #893 and it probably makes sense to leave them unchanged until the next SS3 release includes updated comments in the ss_new files.