### PR TITLE
Try fixing jitter & file_increment functions

### DIFF
--- a/R/file_increment.R
+++ b/R/file_increment.R
@@ -21,7 +21,7 @@ file_increment <- function(i, verbose = FALSE,
   if (verbose) {
     message("Renaming output files to have names like Report", i, ".sso")
   }
-  ignore <- file.rename(
+  ignore <- file.copy(
     from = dir(pattern = pattern),
     to = gsub("par", "par_", gsub(
       "\\.sso|(\\.par)",

--- a/R/file_increment.R
+++ b/R/file_increment.R
@@ -1,4 +1,4 @@
-#' Rename Stock Synthesis files by adding integer value
+#' Rename key Stock Synthesis output files by adding integer value
 #'
 #' Rename files found with `pattern` by adding `i` to their
 #' name before the extension.
@@ -15,7 +15,7 @@
 #' @author Kelli F. Johnson
 #' @returns Invisibly returns a vector of logical values specifying
 #' whether or not the file was successfully renamed.
-#'
+#' @seealso [jitter()]
 file_increment <- function(i, verbose = FALSE,
                            pattern = "^[CcPRw][a-zA-Z]+\\.sso|summary\\.sso|\\.par$") {
   if (verbose) {

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -258,7 +258,7 @@ iterate_jitter <- function(i,
   )
 
   # run model
-  r4ss::run(dir = jitter_dir, exe = exe, verbose = verbose)
+  r4ss::run(dir = jitter_dir, exe = exe, verbose = verbose, ...)
   # Only save stuff if it converged
   if ("Report.sso" %in% list.files(path = jitter_dir)) {
     rep <- SS_read_summary(file.path(jitter_dir, "ss_summary.sso"))

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -162,14 +162,14 @@ jitter <- function(dir = getwd(),
   r4ss::SS_writestarter(starter, overwrite = TRUE, verbose = FALSE)
 
   # I'm not sure if this is necessary anymore
-  file_increment(0, verbose = verbose)
+  # file_increment(0, verbose = verbose)
 
   # check length of Njitter input
   if (length(Njitter) == 1) {
     Njitter <- 1:Njitter
   }
 
-  likesaved <- furrr::future_map_dbl(Njitter, function(.x) {
+  likesaved <- furrr::future_map(Njitter, function(.x) {
     iterate_jitter(
       i = .x,
       dir = dir,
@@ -246,7 +246,7 @@ jitter <- function(dir = getwd(),
 iterate_jitter <- function(i,
                            dir = getwd(),
                            printlikes = TRUE,
-                           exe = "ss",
+                           exe = "ss3",
                            verbose = FALSE,
                            init_values_src = 0,
                            ...) {
@@ -257,7 +257,7 @@ iterate_jitter <- function(i,
     copy_par = as.logical(init_values_src)
   )
   # run model
-  r4ss::run(dir = jitter_dir, exe = exe, verbose = verbose, ...)
+  r4ss::run(dir = jitter_dir, exe = exe, verbose = verbose)
   # Only save stuff if it converged
   if ("Report.sso" %in% list.files(path = jitter_dir)) {
     rep <- SS_read_summary(file.path(jitter_dir, "ss_summary.sso"))

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -179,7 +179,6 @@ jitter <- function(dir = getwd(),
       init_values_src = starter[["init_values_src"]],
       ...
     )
-  })
 
   # rename output files and move them to base model directory
   to_copy <- purrr::map(Njitter, ~ list.files(

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -169,7 +169,7 @@ jitter <- function(dir = getwd(),
     Njitter <- 1:Njitter
   }
 
-  likesaved <- furrr::future_map(Njitter, function(.x) {
+  likesaved <- furrr::future_map_dbl(Njitter, function(.x) {
     iterate_jitter(
       i = .x,
       dir = dir,

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -169,9 +169,9 @@ jitter <- function(dir = getwd(),
     Njitter <- 1:Njitter
   }
 
-  likesaved <- furrr::future_map_dbl(Njitter, function(.x) {
-    iterate_jitter(
-      i = .x,
+  likesaved <- furrr::future_map_dbl(
+      .x = Njitter,
+      .f = iterate_jitter,
       dir = dir,
       printlikes = printlikes,
       exe = exe,

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -162,7 +162,7 @@ jitter <- function(dir = getwd(),
   r4ss::SS_writestarter(starter, overwrite = TRUE, verbose = FALSE)
 
   # I'm not sure if this is necessary anymore
-  # file_increment(0, verbose = verbose)
+  file_increment(0, verbose = verbose)
 
   # check length of Njitter input
   if (length(Njitter) == 1) {
@@ -256,6 +256,7 @@ iterate_jitter <- function(i,
     verbose = verbose, copy_exe = TRUE,
     copy_par = as.logical(init_values_src)
   )
+
   # run model
   r4ss::run(dir = jitter_dir, exe = exe, verbose = verbose)
   # Only save stuff if it converged

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -172,7 +172,6 @@ jitter <- function(dir = getwd(),
   likesaved <- furrr::future_map_dbl(
       .x = Njitter,
       .f = iterate_jitter,
-      dir = dir,
       printlikes = printlikes,
       exe = exe,
       verbose = verbose,
@@ -182,7 +181,7 @@ jitter <- function(dir = getwd(),
 
   # rename output files and move them to base model directory
   to_copy <- purrr::map(Njitter, ~ list.files(
-    path = file.path(dir, paste0("jitter", .x)),
+    path = paste0("jitter", .x),
     pattern = "^[CcPRw][a-zA-Z]+\\.sso|summary\\.sso|\\.par$"
   ))
 
@@ -206,6 +205,9 @@ jitter <- function(dir = getwd(),
       )
     }
   )
+  if(verbose){
+    message("Finished running jitters, running last few clean-up steps")
+    }
 
   # delete jitter model directory
   purrr::walk(Njitter, ~ unlink(paste0("jitter", .x), recursive = TRUE))
@@ -243,18 +245,21 @@ jitter <- function(dir = getwd(),
 #' @return Negative log-likelihood of one jittered model
 #'
 iterate_jitter <- function(i,
-                           dir = getwd(),
                            printlikes = TRUE,
                            exe = "ss3",
                            verbose = FALSE,
                            init_values_src = 0,
                            ...) {
-  jitter_dir <- file.path(dir, paste0("jitter", i))
+  jitter_dir <- paste0("jitter", i)
   copy_SS_inputs(
-    dir.old = dir, dir.new = jitter_dir, overwrite = TRUE,
+    dir.old = getwd(), dir.new = jitter_dir, overwrite = TRUE,
     verbose = verbose, copy_exe = TRUE,
     copy_par = as.logical(init_values_src)
   )
+  
+  if(verbose){
+    message(paste0("Starting run of jitter", i))
+    }
 
   # run model
   r4ss::run(dir = jitter_dir, exe = exe, verbose = verbose, ...)

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -203,6 +203,7 @@ num
 ogive
 optim
 ost
+osx
 outfile
 overfished
 overfishing

--- a/man/file_increment.Rd
+++ b/man/file_increment.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/file_increment.R
 \name{file_increment}
 \alias{file_increment}
-\title{Rename Stock Synthesis files by adding integer value}
+\title{Rename key Stock Synthesis output files by adding integer value}
 \usage{
 file_increment(
   i,
@@ -32,6 +32,9 @@ name before the extension.
 The \code{.par} file, which is the only file extension searched for
 with the default entry that does not end in \code{.sso}, is
 modified differently.\verb{_i.sso} is added to the file name.
+}
+\seealso{
+\code{\link[=jitter]{jitter()}}
 }
 \author{
 Kelli F. Johnson

--- a/man/iterate_jitter.Rd
+++ b/man/iterate_jitter.Rd
@@ -8,7 +8,7 @@ iterate_jitter(
   i,
   dir = getwd(),
   printlikes = TRUE,
-  exe = "ss",
+  exe = "ss3",
   verbose = FALSE,
   init_values_src = 0,
   ...

--- a/vignettes/r4ss-intro-vignette.Rmd
+++ b/vignettes/r4ss-intro-vignette.Rmd
@@ -272,7 +272,10 @@ operating systems automatically. Another advantage of `run()` is that
 there is no need to change the working directory.
 
 If the executable in a different folder than the model, specify either
-the absolute or relative path to the executable.
+the absolute or relative path to the executable. Note that executables for 
+v3.30.22.1 and after are named ss3.exe, ss3_linux, and ss3_osx *unless* you 
+download the executables using `get_ss3_exe()` which gives them the names 
+ss3.exe (for windows) and ss3 (for linux/osx) regardless of the version. 
 ```{r exe-in-diff-dir, eval=FALSE}
 # use the absolute exe path in the call on a Windows computer.
 run(dir = new_mod_path, exe = "c:/SS/SSv3.30.19.01_Apr15/ss.exe")


### PR DESCRIPTION
Creating a draft PR (for now) so that it's easier to ask for input on, continue development of a fix to this issue (issue #901), and have a place for conversations about development.

@iantaylor-NOAA I altered the `file_increment()` function so that instead of renaming the files, it copies the files under a new name so that the `copy_SS_inputs()` function can find the ss3.par/ss.par file (which is where it seemed to be running into issues before).

@MOshima-PIFSC, if you would like to try grabbing this branch again and testing it out with the ss3diags jitter vignette, that would be great.  