### PR TITLE
add suppressWarnings() to get_ss3_exe()

### DIFF
--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -64,7 +64,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
         tag, "/ss_win.exe"
       )
       try_ss3 <- tryCatch(
-        utils::download.file(url, destfile = file.path(dir, "ss3.exe"), mode = "wb"),
+        suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3.exe"), mode = "wb")),
         error = function(e) "ss name not right for this version, trying ss3"
       )
 
@@ -88,7 +88,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
         tag, "/ss_osx"
       )
       try_ss3 <- tryCatch(
-        utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb"),
+        suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
         error = function(e) "ss name not right for this version, trying ss3"
       )
 
@@ -114,7 +114,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
           tag, "/ss_linux"
         )
         try_ss3 <- tryCatch(
-          utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb"),
+          suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
           error = function(e) "ss name not right for this version, trying ss3"
         )
 

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -61,17 +61,17 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     } else {
       url <- paste0(
         "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-        tag, "/ss_win.exe"
+        tag, "/ss3_win.exe"
       )
-      try_ss3 <- tryCatch(
+      try_ss <- tryCatch(
         suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3.exe"), mode = "wb")),
-        error = function(e) "ss name not right for this version, trying ss3"
+        error = function(e) "ss3 name not right for this version, trying ss"
       )
 
-      if (try_ss3 == "ss name not right for this version, trying ss3") {
+      if (try_ss == "ss3 name not right for this version, trying ss") {
         url <- paste0(
           "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-          tag, "/ss3_win.exe"
+          tag, "/ss_win.exe"
         )
         utils::download.file(url, destfile = file.path(dir, "ss3.exe"), mode = "wb")
       }
@@ -85,17 +85,17 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     if (substr(R.version[["os"]], 1, 6) == "darwin") {
       url <- paste0(
         "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-        tag, "/ss_osx"
+        tag, "/ss3_osx"
       )
-      try_ss3 <- tryCatch(
+      try_ss <- tryCatch(
         suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
-        error = function(e) "ss name not right for this version, trying ss3"
+        error = function(e) "ss3 name not right for this version, trying ss"
       )
 
-      if (try_ss3 == "ss name not right for this version, trying ss3") {
+      if (try_ss == "ss3 name not right for this version, trying ss") {
         url <- paste0(
           "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-          tag, "/ss3_osx"
+          tag, "/ss_osx"
         )
         utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
       }
@@ -111,17 +111,17 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       if (R.version[["os"]] == "linux-gnu") {
         url <- paste0(
           "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-          tag, "/ss_linux"
+          tag, "/ss3_linux"
         )
-        try_ss3 <- tryCatch(
+        try_ss <- tryCatch(
           suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
-          error = function(e) "ss name not right for this version, trying ss3"
+          error = function(e) "ss3 name not right for this version, trying ss"
         )
 
-        if (try_ss3 == "ss name not right for this version, trying ss3") {
+        if (try_ss == "ss3 name not right for this version, trying ss") {
           url <- paste0(
             "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-            tag, "/ss3_linux"
+            tag, "/ss_linux"
           )
           utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
         }


### PR DESCRIPTION
Added the suppressWarnings() to where the function tries ss_win/ss_osx/ss_linux first because when it downloads the exe for the latest release (which is ss3_win/ss3_osx/ss3_linux), there are still some warnings (even though they are expected, they just don't need to be shown to the user). 

The warnings that this should hopefully get rid of are:
Warning messages:
1: In utils::download.file(url, destfile = file.path(dir, "ss3.exe"),  :
  downloaded length 0 != reported length 0
2: In utils::download.file(url, destfile = file.path(dir, "ss3.exe"),  :
  cannot open URL 'https://github.com/nmfs-ost/ss3-source-code/releases/download/v3.30.22.1/ss_win.exe': HTTP status was '404 Not Found'