### PR TITLE
Allow SS_output() to run if only Report.sso is present

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: r4ss
 Title: R Code for Stock Synthesis
-Version: 1.49.1
+Version: 1.49.2
 Authors@R: c(
     person("Ian G.", "Taylor", , "Ian.Taylor@noaa.gov", role = c("aut", "cre")),
     person("Ian J.", "Stewart", role = "aut"),

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -3067,11 +3067,15 @@ SS_output <-
 
 
     if (depletion_basis %in% c(1, 3:4)) {
-      starter <- SS_readstarter(
-        file = file.path(dir, "starter.ss"),
-        verbose = verbose
-      )
-      depletion_multiplier <- starter[["depl_denom_frac"]]
+      if (file.exists(file.path(dir, "starter.ss"))) {
+        starter <- SS_readstarter(
+          file = file.path(dir, "starter.ss"),
+          verbose = verbose
+        )
+        depletion_multiplier <- starter[["depl_denom_frac"]]
+      } else {
+        depletion_multiplier <- NULL  
+      }
     } else {
       depletion_multiplier <- 1
     }
@@ -3080,6 +3084,13 @@ SS_output <-
     if (Bratio_denominator == "no_depletion_basis") {
       Bratio_label <- "no_depletion_basis"
     } else {
+      # get depletion_multiplier if no starter file was available
+      # will be rounded to nearest % so potentially less accurate than
+      # value in the starter file
+      if (is.null(depletion_multiplier)) {
+        depletion_multiplier <- 
+          as.numeric(strsplit(Bratio_denominator, "%")[[1]][1])/100
+      }
       # create Bratio label for use in various plots
       if (grepl(pattern = "100", x = Bratio_denominator)) {
         # exclude 100% if present

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -3074,7 +3074,7 @@ SS_output <-
         )
         depletion_multiplier <- starter[["depl_denom_frac"]]
       } else {
-        depletion_multiplier <- NULL  
+        depletion_multiplier <- NULL
       }
     } else {
       depletion_multiplier <- 1
@@ -3088,8 +3088,8 @@ SS_output <-
       # will be rounded to nearest % so potentially less accurate than
       # value in the starter file
       if (is.null(depletion_multiplier)) {
-        depletion_multiplier <- 
-          as.numeric(strsplit(Bratio_denominator, "%")[[1]][1])/100
+        depletion_multiplier <-
+          as.numeric(strsplit(Bratio_denominator, "%")[[1]][1]) / 100
       }
       # create Bratio label for use in various plots
       if (grepl(pattern = "100", x = Bratio_denominator)) {


### PR DESCRIPTION
In recent r4ss versions the `SS_output()` function reads the starter file to get the depletion denominator whereas in earlier versions the function could work if only the Report.sso file was available with no additional files.

This change restores the ability to skip the starter file read if the file is not present by relying on a separate output of the depletion denominator (rounded to the nearest percent) in the report file.

Thanks to David Chagaris for report this.