### PR TITLE
Improve get_SIS_info()

### DIFF
--- a/R/get_SIS_info.R
+++ b/R/get_SIS_info.R
@@ -8,7 +8,7 @@
 #' copy step.
 
 #' @param model Output from SS_output
-#' @template dir
+#' @param dir Directory in which to write the CSV files.
 #' @param writecsv Write results to a CSV file (where the name will have the
 #' format "\[stock\]_2019_SIS_info.csv" where `stock`
 #' is an additional input
@@ -32,17 +32,14 @@
 #' info <- get_SIS_info(model, stock = "SimpleExample")
 #' }
 #'
-get_SIS_info <- function(model, dir = NULL, writecsv = TRUE,
-                         stock = "StockName", final_year = 2019, data_year = NULL, sciencecenter = "NWFSC", Mgt_Council = "NA") {
-  # directory to write file
-  if (is.null(dir)) {
-    dir <- model[["inputs"]][["dir"]]
-  }
-
-
-  if (is.null(data_year)) {
-    data_year <- model[["endyr"]]
-  }
+get_SIS_info <- function(model, 
+                         dir = model[["inputs"]][["dir"]], 
+                         writecsv = TRUE,
+                         stock = "StockName", 
+                         final_year = model[["endyr"]] + 1, 
+                         data_year = model[["endyr"]], 
+                         sciencecenter = "NWFSC", 
+                         Mgt_Council = "NA") {
 
   # construct filename
   filename_values <- paste(gsub(" ", "_", stock), final_year,
@@ -220,8 +217,8 @@ get_SIS_info <- function(model, dir = NULL, writecsv = TRUE,
   header_info["Category", "SpawnBio"] <- "Spawners"
   header_info["Primary", "SpawnBio"] <- "Y"
 
-  # numbers vs biomass switch should work for all models
-  # ran using SS after 8/28/20
+  # SpawnOutputUnits indicating numbers vs biomass switch should work for all 
+  # models run using SS3 versions released after August 2020
   if (model[["SpawnOutputUnits"]] == "numbers") {
     header_info["Description", "SpawnBio"] <- "Spawning Output(Eggs)"
     header_info["Unit", "SpawnBio"] <- "XXXX"

--- a/R/get_SIS_info.R
+++ b/R/get_SIS_info.R
@@ -38,7 +38,7 @@ get_SIS_info <- function(model,
                          stock = "StockName",
                          final_year = model[["endyr"]] + 1,
                          data_year = model[["endyr"]],
-                         month = "XX",
+                         month,
                          sciencecenter = "NWFSC",
                          Mgt_Council = "PFMC",
                          # SpawnOutputLabel is only available in an r4ss branch https://github.com/r4ss/r4ss/compare/main...spawn_output_label_838

--- a/R/get_SIS_info.R
+++ b/R/get_SIS_info.R
@@ -32,15 +32,24 @@
 #' info <- get_SIS_info(model, stock = "SimpleExample")
 #' }
 #'
-get_SIS_info <- function(model, 
-                         dir = model[["inputs"]][["dir"]], 
+get_SIS_info <- function(model,
+                         dir = model[["inputs"]][["dir"]],
                          writecsv = TRUE,
-                         stock = "StockName", 
-                         final_year = model[["endyr"]] + 1, 
-                         data_year = model[["endyr"]], 
-                         sciencecenter = "NWFSC", 
-                         Mgt_Council = "NA") {
-
+                         stock = "StockName",
+                         final_year = model[["endyr"]] + 1,
+                         data_year = model[["endyr"]],
+                         month = "XX",
+                         sciencecenter = "NWFSC",
+                         Mgt_Council = "PFMC",
+                         # SpawnOutputLabel is only available in an r4ss branch https://github.com/r4ss/r4ss/compare/main...spawn_output_label_838
+                         SpawnOutputLabel = model[["SpawnOutputLabel"]],
+                         contact = "first.last@noaa.gov",
+                         review_result = "XXXX",
+                         catch_input_data = "XXXX",
+                         abundance_input_data = "XXXX",
+                         bio_input_data = "XXXX",
+                         comp_input_data = "XXXX",
+                         ecosystem_linkage = "XXXX") {
   # construct filename
   filename_values <- paste(gsub(" ", "_", stock), final_year,
     "SIS_info_values.csv",
@@ -217,14 +226,22 @@ get_SIS_info <- function(model,
   header_info["Category", "SpawnBio"] <- "Spawners"
   header_info["Primary", "SpawnBio"] <- "Y"
 
-  # SpawnOutputUnits indicating numbers vs biomass switch should work for all 
+  # SpawnOutputUnits indicating numbers vs biomass switch should work for all
   # models starting with SS3 version 3.30.20 (September 2020)
   if (model[["SpawnOutputUnits"]] == "numbers") {
     header_info["Description", "SpawnBio"] <- "Spawning Output(Eggs)"
-    header_info["Unit", "SpawnBio"] <- "XXXX"
+    if (is.null(SpawnOutputLabel)) {
+      warning("Need to provide a label for the spawning output (e.g. 'millions of eggs')")
+      SpawnOutputLabel <- "XXXX eggs"
+    }
+    header_info["Unit", "SpawnBio"] <- SpawnOutputLabel
+    B_basis <- "Stock Reproductive Output"
+    B_unit <- SpawnOutputLabel
   } else {
     header_info["Description", "SpawnBio"] <- " Female Mature Spawning Biomass"
     header_info["Unit", "SpawnBio"] <- "Metric Tons"
+    B_basis <- "Spawning Stock Biomass"
+    B_unit <- "mt"
   }
 
   # info on fraction unfished
@@ -251,30 +268,57 @@ get_SIS_info <- function(model,
   header_info["Description", "Catch_n"] <- "Modeled Total Catch"
   header_info["Unit", "Catch_n"] <- "Number x 1000"
 
-  # info on Exploitation rate
+  # info on Exploitation rate (whatever is chosen for the F_YYYY quants)
   header_info["Category", "Exploit_rate"] <- "Fmort"
-  header_info["Primary", "Exploit_rate"] <- "XXX"
+  header_info["Primary", "Exploit_rate"] <-
+    dplyr::case_when(
+      Mgt_Council == "PFMC" ~ "N", # not used as primary exploitation rate by PFMC
+      Mgt_Council == "GM" ~ "XXXX", # fill in value here
+      TRUE ~ "XXXX" # any other Mgt_Council
+    )
   header_info["Description", "Exploit_rate"] <- strsplit(model[["F_report_basis"]], ";")[[1]][1]
   header_info["Unit", "Exploit_rate"] <- "Rate"
 
-  # info on total Exploitation rate
+  # info on total Exploitation rate (catch / summary bio)
   header_info["Category", "Tot_Exploit"] <- "Fmort"
-  header_info["Primary", "Tot_Exploit"] <- "XXX"
+  header_info["Primary", "Tot_Exploit"] <-
+    dplyr::case_when(
+      Mgt_Council == "PFMC" ~ "N", # not used as primary exploitation rate by PFMC
+      Mgt_Council == "GM" ~ "XXXX", # fill in value here
+      TRUE ~ "XXXX" # any other Mgt_Council
+    )
   header_info["Description", "Tot_Exploit"] <-
     paste0("Relative Exploitation Rate (Catch/", summary_bio_label, ")")
   header_info["Unit", "Tot_Exploit"] <- "Rate"
 
-  # info on SPR_report
+  # info on SPR_report (whatever is chosen for SPR ratio)
   header_info["Category", "SPR_report"] <- "Fmort"
-  header_info["Primary", "SPR_report"] <- "XXX"
+  header_info["Primary", "SPR_report"] <-
+    dplyr::case_when(
+      Mgt_Council == "PFMC" ~ "Y", # often used as primary by PFMC
+      Mgt_Council == "GM" ~ "XXXX", # fill in value here
+      TRUE ~ "XXXX" # any other Mgt_Council
+    )
   header_info["Description", "SPR_report"] <- model[["SPRratioLabel"]]
   header_info["Unit", "SPR_report"] <- "Rate"
 
-  # Only needs to be added if SPR_report is not 1-spr
-  # info on 1 - SPR
+  # If SPR_report is not "1-SPR" (e.g. if it's a ratio of 1-SPR to something else)
+  # then add column with 1 - SPR
   if (model[["SPRratioLabel"]] != "1-SPR") {
     header_info["Category", "1-SPR"] <- "Fmort"
-    header_info["Primary", "1-SPR"] <- "XXX"
+    header_info["Primary", "1-SPR"] <-
+      dplyr::case_when(
+        Mgt_Council == "PFMC" ~ "Y", # 1 - SPR is used as primary exploitation rate by PFMC
+        Mgt_Council == "GM" ~ "XXXX", # fill in value here
+        TRUE ~ "XXXX" # any other Mgt_Council
+      )
+    # change the value from the SPR_report set above
+    header_info["Primary", "SPR_report"] <-
+      dplyr::case_when(
+        Mgt_Council == "PFMC" ~ "N", # SPR_ratio is not primary if not equal to 1-SPR
+        Mgt_Council == "GM" ~ "XXXX", # fill in value here
+        TRUE ~ "XXXX" # any other Mgt_Council
+      )
     header_info["Description", "1-SPR"] <- "1 - SPR"
     header_info["Unit", "1-SPR"] <- "Rate"
   }
@@ -294,14 +338,17 @@ get_SIS_info <- function(model,
     SPRtarg_text <- paste0("SPR", 100 * model[["sprtarg"]], "%") # e.g. SPR50%
   }
 
-  F_limit <- 1 - model[["sprtarg"]]
-  F_limit_basis <- paste0("1-SPR_", SPRtarg_text)
-  F_msy <- F_limit
-  F_msy_basis <- F_limit_basis
+  # PFMC Settings (F limit and MSY proxy are in units of 1-SPR)
+  if (Mgt_Council == "PFMC") {
+    F_limit <- 1 - model[["sprtarg"]]
+    F_limit_basis <- paste0("1-SPR_", SPRtarg_text)
+    F_msy <- F_limit
+    F_msy_basis <- F_limit_basis
+  }
 
   # GM Settings: Using F_SPR target
   if (Mgt_Council == "GM") {
-    # Annual FSPR names changed between versions
+    # Annual F_SPR names changed between versions
     if ("annF_SPR" %in% rownames(model[["derived_quants"]])) {
       F_limit <- round(model[["derived_quants"]]["annF_SPR", "Value"], digits = 3)
     } else {
@@ -318,7 +365,10 @@ get_SIS_info <- function(model,
     model[["btarg"]] <- NA
     warning("No value for model[['btarg']]")
   } else {
-    Btarg_text <- paste0("B", 100 * model[["btarg"]], "%") # e.g. B40%
+    # PFMC Settings
+    if (Mgt_Council == "PFMC") {
+      Btarg_text <- paste0("B", 100 * model[["btarg"]], "%") # e.g. B40%
+    }
     # GM Settings:
     if (Mgt_Council == "GM") {
       Btarg_text <- paste0("SPR", 100 * model[["btarg"]], "%")
@@ -326,14 +376,14 @@ get_SIS_info <- function(model,
   }
 
   if (model[["minbthresh"]] == -999) {
-    MinBthresh_text <- "BXX%"
+    MinBthresh_text <- "SSBXX%"
     model[["minbthresh"]] <- NA
     warning("No value for model[['minbthresh']]")
   } else {
-    MinBthresh_text <- paste0("B", 100 * model[["minbthresh"]], "%") # e.g. B25%
+    MinBthresh_text <- paste0("SSB", 100 * model[["minbthresh"]], "%") # e.g. B25%
     B_msy_basis <- paste0("SS", Btarg_text)
-    B_msy <- round(model[["SBzero"]] * model[["btarg"]])
-    B_limit <- round(model[["SBzero"]] * model[["minbthresh"]])
+    B_msy <- model[["SBzero"]] * model[["btarg"]]
+    B_limit <- model[["SBzero"]] * model[["minbthresh"]]
   }
 
   # GM Settings:
@@ -341,8 +391,8 @@ get_SIS_info <- function(model,
     MinBthresh_text <- paste0("(1-M)*SPR", 100 * model[["btarg"]], "%") # e.g. B25%
     B_msy_basis <- Btarg_text
     eq_year <- data_year + model[["nforecastyears"]]
-    B_msy <- round(model[["derived_quants"]][["Value"]][which(model[["derived_quants"]][["Label"]] == paste0("SSB_", eq_year))])
-    B_limit <- round((0.5 * B_msy))
+    B_msy <- model[["derived_quants"]][["Value"]][which(model[["derived_quants"]][["Label"]] == paste0("SSB_", eq_year))]
+    B_limit <- (0.5 * B_msy)
   }
 
   B_year <- final_year
@@ -350,26 +400,32 @@ get_SIS_info <- function(model,
     Year = ts[["Yr"]],
     SpawnBio = round(ts[["SpawnBio"]], 2)
   )
-  Bcurrent <- round(ts_tab_short[["SpawnBio"]][ts_tab_short[["Year"]] == final_year])
+  Bcurrent <- ts_tab_short[["SpawnBio"]][ts_tab_short[["Year"]] == final_year]
 
   # GM Settings:
   if (Mgt_Council == "GM") {
     B_year <- data_year
-    Bcurrent <- round(tab[["SpawnBio"]][tab[["Year"]] == data_year])
+    Bcurrent <- tab[["SpawnBio"]][tab[["Year"]] == data_year]
   }
 
   # MSY-proxy labels were changed at some point
   if ("Dead_Catch_SPR" %in% rownames(model[["derived_quants"]])) {
-    Yield_at_SPR_target <- round(model[["derived_quants"]]["Dead_Catch_SPR", "Value"])
-    Yield_at_B_target <- round(model[["derived_quants"]]["Dead_Catch_Btgt", "Value"])
+    Yield_at_SPR_target <- round(model[["derived_quants"]]["Dead_Catch_SPR", "Value"], 1)
+    Yield_at_B_target <- round(model[["derived_quants"]]["Dead_Catch_Btgt", "Value"], 1)
   } else {
-    Yield_at_SPR_target <- round(model[["derived_quants"]]["TotYield_SPRtgt", "Value"])
-    Yield_at_B_target <- round(model[["derived_quants"]]["TotYield_Btgt", "Value"])
+    Yield_at_SPR_target <- round(model[["derived_quants"]]["TotYield_SPRtgt", "Value"], 1)
+    Yield_at_B_target <- round(model[["derived_quants"]]["TotYield_Btgt", "Value"], 1)
   }
 
-  Best_F_Est <- tab$"1-SPR"[tab[["Year"]] == data_year]
-  F_basis <- "Equilibrium SPR"
-  F_unit <- "1-SPR"
+  if (Mgt_Council == "PFMC") {
+    best_F_column <- "1-SPR"
+    if(!best_F_column %in% names(tab)) {
+      best_F_column <- "SPR_report"
+    }
+    Best_F_Est <- tab[tab[["Year"]] == data_year, best_F_column]
+    F_basis <- "Equilibrium SPR"
+    F_unit <- "1-SPR"
+  }
 
   # GM Settings: Best F estimate = geometric mean of last three data years
   if (Mgt_Council == "GM") {
@@ -378,7 +434,7 @@ get_SIS_info <- function(model,
     F_unit <- "Exploitation Rate"
   }
 
-  # SS version
+  # SS3 version
   SS_version <- strsplit(model[["SS_version"]], split = ";")[[1]][1]
   gsub("-safe", "", SS_version)
   gsub("-opt", "", SS_version)
@@ -395,28 +451,27 @@ get_SIS_info <- function(model,
   }
 
 
-
-
   # make big 2-column table of info about each model
   info_tab <- c(
     paste0("SAIP:,", "https://spo.nmfs.noaa.gov/sites/default/files/TMSPO183.pdf"),
     "",
     paste0("Stock / Entity Name,", stock),
-    paste0("Assessment Type,", "X"),
+    paste0("Assessment Type,", "Operational"),
     paste0("Ensemble/Multimodel Approach,", "NA"),
-    paste0("Asmt Year and Month,", final_year, ".XX"),
+    # sprintf command in line below converts month 9 to "09" (for example)
+    paste0("Asmt Year and Month,", final_year, ".", sprintf("%02d", month)),
     paste0("Last Data Year,", data_year),
     paste0("Asmt Model Category,", "6 - Statistical Catch-at-Age (SS, ASAP, AMAK, BAM, MultifancL< CASAL)"),
     paste0("Asmt Model Category,", "SS"),
     paste0("Model Version,", SS_version),
     paste0("Lead Lab,", sciencecenter),
-    paste0("Point of Contact (assessment lead),", "XXXX"),
-    paste0("Review Result,", "XXXX"),
-    paste0("Catch Input Data,", "XXXX"),
-    paste0("Abundance Input Data,", "XXXX"),
-    paste0("Biological Input Data,", "XXXX"),
-    paste0("Size/Age Composition Input Data,", "XXXX"),
-    paste0("Ecosystem Linkage,", "XXXX"),
+    paste0("Point of Contact (assessment lead),", contact),
+    paste0("Review Result,", review_result),
+    paste0("Catch Input Data,", catch_input_data),
+    paste0("Abundance Input Data,", abundance_input_data),
+    paste0("Biological Input Data,", bio_input_data),
+    paste0("Size/Age Composition Input Data,", comp_input_data),
+    paste0("Ecosystem Linkage,", ecosystem_linkage),
     "",
     "Fishing Mortality Estimates",
     paste0("F Year, ", data_year),
@@ -431,39 +486,31 @@ get_SIS_info <- function(model,
     paste0("Flimit Basis, ", F_limit_basis),
     paste0("FMSY, ", F_msy),
     paste0("FMSY Basis, ", F_msy_basis),
-    paste0("F target,", ""),
-    paste0("F target Basis,", ""),
-    # paste0("MSY, ",             Yield_at_SPR_target), # These lines have moved to the next section
-    # paste0("MSY Unit,",         "mt"),
-    # paste0("MSY Basis, ",     "Yield with ", SPRtarg_text,
-    #      " at SB_", SPRtarg_text),
+    paste0("F target, ", ""),
+    paste0("F target Basis, ", ""),
+    paste0("F/F_limit, ", round(Best_F_Est / F_limit, 3)),
+    paste0("F/F_MSY, ", round(Best_F_Est / F_msy, 3)),
+    paste0("F/F_target, ", ""),
     "",
     "Biomass Estimates",
-    paste0("[Unfished Spawning Biomass], ", model[["SBzero"]]), # no longer a requested value
+    paste0("[Unfished Spawning Biomass], ", round(model[["SBzero"]], 1)), # no longer a requested value
     paste0("B Year, ", B_year),
     paste0("Min B. Estimate, ", ""),
     paste0("Max. B Estimate, ", ""),
-    paste0("Best B Estimate, ", Bcurrent),
-    paste0("B Basis, ", "Spawning Biomass / Female mature biomass"),
-    paste0("B Unit, ", "mt"),
+    paste0("Best B Estimate, ", round(Bcurrent, 1)),
+    paste0("B Basis, ", B_basis),
+    paste0("B Unit, ", B_unit),
     paste0("MSY, ", Yield_at_B_target),
     paste0("MSY Unit, ", "mt"),
-    # paste0("[MSY Basis], ",     "Yield with SPR_",
-    #        Btarg_text," at ",   Btarg_text, "(mt)"),
-    # paste0("[Depletion], ",
-    #        round(model[["derived_quants"]][paste0("Bratio_", final_year),
-    #                                   "Value"], 3)),
     "",
     "Domestic Biomass Derived Management Quantities",
-    paste0("Blimit, ", B_limit),
+    paste0("Blimit, ", round(B_limit, 1)),
     paste0("Blimit Basis, ", MinBthresh_text),
-    paste0("BMSY, ", B_msy),
+    paste0("BMSY, ", round(B_msy, 1)),
     paste0("BMSY Basis, ", B_msy_basis), # e.g. SSB40%
-    paste0("B/Blimit, ", round((Bcurrent / B_limit), 2)),
+    paste0("B/Blimit, ", round((Bcurrent / B_limit), 3)),
     paste0("B/Bmsy, ", round((Bcurrent / B_msy), 3)),
     paste0("Stock Level (relative) to BMSY, ", stock_level_to_MSY),
-    # paste0("age ", summary_age, "+ summary biomass, ",
-    #        model[["timeseries"]][["Bio_smry"]][model[["timeseries"]][["Yr"]] == final_year - 1]),
     "",
     ""
   )

--- a/R/get_SIS_info.R
+++ b/R/get_SIS_info.R
@@ -218,7 +218,7 @@ get_SIS_info <- function(model,
   header_info["Primary", "SpawnBio"] <- "Y"
 
   # SpawnOutputUnits indicating numbers vs biomass switch should work for all 
-  # models run using SS3 versions released after August 2020
+  # models starting with SS3 version 3.30.20 (September 2020)
   if (model[["SpawnOutputUnits"]] == "numbers") {
     header_info["Description", "SpawnBio"] <- "Spawning Output(Eggs)"
     header_info["Unit", "SpawnBio"] <- "XXXX"

--- a/man/get_SIS_info.Rd
+++ b/man/get_SIS_info.Rd
@@ -9,6 +9,7 @@ get_SIS_info(
   dir = model[["inputs"]][["dir"]],
   writecsv = TRUE,
   stock = "StockName",
+  assessment_type = "Operational",
   final_year = model[["endyr"]] + 1,
   data_year = model[["endyr"]],
   month,
@@ -35,6 +36,9 @@ is an additional input}
 
 \item{stock}{String to prepend id info to filename for CSV file}
 
+\item{assessment_type}{"Operational" or "Stock Monitoring Updates"
+(or perhaps additional options as well)}
+
 \item{final_year}{Year of assessment and reference points
 (typically will be \code{model[["endyr"]] + 1})}
 
@@ -42,8 +46,28 @@ is an additional input}
 
 \item{sciencecenter}{Origin of assessment report}
 
-\item{Mgt_Council}{Council jurisdiction. Currently the only option
-outside of the default is Gulf of Mexico (\code{"GM"})}
+\item{Mgt_Council}{Council jurisdiction. Currently only
+\code{"PFMC"} (Pacific Fishery Management Council) and \code{"GM"}
+(Gulf of Mexico) are the only options.}
+
+\item{SpawnOutputLabel}{Units for spawning output if not in mt
+(e.g. "Millions of eggs"). In the future this can be included in the
+\code{model} list created by \code{r4ss::SS_output()}}
+
+\item{contact}{Name and/or email address for lead author.}
+
+\item{review_result}{Something like "Full Acceptance"}
+
+\item{catch_input_data}{Qualitative category for catch input data}
+
+\item{abundance_input_data}{Qualitative category for abundance input data}
+
+\item{bio_input_data}{Qualitative category for biological input data}
+
+\item{comp_input_data}{Qualitative category for size/age composition input
+data}
+
+\item{ecosystem_linkage}{Qualitative category for ecosystem linkage}
 }
 \description{
 Processes model results contained in the list created by
@@ -55,12 +79,11 @@ copy step.
 }
 \examples{
 \dontrun{
-# directory with the model output
-mydir <- file.path(path.package("r4ss"), "extdata/simple_small")
 # read the model output
-model <- SS_output(dir = mydir)
+model <- SS_output(dir = system.file("extdata/simple_small", package = "r4ss"),
+  printstats = FALSE, verbose = FALSE)
 # run get_SIS_info:
-info <- get_SIS_info(model, stock = "SimpleExample")
+info <- get_SIS_info(model, stock = "SimpleExample", month = 1)
 }
 
 }

--- a/man/get_SIS_info.Rd
+++ b/man/get_SIS_info.Rd
@@ -6,21 +6,28 @@
 \usage{
 get_SIS_info(
   model,
-  dir = NULL,
+  dir = model[["inputs"]][["dir"]],
   writecsv = TRUE,
   stock = "StockName",
-  final_year = 2019,
-  data_year = NULL,
+  final_year = model[["endyr"]] + 1,
+  data_year = model[["endyr"]],
+  month,
   sciencecenter = "NWFSC",
-  Mgt_Council = "NA"
+  Mgt_Council = "PFMC",
+  SpawnOutputLabel = model[["SpawnOutputLabel"]],
+  contact = "first.last@noaa.gov",
+  review_result = "XXXX",
+  catch_input_data = "XXXX",
+  abundance_input_data = "XXXX",
+  bio_input_data = "XXXX",
+  comp_input_data = "XXXX",
+  ecosystem_linkage = "XXXX"
 )
 }
 \arguments{
 \item{model}{Output from SS_output}
 
-\item{dir}{A file path to the directory of interest.
-The default value is \code{dir = NULL}, which leads to using
-the current working directory.}
+\item{dir}{Directory in which to write the CSV files.}
 
 \item{writecsv}{Write results to a CSV file (where the name will have the
 format "[stock]_2019_SIS_info.csv" where \code{stock}

--- a/man/r4ss-package.Rd
+++ b/man/r4ss-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-A collection of R functions for use with Stock Synthesis, a fisheries stock assessment modeling platform written in ADMB by Dr. Richard D. Methot at the NOAA Northwest Fisheries Science Center. The functions include tools for summarizing and plotting results, manipulating files, visualizing model parameterizations, and various other common stock assessment tasks. This version of '{r4ss}' is compatible with Stock Synthesis versions 3.24 through 3.30 (specifically version 3.30.21 beta, from January 2023). Support for 3.24 models is only through the core functions for reading output and plotting.
+A collection of R functions for use with Stock Synthesis, a fisheries stock assessment modeling platform written in ADMB by Dr. Richard D. Methot at the NOAA Northwest Fisheries Science Center. The functions include tools for summarizing and plotting results, manipulating files, visualizing model parameterizations, and various other common stock assessment tasks. This version of '{r4ss}' is compatible with Stock Synthesis versions 3.24 through 3.30 (specifically version 3.30.22, from October 2023). Support for 3.24 models is only through the core functions for reading output and plotting.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-get_SIS_info.R
+++ b/tests/testthat/test-get_SIS_info.R
@@ -21,6 +21,6 @@ simple_small <- SS_output(file.path(example_path, "simple_small"),
 get_SIS_info(simple_small, dir = temp_path)
 
 test_that("SSexecutivesummary() runs on simple_small model", {
-  expect_true("StockName_2023_SIS_info_values.csv" %in% dir(file.path(temp_path, "tables")))
-  expect_true("StockName_2023_SIS_info_timeseries.csv" %in% dir(file.path(temp_path, "tables")))
+  expect_true("StockName_2023_SIS_info_values.csv" %in% dir(temp_path))
+  expect_true("StockName_2023_SIS_info_timeseries.csv" %in% dir(temp_path))
 })

--- a/tests/testthat/test-get_SIS_info.R
+++ b/tests/testthat/test-get_SIS_info.R
@@ -1,0 +1,26 @@
+context("Run get_SIS_info() on simple_small model output")
+
+example_path <- system.file("extdata", package = "r4ss")
+# create a temporary directory location to write files to.
+# to view the temp_path location, you can add a browser() statement after
+# creating the temp_path directory and see what temp_path is. R should write
+# to the same location for the same R session (if you restart R, temp_path will)
+# change.
+temp_path <- file.path(tempdir(), "test_basics")
+dir.create(temp_path, showWarnings = FALSE)
+# remove all artifacts created from testing. (developers: simply comment out
+# the line below if you want to keep artifacts for troubleshooting purposes)
+on.exit(unlink(temp_path, recursive = TRUE), add = TRUE)
+
+# get model output (already tested in test-basics.R)
+simple_small <- SS_output(file.path(example_path, "simple_small"),
+  verbose = FALSE, printstats = FALSE
+)
+
+# run function
+get_SIS_info(simple_small, dir = temp_path)
+
+test_that("SSexecutivesummary() runs on simple_small model", {
+  expect_true("StockName_2023_SIS_info_values.csv" %in% dir(file.path(temp_path, "tables")))
+  expect_true("StockName_2023_SIS_info_timeseries.csv" %in% dir(file.path(temp_path, "tables")))
+})

--- a/tests/testthat/test-get_SIS_info.R
+++ b/tests/testthat/test-get_SIS_info.R
@@ -18,9 +18,9 @@ simple_small <- SS_output(file.path(example_path, "simple_small"),
 )
 
 # run function
-get_SIS_info(simple_small, dir = temp_path)
+get_SIS_info(simple_small, dir = temp_path, month = 1)
 
-test_that("SSexecutivesummary() runs on simple_small model", {
+test_that("get_SIS_info() runs on simple_small model", {
   expect_true("StockName_2023_SIS_info_values.csv" %in% dir(temp_path))
   expect_true("StockName_2023_SIS_info_timeseries.csv" %in% dir(temp_path))
 })


### PR DESCRIPTION
This Pull Request includes the following:
* add additional arguments (with default = "XXXX") instead of hard-wiring "XXXX" in output files
* improved rounding in a few places
* `Mgt_Council` input can now be "PFMC" or "GM" (additional councils can be added by anyone with interest) with use of `dplyr::case_when()` to switch among options
* add testthat test #316 
* general code cleanup

@latreesedenson-NOAA, if you have time to take a look at any of these changes and make suggestions or further improvements, please do. In particular, there are a bunch of places where I've filled in the default choice for PFMC assessments, but didn't know how to fill in the GM option, so left it as something like the following. Improvements could be made at any point in the future outside of this pull request, so there's no rush.
```
dplyr::case_when(
        Mgt_Council == "PFMC" ~ "N", # not used as primary exploitation rate by PFMC
        Mgt_Council == "GM" ~ "XXXX", # fill in value here
        TRUE ~ "XXXX" # any other Mgt_Council
      )
```