### PR TITLE
fix: reference year for Mohn's Rho calc #924

### DIFF
--- a/R/SSmohnsrho.R
+++ b/R/SSmohnsrho.R
@@ -82,17 +82,17 @@ SSmohnsrho <- function(summaryoutput,
   # the retrospectives relative to the reference model
   # rho <- sum over y [ (X_y,retro - X_y,ref) / X_y,ref ]
   for (i in 1:(N - 1)) {
-    ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1] + 1)
+    ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
     mohnSSB[i] <- (summaryoutput[["SpawnBio"]][ind, i + 1] -
       summaryoutput[["SpawnBio"]][ind, 1]) /
       summaryoutput[["SpawnBio"]][ind, 1]
 
-    ind <- which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1] + 1)
+    ind <- which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1])
     mohnRec[i] <- (summaryoutput[["recruits"]][ind, i + 1] -
       summaryoutput[["recruits"]][ind, 1]) /
       summaryoutput[["recruits"]][ind, 1]
 
-    ind <- which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1] + 1)
+    ind <- which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1])
     mohnBratio[i] <- (summaryoutput[["Bratio"]][ind, i + 1] -
       summaryoutput[["Bratio"]][ind, 1]) /
       summaryoutput[["Bratio"]][ind, 1]
@@ -111,7 +111,7 @@ SSmohnsrho <- function(summaryoutput,
   # rho <- rho / Number of Years
   for (i in 1:(N - 1)) {
     ind <- which(summaryoutput[["SpawnBio"]][["Yr"]] == startyr + 1):
-    which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1] + 1)
+    which(summaryoutput[["SpawnBio"]][["Yr"]] == endyrvec[i + 1])
     mohnSSB.all[i] <- sum(
       (summaryoutput[["SpawnBio"]][ind, i + 1] -
         summaryoutput[["SpawnBio"]][ind, 1]
@@ -119,7 +119,7 @@ SSmohnsrho <- function(summaryoutput,
         summaryoutput[["SpawnBio"]][ind, 1]
     ) / length(ind)
     ind <- which(summaryoutput[["recruits"]][["Yr"]] == startyr + 1):
-    which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1] + 1)
+    which(summaryoutput[["recruits"]][["Yr"]] == endyrvec[i + 1])
     mohnRec.all[i] <- sum(
       (summaryoutput[["recruits"]][ind, i + 1] -
         summaryoutput[["recruits"]][ind, 1]
@@ -128,7 +128,7 @@ SSmohnsrho <- function(summaryoutput,
     ) / length(ind)
     if (length(which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1)) != 0) {
       ind <- which(summaryoutput[["Bratio"]][["Yr"]] == startyr + 1):
-      which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1] + 1)
+      which(summaryoutput[["Bratio"]][["Yr"]] == endyrvec[i + 1])
       mohnBratio.all[i] <- sum(
         (summaryoutput[["Bratio"]][ind, i + 1] -
           summaryoutput[["Bratio"]][ind, 1]


### PR DESCRIPTION
This change fixes the reference year for calculating the Mohn's Rho to compare estimates to the final year with data rather than final year with data + 1 (forecast Mohn's Rho) consistently across parameters.  This should address the error found by @MOshima-PIFSC .    