### PR TITLE
Add pt.cex as input argument to add_legend

### DIFF
--- a/R/helper_fxns.R
+++ b/R/helper_fxns.R
@@ -181,6 +181,7 @@ SSdiagsTime2Year <- function(ss3out, time.steps = 0.25, end.time) {
 #' @param legendsp Space between legend labels
 #' @param col Optional vector of colors to be used for lines. Input NULL
 #' @param pch Optional vector of plot character values
+#' @param pt.cex Adjust the cex of points.  
 #' @param lty Optional vector of line types
 #' @param lwd Optional vector of line widths
 #' @param type Type parameter passed to points (default 'o' overplots points on

--- a/R/helper_fxns.R
+++ b/R/helper_fxns.R
@@ -197,6 +197,7 @@ add_legend <- function(legendlabels,
                        legendsp = 0.9,
                        col = NULL,
                        pch = NULL,
+                       pt.cex = 0.7,
                        lty = 1,
                        lwd = 2,
                        type = "l") {
@@ -225,7 +226,7 @@ add_legend <- function(legendlabels,
     pch = legend.pch[legendorder],
     bty = "n",
     ncol = legendncol,
-    pt.cex = 0.7,
+    pt.cex = pt.cex[legendorder],
     cex = legendcex,
     y.intersp = legendsp
   )

--- a/man/add_legend.Rd
+++ b/man/add_legend.Rd
@@ -13,6 +13,7 @@ add_legend(
   legendsp = 0.9,
   col = NULL,
   pch = NULL,
+  pt.cex = 0.7,
   lty = 1,
   lwd = 2,
   type = "l"
@@ -39,6 +40,8 @@ which is represented in the summary input object.}
 \item{col}{Optional vector of colors to be used for lines. Input NULL}
 
 \item{pch}{Optional vector of plot character values}
+
+\item{pt.cex}{Adjust the cex of points.}
 
 \item{lty}{Optional vector of line types}
 


### PR DESCRIPTION
I added pt.cex as an argument that can be specified (instead of fixed at 0.7 as was previously) in add_legend(). This gives users more control for changing the size of points in the legend. I set the default to 0.7 so it shouldn't affect any of legends as they currently are. I also updated the documentation for the function by running `devtools::document()`. 