### PR TITLE
add m2 chip ss3 executable to get_ss3_exe() function

### DIFF
--- a/.github/workflows/r4ss-extra-tests.yml
+++ b/.github/workflows/r4ss-extra-tests.yml
@@ -91,6 +91,7 @@ jobs:
         shell: bash
   
       - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -82,62 +82,84 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       ))
     }
   } else {
-    if (substr(R.version[["os"]], 1, 6) == "darwin") {
-      url <- paste0(
-        "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-        tag, "/ss3_osx"
-      )
-      try_ss <- tryCatch(
-        suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
-        error = function(e) "ss3 name not right for this version, trying ss"
-      )
-
-      if (try_ss == "ss3 name not right for this version, trying ss") {
+      if (substr(R.version[["os"]], 1, 6) == "darwin" && R.version[["arch"]] == "aarch64"){
         url <- paste0(
-          "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-          tag, "/ss_osx"
+            "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
+            tag, "/ss3_osx_m2"
         )
-        utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
-      }
-      Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
-      download_location <- file.path(dir, "ss3")
+        try_M2 <- tryCatch(
+            suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
+            error = function(e) "ss3 executable not available for macOS M2 chip 
+            computers for versions prior to v.3.30.21.1"
+          )
 
-
-      message(paste0(
-        "The stock synthesis executable for Mac ", tag, " was downloaded to: ",
-        download_location
-      ))
-    } else {
-      if (R.version[["os"]] == "linux-gnu") {
-        url <- paste0(
-          "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-          tag, "/ss3_linux"
-        )
-        try_ss <- tryCatch(
-          suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
-          error = function(e) "ss3 name not right for this version, trying ss"
-        )
-
-        if (try_ss == "ss3 name not right for this version, trying ss") {
+        if(try_M2 == "ss3 executable not available for macOS M2 chip computers for 
+        versions prior to v.3.30.21.1"){
+          print(try_M2)
+        } else {
+          Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
+          download_location <- file.path(dir, "ss3")
+          message(paste0(
+            "The stock synthesis executable for Mac ", tag, " was downloaded to: ",
+            download_location
+            ))
+          }
+      } else {
+        if (substr(R.version[["os"]], 1, 6) == "darwin" && R.version[["arch"]] == "x86_64") {
           url <- paste0(
             "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-            tag, "/ss_linux"
+            tag, "/ss3_osx"
           )
-          utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
+          try_ss <- tryCatch(
+            suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
+            error = function(e) "ss3 name not right for this version, trying ss"
+          )
+
+          if (try_ss == "ss3 name not right for this version, trying ss") {
+            url <- paste0(
+              "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
+              tag, "/ss_osx"
+            )
+            utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
+          }
+          Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
+          download_location <- file.path(dir, "ss3")
+          message(paste0(
+            "The stock synthesis executable for Mac ", tag, " was downloaded to: ",
+            download_location
+          ))
+        } else {
+          if (R.version[["os"]] == "linux-gnu") {
+            url <- paste0(
+              "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
+              tag, "/ss3_linux"
+            )
+            try_ss <- tryCatch(
+              suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
+              error = function(e) "ss3 name not right for this version, trying ss"
+            )
+
+            if (try_ss == "ss3 name not right for this version, trying ss") {
+              url <- paste0(
+                "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
+                tag, "/ss_linux"
+              )
+              utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")
+            }
+            Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
+            Sys.chmod(paths = dir, mode = "0777")
+            download_location <- file.path(dir, "ss3")
+            message(paste0(
+              "The stock synthesis executable for Linux ", tag, " was downloaded to: ",
+              download_location
+            ))
+          } else {
+            stop(
+              "The Stock Synthesis executable is not available for ", R.version[["os"]], "."
+            ) # nocov end
+          }
         }
-        Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
-        Sys.chmod(paths = dir, mode = "0777")
-        download_location <- file.path(dir, "ss3")
-        message(paste0(
-          "The stock synthesis executable for Linux ", tag, " was downloaded to: ",
-          download_location
-        ))
-      } else {
-        stop(
-          "The Stock Synthesis executable is not available for ", R.version[["os"]], "."
-        ) # nocov end
       }
-    }
   }
   return(invisible(download_location))
 }

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -94,7 +94,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
           )
 
         if(try_arm64 == "ss3 executable not available for macOS arm64 architecture computers for 
-        versions prior to v.3.30.21.1"){
+        versions prior to v.3.30.22.1"){
           print(try_arm64)
         } else {
           Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -85,17 +85,17 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
       if (substr(R.version[["os"]], 1, 6) == "darwin" && R.version[["arch"]] == "aarch64"){
         url <- paste0(
             "https://github.com/nmfs-ost/ss3-source-code/releases/download/",
-            tag, "/ss3_osx_m2"
+            tag, "/ss3_osx_arm64"
         )
-        try_M2 <- tryCatch(
+        try_arm64 <- tryCatch(
             suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
-            error = function(e) "ss3 executable not available for macOS M2 chip 
+            error = function(e) "ss3 executable not available for macOS arm64 architecture 
             computers for versions prior to v.3.30.21.1"
           )
 
-        if(try_M2 == "ss3 executable not available for macOS M2 chip computers for 
+        if(try_arm64 == "ss3 executable not available for macOS arm64 architecture computers for 
         versions prior to v.3.30.21.1"){
-          print(try_M2)
+          print(try_arm64)
         } else {
           Sys.chmod(paths = file.path(dir, "ss3"), mode = "0700")
           download_location <- file.path(dir, "ss3")

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -90,7 +90,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
         try_arm64 <- tryCatch(
             suppressWarnings(utils::download.file(url, destfile = file.path(dir, "ss3"), mode = "wb")),
             error = function(e) "ss3 executable not available for macOS arm64 architecture 
-            computers for versions prior to v.3.30.21.1"
+            computers for versions prior to v.3.30.22.1"
           )
 
         if(try_arm64 == "ss3 executable not available for macOS arm64 architecture computers for 

--- a/tests/testthat/test-runs.R
+++ b/tests/testthat/test-runs.R
@@ -143,7 +143,7 @@ test_that("jitter runs on simple_small model", {
     expect_equal(starter$jitter_fraction, 0)
   } else {
     run_results_jit_init <- run(dir = dir.jit)
-    expect_true(run_results_jit_init == "ran model")
+    expect_true(all(unlist(run_results_jit_init == "ran model")))
 
     likesaved <- jitter(
       dir = dir.jit, Njitter = 2, jitter_fraction = 0.1,
@@ -242,7 +242,7 @@ test_that("Run an SS3 model and read the hessian", {
   )
   expect_true(copy_results)
   run_results <- run(dir = file.path(tmp_path, "test_mod_run"))
-  expect_true(run_results == "ran model")
+  expect_true(all(unlist(run_results == "ran model")))
   hes <- getADMBHessian(
     hesfile = file.path(tmp_path, "test_mod_run", "admodel.hes")
   )


### PR DESCRIPTION
Exe added to v.3.30.21.1 release for mac M2 chips (use aarch64 architecture). Updated get_ss3_exe() function to get that additional exe for macs that have that architecture.

See [successful test of the get_ss3_exe() function on macos-14](https://github.com/nmfs-ost/ss3-test-models/actions/runs/8726931784).