### PR TITLE
fix(DESCRIPTION): Removes duplicated purrr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,6 @@ Imports:
     lifecycle,
     magrittr,
     purrr,
-    purrr,
     stringr,
     tidyr
 Suggests: 


### PR DESCRIPTION
There were two lines in the DESCRIPTION file with purrr as an imported package. This PR removes one of them.