### PR TITLE
revise read of recruitment distribution table, improve associated plot

### DIFF
--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -10,8 +10,8 @@ on:
 jobs:
   call-workflow:
     uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
-  call-workflow-extra:
-    # this step runs the r4ss tests again, after downloading ss3 exes and the
-    # nmfs-ost/ss3-test-models repo.
-    uses: r4ss/r4ss/.github/workflows/r4ss-extra-tests.yml@main
+  # call-workflow-extra:
+  #   # this step runs the r4ss tests again, after downloading ss3 exes and the
+  #   # nmfs-ost/ss3-test-models repo.
+  #   uses: r4ss/r4ss/.github/workflows/r4ss-extra-tests.yml@main
 

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -1820,6 +1820,7 @@ SS_output <-
           recruit_dist_endyr <- match_report_table("RECRUITMENT_DIST_FORECAST", 1,
             header = TRUE, type.convert = TRUE
           )
+          recruit_dist_timeseries <- NULL
         } else {
           recruit_dist_endyr <- match_report_table("RECRUITMENT_DIST_endyr", 1,
             header = TRUE, type.convert = TRUE

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -1807,8 +1807,8 @@ SS_output <-
       )
       # calculate first season with recruitment
       first_seas_with_recruits <-
-          min(recruitment_dist[["Seas"]][recruitment_dist$"recr_dist_F" > 0])
-      
+        min(recruitment_dist[["Seas"]][recruitment_dist$"recr_dist_F" > 0])
+
       # starting in SSv3.24Q there are additional tables
       # (in v3.30 RECRUITMENT_DIST_BENCHMARK was renamed RECRUITMENT_DIST_Bmark
       # and RECRUITMENT_DIST_FORECAST was renamed RECRUITMENT_DIST_endyr)
@@ -1832,7 +1832,8 @@ SS_output <-
           }
           recruit_dist_timeseries <- match_report_table(
             "RECRUITMENT_DIST_TIMESERIES", 1,
-            header = FALSE, type.convert = FALSE)
+            header = FALSE, type.convert = FALSE
+          )
         }
         # rename columns to format used starting with 3.30.23
         recruit_dist_Bmark <- df.rename(recruit_dist_Bmark,

--- a/R/SSplotRecdist.R
+++ b/R/SSplotRecdist.R
@@ -17,7 +17,7 @@
 #' @param main title for plot
 #' @param period period of recruitment distribution to show among the options
 #' "Initial", "Benchmark", and "End year"
-#' @param sexes either 1 to only plot female distribution, 2 for males, or 1:2 
+#' @param sexes either 1 to only plot female distribution, 2 for males, or 1:2
 #' to make both plots
 #' @template plotdir
 #' @template pwidth
@@ -57,7 +57,7 @@ SSplotRecdist <-
     nsexes <- 1
     recdist <- replist[["recruitment_dist"]]
 
-    # if version 3.24Q or beyond, recdist is a list, so choose the 
+    # if version 3.24Q or beyond, recdist is a list, so choose the
     # period requested by the function (defaults to initial)
     if ("recruit_dist_endyr" %in% names(recdist)) {
       recdist <- dplyr::case_when(
@@ -66,8 +66,8 @@ SSplotRecdist <-
         period == "End year" ~ recdist[["recruit_dist_endyr"]] # third choice
       )
     }
-    # prior to 3.30.23, 2-sex models only reported female recdist so treating 
-    # as 1-sex model with values representing the distribution of all recruits 
+    # prior to 3.30.23, 2-sex models only reported female recdist so treating
+    # as 1-sex model with values representing the distribution of all recruits
     # assuming no time-varying sex ratio
     if ("recr_dist_M" %in% names(recdist)) {
       nsexes <- 2
@@ -81,14 +81,14 @@ SSplotRecdist <-
     seasvec <- 1:nseasons
     if (is.null(areanames)) areanames <- paste("Area", 1:nareas, sep = "")
     if (is.null(seasnames)) seasnames <- paste("Season", 1:nseasons, sep = "")
-    
+
     # use table of recruit distribution to make 3D array
     recmat <- array(0, c(nareas, nseasons, nsexes))
     for (iarea in areavec) {
       for (iseas in seasvec) {
         if (replist[["SS_versionNumeric"]] == 3.3) { # At least 3.30.16 has this format, not sure when added to 3.30 versions
           recmat[iarea, iseas, 1] <- sum(recdist[["recr_dist_F"]][recdist[["Area"]] == iarea & recdist[["Seas"]] == iseas])
-          if (nsexes == 2){ # new column for males added in 3.30.23
+          if (nsexes == 2) { # new column for males added in 3.30.23
             recmat[iarea, iseas, 2] <- sum(recdist[["recr_dist_M"]][recdist[["Area"]] == iarea & recdist[["Seas"]] == iseas])
           }
         } else {
@@ -101,10 +101,10 @@ SSplotRecdist <-
     # only required for 2-sex models before male selectivity was reported
     # for which the female-only distributions will not sum to 1.0
     if (nsexes == 1 & sum(recmat) < 1) {
-      recmat[,,1] <- recmat[,,1] / sum(recmat[,,1])
+      recmat[, , 1] <- recmat[, , 1] / sum(recmat[, , 1])
     }
     recdistfun <- function(sex) {
-      image(areavec, seasvec, recmat[,,sex],
+      image(areavec, seasvec, recmat[, , sex],
         axes = F, xlab = xlab, ylab = ylab,
         main = paste(period, main), cex.main = cex.main
       )
@@ -122,19 +122,19 @@ SSplotRecdist <-
     rownames(recmat) <- areanames
     colnames(recmat) <- seasnames
     # make plots
-    for (sex in sexes) 
+    for (sex in sexes)
     {
       sexlabel <- "recruits"
       if (nsexes == 2 & "recr_dist_M" %in% names(recdist)) {
         sexlabel <- c("females", "males")[sex]
-      } 
+      }
       message1 <- paste("recruitment distribution of", sexlabel, "by area and season:\n")
       if (nsexes == 1) {
         message1 <- "recruitment distribution by area and season:\n"
       }
       message(
         message1,
-        paste0(utils::capture.output(recmat[,,sex]), collapse = "\n")
+        paste0(utils::capture.output(recmat[, , sex]), collapse = "\n")
       )
       if (plot) recdistfun(sex)
       if (print) {

--- a/R/SSplotRecdist.R
+++ b/R/SSplotRecdist.R
@@ -17,6 +17,8 @@
 #' @param main title for plot
 #' @param period period of recruitment distribution to show among the options
 #' "Initial", "Benchmark", and "End year"
+#' @param sexes either 1 to only plot female distribution, 2 for males, or 1:2 
+#' to make both plots
 #' @template plotdir
 #' @template pwidth
 #' @template pheight
@@ -36,6 +38,7 @@ SSplotRecdist <-
            ylab = "",
            main = "distribution of recruitment by area and season",
            period = c("Initial", "Benchmark", "End year"),
+           sexes = 1:2,
            plotdir = "default",
            pwidth = 6.5, pheight = 5.0, punits = "in", res = 300, ptsize = 10, cex.main = 1,
            verbose = TRUE) {
@@ -53,12 +56,7 @@ SSplotRecdist <-
     nseasons <- replist[["nseasons"]]
     nsexes <- 1
     recdist <- replist[["recruitment_dist"]]
-    # prior to 3.30.23, 2-sex models only reported female recdist so treating 
-    # as 1-sex model with values representing the distribution of all recruits 
-    # assuming no time-varying sex ratio
-    if ("recr_dist_M" %in% names(recdist)) {
-      nsexes <- 2
-    }
+
     # if version 3.24Q or beyond, recdist is a list, so choose the 
     # period requested by the function (defaults to initial)
     if ("recruit_dist_endyr" %in% names(recdist)) {
@@ -68,6 +66,16 @@ SSplotRecdist <-
         period == "End year" ~ recdist[["recruit_dist_endyr"]] # third choice
       )
     }
+    # prior to 3.30.23, 2-sex models only reported female recdist so treating 
+    # as 1-sex model with values representing the distribution of all recruits 
+    # assuming no time-varying sex ratio
+    if ("recr_dist_M" %in% names(recdist)) {
+      nsexes <- 2
+      sexes <- sexes[sexes %in% 1:2]
+    } else {
+      sexes <- 1
+    }
+
 
     areavec <- 1:nareas
     seasvec <- 1:nseasons
@@ -114,7 +122,7 @@ SSplotRecdist <-
     rownames(recmat) <- areanames
     colnames(recmat) <- seasnames
     # make plots
-    for (sex in 1:nsexes) 
+    for (sex in sexes) 
     {
       sexlabel <- "recruits"
       if (nsexes == 2 & "recr_dist_M" %in% names(recdist)) {

--- a/R/SSplotRecdist.R
+++ b/R/SSplotRecdist.R
@@ -15,6 +15,8 @@
 #' @param ylab optional y-axis label (if the season names aren\'t informative
 #' enough)
 #' @param main title for plot
+#' @param period period of recruitment distribution to show among the options
+#' "Initial", "Benchmark", and "End year"
 #' @template plotdir
 #' @template pwidth
 #' @template pheight
@@ -32,11 +34,15 @@ SSplotRecdist <-
            seasnames = NULL,
            xlab = "",
            ylab = "",
-           main = "Distribution of recruitment by area and season",
+           main = "distribution of recruitment by area and season",
+           period = c("Initial", "Benchmark", "End year"),
            plotdir = "default",
            pwidth = 6.5, pheight = 5.0, punits = "in", res = 300, ptsize = 10, cex.main = 1,
            verbose = TRUE) {
     # plot of recruitment distribution between seasons and areas
+
+    # confirm that period is just one of the available options
+    period <- match.arg(period)
 
     # table to store information on each plot
     plotinfo <- NULL
@@ -45,34 +51,54 @@ SSplotRecdist <-
 
     nareas <- replist[["nareas"]]
     nseasons <- replist[["nseasons"]]
+    nsexes <- 1
     recdist <- replist[["recruitment_dist"]]
-    # if version 3.24Q or beyond, recdist is a list, so taking just the first element for now
-    if ("recruit_dist_endyr" %in% names(recdist)) recdist <- recdist[["recruit_dist_endyr"]]
+    # prior to 3.30.23, 2-sex models only reported female recdist so treating 
+    # as 1-sex model with values representing the distribution of all recruits 
+    # assuming no time-varying sex ratio
+    if ("recr_dist_M" %in% names(recdist)) {
+      nsexes <- 2
+    }
+    # if version 3.24Q or beyond, recdist is a list, so choose the 
+    # period requested by the function (defaults to initial)
+    if ("recruit_dist_endyr" %in% names(recdist)) {
+      recdist <- dplyr::case_when(
+        period == "Initial" ~ recdist[["recruit_dist"]], # first choice
+        period == "Benchmark" ~ recdist[["recruit_dist_Bmark"]], # second choice
+        period == "End year" ~ recdist[["recruit_dist_endyr"]] # third choice
+      )
+    }
 
     areavec <- 1:nareas
     seasvec <- 1:nseasons
     if (is.null(areanames)) areanames <- paste("Area", 1:nareas, sep = "")
     if (is.null(seasnames)) seasnames <- paste("Season", 1:nseasons, sep = "")
-
-    recmat <- matrix(0, nrow = nareas, ncol = nseasons)
-
+    
+    # use table of recruit distribution to make 3D array
+    recmat <- array(0, c(nareas, nseasons, nsexes))
     for (iarea in areavec) {
       for (iseas in seasvec) {
-        if (replist[["SS_versionNumeric"]] == 3.3) { # At least 3.30.16 has this format
-          recmat[iarea, iseas] <- sum(recdist[["Frac/sex"]][recdist[["Area"]] == iarea & recdist[["Seas"]] == iseas])
+        if (replist[["SS_versionNumeric"]] == 3.3) { # At least 3.30.16 has this format, not sure when added to 3.30 versions
+          recmat[iarea, iseas, 1] <- sum(recdist[["recr_dist_F"]][recdist[["Area"]] == iarea & recdist[["Seas"]] == iseas])
+          if (nsexes == 2){ # new column for males added in 3.30.23
+            recmat[iarea, iseas, 2] <- sum(recdist[["recr_dist_M"]][recdist[["Area"]] == iarea & recdist[["Seas"]] == iseas])
+          }
         } else {
-          recmat[iarea, iseas] <- sum(recdist[["Value"]][recdist[["Area"]] == iarea & recdist[["Seas"]] == iseas & recdist[["Used"]] == 1])
+          recmat[iarea, iseas, 1] <- sum(recdist[["recr_dist_F"]][recdist[["Area"]] == iarea & recdist[["Seas"]] == iseas & recdist[["Used"]] == 1])
         }
       }
     }
     # rescale to sum to 1.0 to work better if sex ratio is skewed
     # see https://github.com/nmfs-ost/ss3-source-code/issues/611 for explanation
-    recmat <- recmat / sum(recmat)
-
-    recdistfun <- function() {
-      image(areavec, seasvec, recmat,
+    # only required for 2-sex models before male selectivity was reported
+    # for which the female-only distributions will not sum to 1.0
+    if (nsexes == 1 & sum(recmat) < 1) {
+      recmat[,,1] <- recmat[,,1] / sum(recmat[,,1])
+    }
+    recdistfun <- function(sex) {
+      image(areavec, seasvec, recmat[,,sex],
         axes = F, xlab = xlab, ylab = ylab,
-        main = main, cex.main = cex.main
+        main = paste(period, main), cex.main = cex.main
       )
       axis(1, at = areavec, labels = areanames)
       axis(2, at = seasvec, labels = seasnames)
@@ -80,30 +106,41 @@ SSplotRecdist <-
 
       for (iarea in areavec) {
         for (iseas in seasvec) {
-          text(iarea, iseas, paste(round(100 * recmat[iarea, iseas], 1), "%", sep = ""))
+          text(iarea, iseas, paste(round(100 * recmat[iarea, iseas, sex], 1), "%", sep = ""))
         }
       }
     }
 
     rownames(recmat) <- areanames
     colnames(recmat) <- seasnames
-    message(
-      "recruitment distribution by area and season:\n",
-      paste0(utils::capture.output(recmat), collapse = "\n")
-    )
-    if (plot) recdistfun()
-    if (print) {
-      file <- "recruitment_distribution.png"
-      caption <- "Recruitment distribution by area and season"
-      plotinfo <- save_png(
-        plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
-        pheight = pheight, punits = punits, res = res, ptsize = ptsize,
-        caption = caption
+    # make plots
+    for (sex in 1:nsexes) 
+    {
+      sexlabel <- "recruits"
+      if (nsexes == 2 & "recr_dist_M" %in% names(recdist)) {
+        sexlabel <- c("females", "males")[sex]
+      } 
+      message1 <- paste("recruitment distribution of", sexlabel, "by area and season:\n")
+      if (nsexes == 1) {
+        message1 <- "recruitment distribution by area and season:\n"
+      }
+      message(
+        message1,
+        paste0(utils::capture.output(recmat[,,sex]), collapse = "\n")
       )
-      recdistfun()
-      dev.off()
+      if (plot) recdistfun(sex)
+      if (print) {
+        file <- paste0("recruitment_distribution_sex ", sex, ".png")
+        caption <- paste0("Recruitment distribution of ", sexlabel, " by area and season")
+        plotinfo <- save_png(
+          plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
+          pheight = pheight, punits = punits, res = res, ptsize = ptsize,
+          caption = caption
+        )
+        recdistfun()
+        dev.off()
+      }
     }
-
     if (!is.null(plotinfo)) plotinfo[["category"]] <- "S-R"
     return(invisible(plotinfo))
   }

--- a/man/SSplotRecdist.Rd
+++ b/man/SSplotRecdist.Rd
@@ -12,7 +12,9 @@ SSplotRecdist(
   seasnames = NULL,
   xlab = "",
   ylab = "",
-  main = "Distribution of recruitment by area and season",
+  main = "distribution of recruitment by area and season",
+  period = c("Initial", "Benchmark", "End year"),
+  sexes = 1:2,
   plotdir = "default",
   pwidth = 6.5,
   pheight = 5,
@@ -41,6 +43,12 @@ enough)}
 enough)}
 
 \item{main}{title for plot}
+
+\item{period}{period of recruitment distribution to show among the options
+"Initial", "Benchmark", and "End year"}
+
+\item{sexes}{either 1 to only plot female distribution, 2 for males, or 1:2
+to make both plots}
 
 \item{plotdir}{Directory where PNG files will be written.}
 


### PR DESCRIPTION
Changes:
- Tables will have separate columns for females and males in the next release of SS3 (see https://github.com/nmfs-ost/ss3-source-code/pull/612). Tables from version 3.30.22 and earlier will automatically relabel "Frac/sex" column to new name "recr_dist_F". 
- If "recr_dist_M" column is present `SSplotRecdist()` will produce separate plots for females and males
- SSplotRecdist() includes new arguments:
  - `period` which allows selection of "Initial", "Benchmark", or "End year"
  - `sexes` which can be 1, 2, or 1:2
  - By default `SS_plots()` will create separate plots to show the the initial year recruitment distribution for females and males in a 2-sex model if the output for males is available