### PR TITLE
Better error message from `run`

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -117,19 +117,15 @@ run <- function(dir = getwd(),
           if (grepl("'CreateProcess' failed to run", err)) { 
             stop(
               "There is a problem with the SS3 executable, perhaps due to mismatch ",
-              "with the operating system."
+              "with the operating system. Please make sure that you have the correct",
+              "executable and it is named appropriately for your operating system"
             )
           } else {
             err
           }
         }
       )
-      if (length(console_output) > 0 && console_output[1] == 127) {
-        stop(
-          "There is a problem with the executable, perhaps due to mismatch ",
-          "with the operating system."
-        )
-      }
+
       # write console output to file if not shown in console
       if (!show_in_console) {
         writeLines(

--- a/R/run.R
+++ b/R/run.R
@@ -115,6 +115,12 @@ run <- function(dir = getwd(),
           TRUE
         )
       )
+      if (console_output[[1]] == 127) {
+        stop(
+          "There is a problem with the executable, perhaps due to mismatch ",
+          "with the operating system."
+        )
+      }
       # write console output to file if not shown in console
       if (!show_in_console) {
         writeLines(

--- a/R/run.R
+++ b/R/run.R
@@ -103,17 +103,26 @@ run <- function(dir = getwd(),
         )
       }
       # call system2() to actually run the model
-      console_output <- system2(
-        command = command,
-        args = extras,
-        stdout = ifelse(show_in_console,
-          "",
-          TRUE
+      console_output <- tryCatch(
+        system2(
+          command = command,
+          args = extras,
+          stdout = ifelse(show_in_console,
+            "",
+            TRUE
+          ),
+          stderr = ""
         ),
-        stderr = ifelse(show_in_console,
-          "",
-          TRUE
-        )
+        error = function(err){
+          if (grepl("'CreateProcess' failed to run", err)) { 
+            stop(
+              "There is a problem with the SS3 executable, perhaps due to mismatch ",
+              "with the operating system."
+            )
+          } else {
+            err
+          }
+        }
       )
       if (console_output[[1]] == 127) {
         stop(

--- a/R/run.R
+++ b/R/run.R
@@ -124,7 +124,7 @@ run <- function(dir = getwd(),
           }
         }
       )
-      if (console_output[[1]] == 127) {
+      if (length(console_output) > 0 && console_output[1] == 127) {
         stop(
           "There is a problem with the executable, perhaps due to mismatch ",
           "with the operating system."

--- a/R/run.R
+++ b/R/run.R
@@ -113,8 +113,8 @@ run <- function(dir = getwd(),
           ),
           stderr = ""
         ),
-        error = function(err){
-          if (grepl("'CreateProcess' failed to run", err)) { 
+        error = function(err) {
+          if (grepl("'CreateProcess' failed to run", err)) {
             stop(
               "There is a problem with the SS3 executable, perhaps due to mismatch ",
               "with the operating system. Please make sure that you have the correct",


### PR DESCRIPTION
See issue #853

Create an error if trying to use the wrong executable.