### PR TITLE
fix: add directory for file copying

### DIFF
--- a/R/profile.R
+++ b/R/profile.R
@@ -619,11 +619,11 @@ profile <- function(dir,
           overwrite = overwrite
         )
         file.copy(file.path(profile_dir, "admodel.hes"),
-          file.path(paste0("admodel", i, ".hes")),
+          file.path(dir, paste0("admodel", i, ".hes")),
           overwrite = overwrite
         )
         file.copy(file.path(profile_dir, parfile),
-          file.path(paste0(parfile, "_", i, ".sso")),
+          file.path(dir, paste0(parfile, "_", i, ".sso")),
           overwrite = overwrite
         )
       }


### PR DESCRIPTION
The par and admodel files were not being copied and numbered within the dir since this was missing from the file.path for the copy location.