### PR TITLE
Fix issue with recent incusion of summary biomass in SSsummarize()

### DIFF
--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -2387,8 +2387,10 @@ SSplotComparisons <-
       if (any(uncertainty)) {
         if (all(is.na(summaryoutput[["SmryBioSD"]][["Label"]]))) {
           if (verbose) {
-            message("skipping subplot 19 summary biomass with uncertainty ",
-              "because no models include summary biomass as a derived quantity")
+            message(
+              "skipping subplot 19 summary biomass with uncertainty ",
+              "because no models include summary biomass as a derived quantity"
+            )
           }
         } else {
           if (verbose) {

--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -814,7 +814,7 @@ SSplotComparisons <-
       # get axis limits
       if (is.null(xlim)) {
         if (show_equilibrium) {
-          xlim <- range(Bio[["Yr"]], na.rm = TRUE) + c(-0.2, 0.2)
+          xlim <- range(Bio[["Yr"]], na.rm = TRUE) + c(-0.5, 0.5)
         } else {
           xlim <- range(Bio[["Yr"]][-c(1, 2)], na.rm = TRUE) + c(-0.2, 0.2)
         }
@@ -2385,16 +2385,23 @@ SSplotComparisons <-
     # subplot 19: summary biomass with uncertainty intervals
     if (19 %in% subplots) {
       if (any(uncertainty)) {
-        if (verbose) {
-          message("subplot 19: summary biomass with uncertainty intervals")
-        }
-        if (plot) {
-          ymax_vec[19] <- plotBio(option = 2, show_uncertainty = TRUE)
-        }
-        if (print) {
-          save_png_comparisons("compare19_smrybio_uncertainty.png")
-          ymax_vec[19] <- plotBio(option = 2, show_uncertainty = TRUE)
-          dev.off()
+        if (all(is.na(summaryoutput[["SmryBioSD"]][["Label"]]))) {
+          if (verbose) {
+            message("skipping subplot 19 summary biomass with uncertainty ",
+              "because no models include summary biomass as a derived quantity")
+          }
+        } else {
+          if (verbose) {
+            message("subplot 19: summary biomass with uncertainty intervals")
+          }
+          if (plot) {
+            ymax_vec[19] <- plotBio(option = 2, show_uncertainty = TRUE)
+          }
+          if (print) {
+            save_png_comparisons("compare19_smrybio_uncertainty.png")
+            ymax_vec[19] <- plotBio(option = 2, show_uncertainty = TRUE)
+            dev.off()
+          }
         }
       }
     }

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -2,7 +2,7 @@
 #'
 #' Summarize various quantities from the model output collected by
 #' [SSgetoutput()] and return them in a list of tables and vectors.
-#' If the models have incompatible dimensions, some quantities can't be 
+#' If the models have incompatible dimensions, some quantities can't be
 #' compared via this function, such as selectivity.
 #'
 #' @param biglist A list of lists, one for each model. The individual lists can
@@ -580,7 +580,7 @@ SSsummarize <- function(biglist,
   # identify summary biomass values in derived quantities
   SmryBio <- quants[SmryBiorows, ]
   SmryBioSD <- quantsSD[SmryBiorows, ]
-  
+
   # create dataframe full of NAs based on SpawnBio to fill in any missing years
   # SpawnBio always spans full range of years included in any model
   SmryBio_extras <- SpawnBio[-(1:2), ] # exclude VIRG and INIT years as these should be added from one of the models
@@ -607,12 +607,12 @@ SSsummarize <- function(biglist,
     # renumber years of timeseries so that models with different starting years
     # have VIRG and INIT values associated with the same numerical year
     ts <- biglist[[imodel]][["timeseries"]]
-    ts[ts$Era == "VIRG", "Yr"] <- minyr - 2
-    ts[ts$Era == "INIT", "Yr"] <- minyr - 1    
+    ts[ts[["Era"]] == "VIRG", "Yr"] <- minyr - 2
+    ts[ts[["Era"]] == "INIT", "Yr"] <- minyr - 1
     # get all years within modified timeseries for this model
     # excluding virgin summary biomass
     yrs <- ts |> dplyr::pull(Yr)
-    # years within range above that have NA in table 
+    # years within range above that have NA in table
     # (may be all years in model if not included in derived quantities)
     NA_yrs <- intersect(yrs, SmryBio[["Yr"]][is.na(SmryBio[, imodel])])
     if (length(NA_yrs) > 0) {

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -2,7 +2,8 @@
 #'
 #' Summarize various quantities from the model output collected by
 #' [SSgetoutput()] and return them in a list of tables and vectors.
-#'
+#' If the models have incompatible dimensions, some quantities can't be 
+#' compared via this function, such as selectivity.
 #'
 #' @param biglist A list of lists, one for each model. The individual lists can
 #' be created by [SS_output()] or the list of lists can be
@@ -566,24 +567,25 @@ SSsummarize <- function(biglist,
   }
 
   # Summary biomass (range of ages defined in starter file and
-  # presence in derived quantities depends on "read specs for more stddev
+  # present in derived quantities depends on "read specs for more stddev
   # reporting" at the bottom of the control file)
 
   # rows numbers of derived quantities that start with "SmryBio_"
   SmryBiorows <- grep("SmryBio_", quants[["Label"]])
-  # exclude "unfished" value--though may be useful in the future
+  # exclude "unfished" value which is reported separately from the timeseries--
+  # though may be useful in the future
   SmryBiorows <- setdiff(SmryBiorows, grep("SmryBio_unfished", quants[["Label"]]))
   SmryBiorows <- setdiff(SmryBiorows, grep("SmryBio_Unfished", quants[["Label"]]))
 
-  # identify summary biomass parameters
+  # identify summary biomass values in derived quantities
   SmryBio <- quants[SmryBiorows, ]
   SmryBioSD <- quantsSD[SmryBiorows, ]
   
-  # add rows based on what's in SpawnBio (which spans full range of years for all models)
-  # create empty dataframe based on SpawnBio
-  SmryBio_extras <- SpawnBio
-  SmryBio_extras[, 1:n] <- NA
-  SmryBio_extras[["Label"]] <- NA
+  # create dataframe full of NAs based on SpawnBio to fill in any missing years
+  # SpawnBio always spans full range of years included in any model
+  SmryBio_extras <- SpawnBio[-(1:2), ] # exclude VIRG and INIT years as these should be added from one of the models
+  SmryBio_extras[, 1:n] <- NA # remove SpawnBio values
+  SmryBio_extras[["Label"]] <- NA # remove SpawnBio labels
   # only those years that aren't yet in the main dataframe
   SmryBio_extras <- SmryBio_extras |> dplyr::filter(!Yr %in% SmryBio[["Yr"]])
   SmryBioSD_extras <- SmryBio_extras
@@ -591,7 +593,7 @@ SSsummarize <- function(biglist,
   SmryBio <- rbind(SmryBio, SmryBio_extras)
   SmryBioSD <- rbind(SmryBioSD, SmryBio_extras)
   # add year values for Virgin and Initial years (if present)
-  minyr <- min(SmryBio[["Yr"]], na.rm = TRUE)
+  minyr <- min(SpawnBio[["Yr"]], na.rm = TRUE) + 2 # startyr of model is 2 larger than minyr in table
   SmryBio[["Yr"]][grep("SmryBio_Virg", SmryBio[["Label"]])] <- minyr - 2
   SmryBio[["Yr"]][grep("SmryBio_InitEq", SmryBio[["Label"]])] <- minyr - 1
   SmryBioSD[["Yr"]] <- SmryBio[["Yr"]]
@@ -602,18 +604,20 @@ SSsummarize <- function(biglist,
   # add any missing values using timeseries
   # TODO: need to get VIRG and INIT values from timeseries
   for (imodel in 1:n) {
-    # all years within timeseries for this model
+    # renumber years of timeseries so that models with different starting years
+    # have VIRG and INIT values associated with the same numerical year
+    ts <- biglist[[imodel]][["timeseries"]]
+    ts[ts$Era == "VIRG", "Yr"] <- minyr - 2
+    ts[ts$Era == "INIT", "Yr"] <- minyr - 1    
+    # get all years within modified timeseries for this model
     # excluding virgin summary biomass
-    yrs <- biglist[[imodel]][["timeseries"]] |> 
-      dplyr::filter(Era != "VIRG") |>
-      dplyr::pull(Yr)
+    yrs <- ts |> dplyr::pull(Yr)
     # years within range above that have NA in table 
     # (may be all years in model if not included in derived quantities)
     NA_yrs <- intersect(yrs, SmryBio[["Yr"]][is.na(SmryBio[, imodel])])
     if (length(NA_yrs) > 0) {
       # filter years to only include those with NA values
-      SmryBio[SmryBio[["Yr"]] %in% NA_yrs, imodel] <-
-        biglist[[imodel]][["timeseries"]] |>
+      SmryBio[SmryBio[["Yr"]] %in% NA_yrs, imodel] <- ts |>
         dplyr::filter(Yr %in% NA_yrs) |>
         dplyr::pull(Bio_smry)
     }

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -186,7 +186,7 @@ SSsummarize <- function(biglist,
         } else {
           warning(
             "problem summarizing size selectivity due to mismatched columns ",
-            "(perhaps different bins)\n"
+            "(perhaps different bins)"
           )
         }
       }
@@ -218,7 +218,7 @@ SSsummarize <- function(biglist,
         } else {
           warning(
             "problem summarizing age selectivity due to mismatched columns ",
-            "(perhaps different bins)\n"
+            "(perhaps different bins)"
           )
         }
       }
@@ -578,32 +578,44 @@ SSsummarize <- function(biglist,
   # identify summary biomass parameters
   SmryBio <- quants[SmryBiorows, ]
   SmryBioSD <- quantsSD[SmryBiorows, ]
-
-  if (nrow(SmryBio) > 0) {
-    # if summary biomass found in derived quanties of any model
-    # add year values for Virgin and Initial years
-    minyr <- min(SmryBio[["Yr"]], na.rm = TRUE)
-    SmryBio[["Yr"]][grep("SmryBio_Virg", SmryBio[["Label"]])] <- minyr - 2
-    SmryBio[["Yr"]][grep("SmryBio_InitEq", SmryBio[["Label"]])] <- minyr - 1
-    SmryBioSD[["Yr"]] <- SmryBio[["Yr"]]
-  } else {
-    # if not in derived quantities, create empty dataframe based on SpawnBio
-    SmryBio <- SpawnBio
-    SmryBio[, 1:n] <- NA
-    SmryBio[["Label"]] <- NA
-    SmryBioSD <- SmryBio
-  }
+  
+  # add rows based on what's in SpawnBio (which spans full range of years for all models)
+  # create empty dataframe based on SpawnBio
+  SmryBio_extras <- SpawnBio
+  SmryBio_extras[, 1:n] <- NA
+  SmryBio_extras[["Label"]] <- NA
+  # only those years that aren't yet in the main dataframe
+  SmryBio_extras <- SmryBio_extras |> dplyr::filter(!Yr %in% SmryBio[["Yr"]])
+  SmryBioSD_extras <- SmryBio_extras
+  # add to main dataframe
+  SmryBio <- rbind(SmryBio, SmryBio_extras)
+  SmryBioSD <- rbind(SmryBioSD, SmryBio_extras)
+  # add year values for Virgin and Initial years (if present)
+  minyr <- min(SmryBio[["Yr"]], na.rm = TRUE)
+  SmryBio[["Yr"]][grep("SmryBio_Virg", SmryBio[["Label"]])] <- minyr - 2
+  SmryBio[["Yr"]][grep("SmryBio_InitEq", SmryBio[["Label"]])] <- minyr - 1
+  SmryBioSD[["Yr"]] <- SmryBio[["Yr"]]
+  # sort by year
   SmryBio <- SmryBio[order(SmryBio[["Yr"]]), ]
   SmryBioSD <- SmryBioSD[order(SmryBioSD[["Yr"]]), ]
+
   # add any missing values using timeseries
+  # TODO: need to get VIRG and INIT values from timeseries
   for (imodel in 1:n) {
-    yrs <- stats[["timeseries"]][["Yr"]]
-    # if there are NA values within the range of years of timeseries
-    if (any(is.na(SmryBio[SmryBio[["Yr"]] %in% yrs, imodel]))) {
-      SmryBio[SmryBio[["Yr"]] %in% yrs, imodel] <-
+    # all years within timeseries for this model
+    # excluding virgin summary biomass
+    yrs <- biglist[[imodel]][["timeseries"]] |> 
+      dplyr::filter(Era != "VIRG") |>
+      dplyr::pull(Yr)
+    # years within range above that have NA in table 
+    # (may be all years in model if not included in derived quantities)
+    NA_yrs <- intersect(yrs, SmryBio[["Yr"]][is.na(SmryBio[, imodel])])
+    if (length(NA_yrs) > 0) {
+      # filter years to only include those with NA values
+      SmryBio[SmryBio[["Yr"]] %in% NA_yrs, imodel] <-
         biglist[[imodel]][["timeseries"]] |>
-        dplyr::filter(Yr %in% yrs) |>
-        dplyr::select(Bio_smry)
+        dplyr::filter(Yr %in% NA_yrs) |>
+        dplyr::pull(Bio_smry)
     }
   }
 

--- a/man/SSsummarize.Rd
+++ b/man/SSsummarize.Rd
@@ -57,6 +57,8 @@ to the screen.}
 \description{
 Summarize various quantities from the model output collected by
 \code{\link[=SSgetoutput]{SSgetoutput()}} and return them in a list of tables and vectors.
+If the models have incompatible dimensions, some quantities can't be
+compared via this function, such as selectivity.
 }
 \seealso{
 \code{\link[=SSgetoutput]{SSgetoutput()}}

--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -102,12 +102,12 @@ test_that("SSsummarize and SSplotComparisons both work", {
     plotdir = temp_path, verbose = FALSE,
     indexUncertainty = TRUE
   )
-  # confirm that function finished 
+  # confirm that function finished
   # (present of plot 19 depends on having SmryBio in derived quants)
   if (all(is.na(simple_summary[["SmryBioSD"]][["Label"]]))) {
-    expect_equal(length(comparison_plots), 18)  
+    expect_equal(length(comparison_plots), 18)
   } else {
-    expect_equal(length(comparison_plots), 19)  
+    expect_equal(length(comparison_plots), 19)
   }
 
   # make table of comparisons

--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -102,8 +102,13 @@ test_that("SSsummarize and SSplotComparisons both work", {
     plotdir = temp_path, verbose = FALSE,
     indexUncertainty = TRUE
   )
-  # confirm that function finished
-  expect_equal(length(comparison_plots), 19)
+  # confirm that function finished 
+  # (present of plot 19 depends on having SmryBio in derived quants)
+  if (all(is.na(simple_summary[["SmryBioSD"]][["Label"]]))) {
+    expect_equal(length(comparison_plots), 18)  
+  } else {
+    expect_equal(length(comparison_plots), 19)  
+  }
 
   # make table of comparisons
   simple_table <- SStableComparisons(simple_summary, verbose = FALSE)

--- a/tests/testthat/test-older_ss3.R
+++ b/tests/testthat/test-older_ss3.R
@@ -72,9 +72,9 @@ test_that("SSsummarize and SSplotComparisons work to compare 3.24 to 3.30", {
   # confirm that function finished
   # (present of plot 19 depends on having SmryBio in derived quants)
   if (all(is.na(simple_summary[["SmryBioSD"]][["Label"]]))) {
-    expect_equal(length(comparison_plots), 18)  
+    expect_equal(length(comparison_plots), 18)
   } else {
-    expect_equal(length(comparison_plots), 19)  
+    expect_equal(length(comparison_plots), 19)
   }
 
   # make table of comparisons

--- a/tests/testthat/test-older_ss3.R
+++ b/tests/testthat/test-older_ss3.R
@@ -70,7 +70,12 @@ test_that("SSsummarize and SSplotComparisons work to compare 3.24 to 3.30", {
   )
 
   # confirm that function finished
-  expect_equal(length(comparison_plots), 19)
+  # (present of plot 19 depends on having SmryBio in derived quants)
+  if (all(is.na(simple_summary[["SmryBioSD"]][["Label"]]))) {
+    expect_equal(length(comparison_plots), 18)  
+  } else {
+    expect_equal(length(comparison_plots), 19)  
+  }
 
   # make table of comparisons
   simple_table <- SStableComparisons(simple_summary, verbose = FALSE)


### PR DESCRIPTION
Summary biomass is different from other summarized quantities because it's inclusion in the derived quantities is optional (depends on control files settings under "read specs for more stddev reporting") so the values are either drawn from derived quantities or the time series table, and uncertainty is only available if they're in derived quantities.

Fixes #973
Will merge myself if/when tests pass.

