### PR TITLE
fix bug in SSsummarize for seasonal models

### DIFF
--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -611,7 +611,9 @@ SSsummarize <- function(biglist,
     ts[ts[["Era"]] == "INIT", "Yr"] <- minyr - 1
     # get all years within modified timeseries for this model
     # excluding virgin summary biomass
-    yrs <- ts |> dplyr::pull(Yr) |> unique()
+    yrs <- ts |>
+      dplyr::pull(Yr) |>
+      unique()
 
     # years within range above that have NA in table
     # (may be all years in model if not included in derived quantities)

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -611,14 +611,15 @@ SSsummarize <- function(biglist,
     ts[ts[["Era"]] == "INIT", "Yr"] <- minyr - 1
     # get all years within modified timeseries for this model
     # excluding virgin summary biomass
-    yrs <- ts |> dplyr::pull(Yr)
+    yrs <- ts |> dplyr::pull(Yr) |> unique()
+
     # years within range above that have NA in table
     # (may be all years in model if not included in derived quantities)
     NA_yrs <- intersect(yrs, SmryBio[["Yr"]][is.na(SmryBio[, imodel])])
     if (length(NA_yrs) > 0) {
       # filter years to only include those with NA values
       SmryBio[SmryBio[["Yr"]] %in% NA_yrs, imodel] <- ts |>
-        dplyr::filter(Yr %in% NA_yrs) |>
+        dplyr::filter(Yr %in% NA_yrs & Seas == 1) |>
         dplyr::pull(Bio_smry)
     }
   }


### PR DESCRIPTION
Thanks to Max Cardinale @akatan999 for reporting an issue with the new feature of showing summary biomass when applied to a seasonal model. The code is complex because summary biomass is optionally included in the derived quantities which is an annual value, but also appears in the time series table for each season.

@Rick-Methot-NOAA clarified that summary biomass in derived quantities is for season 1 in a seasonal model so the code in `r4ss::SSsummarize()` now filters for season 1. This facilitates comparisons between models that have summary biomass in derived quantities and those which do not. 

Before this fix, for instance, a model with 37 years and 2 seasons was using the first 37 year/season combinations to fill in the values which was really 18.5 years.

I will merge into main after checks pass later today or tomorrow but the fix can be tested by installing via `remotes::install_github("r4ss/r4ss@fix-SSsummarize-SmryBio-bug")`.