### PR TITLE
Fix missing biology plots for empirical weight-at-age models

### DIFF
--- a/R/SS_plots.R
+++ b/R/SS_plots.R
@@ -483,7 +483,8 @@ SS_plots <-
         areacols = areacols,
         forecast = forecastplot, minyr = minyr, maxyr = maxyr,
         plot = !png, print = png,
-        pwidth = pwidth, pheight = pheight, punits = punits,
+        pwidth = pwidth, pheight = pheight, pheight_tall = pheight_tall,
+        punits = punits,
         ptsize = ptsize, res = res, mainTitle = mainTitle,
         cex.main = cex.main, plotdir = plotdir
       )

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -385,14 +385,11 @@ SSplotBiology <-
           }
         }
       } else { ## if empirical weight-at-age IS used
-        wtmat <- wtatage[wtatage[["Fleet"]] == -1 &
-          wtatage[["Sex"]] == sex &
-          wtatage[["Seas"]] == seas, -(2:6)]
+        wtmat <- wtatage[wtatage[["fleet"]] == -1 &
+          wtatage[["sex"]] == sex &
+          wtatage[["seas"]] == seas, -(2:6)]
         wtmat <- clean_wtatage(wtmat)
         if (!is.null(wtmat)) {
-          ## persp(x=abs(wtmat[["Yr"]]), y=0:accuage,
-          ##       z=as.matrix(wtmat[,-1]),
-          ##       theta=70,phi=30,xlab="Year",ylab="Age",zlab="Weight", main="")
           makeimage(wtmat, main = "")
         }
       }
@@ -426,13 +423,13 @@ SSplotBiology <-
         }
       } else {
         # if empirical weight-at-age IS used
-        fecmat <- wtatage[wtatage[["Fleet"]] == -2 & wtatage[["Sex"]] == 1, ]
+        fecmat <- wtatage[wtatage[["fleet"]] == -2 & wtatage[["sex"]] == 1, ]
         if (nrow(fecmat) > 1) {
           # figure out which seasons have fecundity values (maybe always only one?)
-          fecseasons <- sort(unique(fecmat[["Seas"]]))
+          fecseasons <- sort(unique(fecmat[["seas"]]))
           seas_label <- NULL
           for (iseas in fecseasons) {
-            fecmat_seas <- fecmat[fecmat[["Seas"]] == iseas, -(2:6)]
+            fecmat_seas <- fecmat[fecmat[["seas"]] == iseas, -(2:6)]
             # label the season only if a multi-season model
             # also testing for length of fecseasons, but that's probably redundant
             if (nseasons > 1 | length(fecseasons) > 1) {
@@ -452,7 +449,7 @@ SSplotBiology <-
     }
 
     makeimage <- function(mat, main = "") {
-      yrvec <- abs(mat[["Yr"]])
+      yrvec <- abs(mat[["year"]])
       ##### this stuff was used to add a row of mean values
       ## if(is.null(meanvec)){
       ##   meanvec <- mat[,1]

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -58,6 +58,7 @@
 #' @template labels
 #' @template pwidth
 #' @template pheight
+#' @template pheight_tall
 #' @template punits
 #' @template res
 #' @template ptsize
@@ -104,7 +105,7 @@ SSplotBiology <-
              "Hermaphroditism transition rate", # 13
              "Fraction females by age in ending year"
            ), # 14
-           pwidth = 6.5, pheight = 5.0,
+           pwidth = 6.5, pheight = 5.0, pheight_tall = 6.5,
            punits = "in", res = 300, ptsize = 10, cex.main = 1,
            mainTitle = TRUE, verbose = TRUE) {
     #### current (Aug 18, 2017) order of plots:
@@ -364,8 +365,8 @@ SSplotBiology <-
       ## This needs to be a function of sex since it can be called
       ## either once for a single sex model or twice to produce plots for
       ## each one.
-      x <- biology[["Len_mean"]]
       if (!wtatage_switch) { # if empirical weight-at-age is not used
+        x <- biology[["Len_mean"]]
         if (!add) {
           ymax <- max(biology[["Wt_F"]])
           if (nsexes > 1) ymax <- max(ymax, biology[["Wt_M"]])
@@ -1295,7 +1296,8 @@ SSplotBiology <-
         }
         plotinfo <- save_png(
           plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
-          pheight = pheight, punits = punits, res = res, ptsize = ptsize,
+          pheight = ifelse(wtatage_switch, pheight_tall, pheight), # weight-at-age matrix works better when taller
+          punits = punits, res = res, ptsize = ptsize,
           caption = caption
         )
         weight_plot(sex = 1)
@@ -1306,7 +1308,7 @@ SSplotBiology <-
           caption <- "Weight-at-age for males"
           plotinfo <- save_png(
             plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
-            pheight = pheight, punits = punits, res = res, ptsize = ptsize,
+            pheight = pheight_tall, punits = punits, res = res, ptsize = ptsize,
             caption = caption
           )
           weight_plot(sex = 2)
@@ -1321,7 +1323,8 @@ SSplotBiology <-
         }
         plotinfo <- save_png(
           plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
-          pheight = pheight, punits = punits, res = res, ptsize = ptsize,
+          pheight = ifelse(wtatage_switch, pheight_tall, pheight), # spawning-output-at-age matrix works better when taller
+          punits = punits, res = res, ptsize = ptsize,
           caption = caption
         )
         maturity_plot()

--- a/man/SSplotBiology.Rd
+++ b/man/SSplotBiology.Rd
@@ -30,6 +30,7 @@ SSplotBiology(
     "Fraction females by age in ending year"),
   pwidth = 6.5,
   pheight = 5,
+  pheight_tall = 6.5,
   punits = "in",
   res = 300,
   ptsize = 10,
@@ -127,6 +128,10 @@ the string options.}
 \item{pheight}{Height of plots printed to png files in units of \code{punits}.
 Default is designed to allow two plots per page, with \code{pheight_tall} used
 for plots that work best with a taller format and a single plot per page.}
+
+\item{pheight_tall}{Height of tall plots printed to png files in units of
+\code{punits}, where the tall plots are a subset of the plots which typically
+work best in a taller format.}
 
 \item{punits}{Units for \code{pwidth} and \code{pheight}. Can be "px"
 (pixels), "in" (inches), "cm" (centimeters), or "mm" (millimeters).


### PR DESCRIPTION
Thanks to @akatan999 for finding and reporting yet another bug in r4ss.

The change in headers to be consistent between SS3 and r4ss as discussed in https://github.com/r4ss/r4ss/issues/512 and https://github.com/nmfs-ost/ss3-source-code/pull/608 mostly impacted the r4ss functions related to reading and writing input files, but the biology plots for models that use the empirical weight-at-age depend on reading wtatage.ss_new to get info for the biology plots and I forgot to update the headers used in `SSplotBiology()` to match the new format. This implements that fix.

I also chose to make the plots of the weight-at-age information taller by default. Most png files created by `r4ss::SS_plots()` are `pheight = 6.5` inches wide and `pheight = 4` inches tall which show allow two plots per page in a document if the captions aren't too long, but a subset of them use the default `pheight_tall = 6.5` because they are better suited to a square aspect ratio, such as the phase plot.

Note that the plots of the weight-at-age info are very crude and you could do much better such as the following figure created by the code at https://github.com/pacific-hake/hake-assessment/blob/master/R/plot-heatmap-weight-at-age.R 
![image](https://github.com/user-attachments/assets/e9c5a12a-1277-4422-8004-c7e919185990)

