### PR TITLE
Provide a fix to use tokens for mac github actions runner for get_ss3_exe()

### DIFF
--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -35,7 +35,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
 
   # Get latest release if version not specified
   if (is.null(version)) {
-    if (dir == "/Users/runner/work/r4ss/r4ss") {
+    if (dir == "/Users/runner/work/r4ss/r4ss" || grepl("/var/folders", dir)) {
       latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1)
     } else {
       latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = NA_character_)
@@ -43,7 +43,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     tag <- latest_release[["tag_name"]]
   } else {
     # Otherwise get specified version
-    if (dir == "/Users/runner/work/r4ss/r4ss") {
+    if (dir == "/Users/runner/work/r4ss/r4ss" || grepl("/var/folders", dir)) {
       all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags")
     } else {
       all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = NA_character_)

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -33,21 +33,21 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     stop("Directory doesn't exist: ", dir)
   }
 
-  if (dir == "/Users/runner/work/r4ss/r4ss") {
-    token <- ""
-  } else {
-    token <- NA_character_
-  }
-
   # Get latest release if version not specified
   if (is.null(version)) {
-    latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1)
-    # latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = token)
+    if (dir == "/Users/runner/work/r4ss/r4ss") {
+      latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1)
+    } else {
+      latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = NA_character_)
+    }
     tag <- latest_release[["tag_name"]]
   } else {
     # Otherwise get specified version
-    all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags")
-    # all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = token)
+    if (dir == "/Users/runner/work/r4ss/r4ss") {
+      all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags")
+    } else {
+      all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = NA_character_)
+    }
     df_tags <- as.data.frame(do.call(rbind, all_tags))
     tags <- unlist(df_tags[["name"]])
 

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -41,11 +41,13 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
 
   # Get latest release if version not specified
   if (is.null(version)) {
-    latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = token)
+    latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1)
+    # latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = token)
     tag <- latest_release[["tag_name"]]
   } else {
     # Otherwise get specified version
-    all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = token)
+    all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags")
+    # all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = token)
     df_tags <- as.data.frame(do.call(rbind, all_tags))
     tags <- unlist(df_tags[["name"]])
 

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -33,7 +33,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     stop("Directory doesn't exist: ", dir)
   }
 
-  if (dir == "/Users/runner/work/github-actions-test/github-actions-test") {
+  if (dir == "/Users/runner/work/r4ss/r4ss") {
     token <- ""
   } else {
     token <- NA_character_

--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -24,13 +24,28 @@
 #' https://github.com/nmfs-ost/ss3-source-code/tags
 
 get_ss3_exe <- function(dir = NULL, version = NULL) {
+  if (is.null(dir)) {
+    dir <- getwd()
+    message("No directory provided, the executable will be downloaded to the working directory")
+  }
+
+  if (!dir.exists(dir)) {
+    stop("Directory doesn't exist: ", dir)
+  }
+
+  if (dir == "/Users/runner/work/github-actions-test/github-actions-test") {
+    token <- ""
+  } else {
+    token <- NA_character_
+  }
+
   # Get latest release if version not specified
   if (is.null(version)) {
-    latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = NA_character_)
+    latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = token)
     tag <- latest_release[["tag_name"]]
   } else {
     # Otherwise get specified version
-    all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = NA_character_)
+    all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = token)
     df_tags <- as.data.frame(do.call(rbind, all_tags))
     tags <- unlist(df_tags[["name"]])
 
@@ -41,15 +56,6 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     } else {
       tag <- version
     }
-  }
-
-  if (is.null(dir)) {
-    dir <- getwd()
-    message("No directory provided, the executable will be downloaded to the working directory")
-  }
-
-  if (!dir.exists(dir)) {
-    stop("Directory doesn't exist: ", dir)
   }
 
   if (.Platform[["OS.type"]] == "windows") {


### PR DESCRIPTION
There are so few mac runners that it causes an error with the api call to GitHub in the `gh()` function when running r_cmd_check on GitHub actions. This fix checks if it's using a GitHub actions runner looking for the `/Users/runner/work/r4ss/r4ss` directory, which is the directory for all github actions run for `r4ss`, OR by looking for the github actions runner temp directory folder text string `/var/folders` which is what is used in the introduction vignette. If it finds either the first directory or the second text string in the directory name, then it does not provide a token parameter to the `gh()` call.