### PR TITLE
Small naming changes to coincide with name changes in ss3

### DIFF
--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -789,7 +789,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
         name = "F_setup2", nrow = ctllist[["F_setup"]][3],
         ncol = 6,
         col.names = c(
-          "fleet", "yr", "seas", "Fvalue", "se",
+          "fleet", "year", "seas", "Fvalue", "se",
           "phase"
         )
       )
@@ -801,7 +801,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   if (ctllist[["F_Method"]] == 4) {
     ctllist <- add_df(
       ctllist = ctllist, ncol = 3,
-      col.names = c("Fleet", "start_F", "first_parm_phase"),
+      col.names = c("fleet", "start_F", "first_parm_phase"),
       name = "F_4_Fleet_Parms"
     )
     ctllist <- add_elem(ctllist, "F_iter")
@@ -1452,7 +1452,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   # Create 3.30 variance adjustments and reset DoVar_adjust if true.
   ctllist <- add_df(ctllist,
     name = "Variance_adjustment_list", nrow = NULL, ncol = 3,
-    col.names = c("Data_type", "Fleet", "Value")
+    col.names = c("factor", "fleet", "value")
   )
   if (!is.null(ctllist[["Variance_adjustment_list"]])) ctllist[["DoVar_adjust"]] <- 1
 
@@ -1752,10 +1752,10 @@ translate_3.30_to_3.24_var_adjust <- function(Variance_adjustment_list = NULL,
     if (nrow(Variance_adjustment_list) > 0) {
       for (j in seq_len(nrow(Variance_adjustment_list))) {
         Variance_adjustments[
-          Variance_adjustment_list[j, ][["Data_type"]],
-          Variance_adjustment_list[j, ][["Fleet"]]
+          Variance_adjustment_list[j, ][["factor"]],
+          Variance_adjustment_list[j, ][["fleet"]]
         ] <-
-          Variance_adjustment_list[j, ][["Value"]]
+          Variance_adjustment_list[j, ][["value"]]
       }
     }
   }

--- a/R/SS_readpar_3.30.R
+++ b/R/SS_readpar_3.30.R
@@ -209,7 +209,7 @@ SS_readpar_3.30 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
     # have estimated parameters when using F_method=4 which allows some fleets to
     # have F parameters and some to use the hybrid method.
     if (!is.null(ctllist[["F_4_Fleet_Parms"]])) {
-      temp_Frate_1 <- temp_Frate_1[is.element(temp_Frate_1[["fleet"]], ctllist[["F_4_Fleet_Parms"]][["Fleet"]][ctllist[["F_4_Fleet_Parms"]][["first_parm_phase"]] != 99]), , drop = FALSE]
+      temp_Frate_1 <- temp_Frate_1[is.element(temp_Frate_1[["fleet"]], ctllist[["F_4_Fleet_Parms"]][["fleet"]][ctllist[["F_4_Fleet_Parms"]][["first_parm_phase"]] != 99]), , drop = FALSE]
     }
     temp_Frate_1 <- temp_Frate_1[temp_Frate_1[["year"]] > 0, 1:4, drop = FALSE]
     temp_Frate_2 <- temp_Frate_1[temp_Frate_1[["catch"]] > 0, , drop = FALSE]

--- a/R/tune_comps.R
+++ b/R/tune_comps.R
@@ -587,21 +587,21 @@ get_tuning_table <- function(replist, fleets,
         # table of info from SS3
         tunetable <- replist[["Length_Comp_Fit_Summary"]]
         factor <- 4 # code for Control file
-        has_marginal <- fleet %in% replist[["lendbase"]][["fleet"]]
+        has_marginal <- fleet %in% replist[["lendbase"]][["Fleet"]]
         has_conditional <- FALSE
       }
       if (type == "age") {
         # table of info from SS3
         tunetable <- replist[["Age_Comp_Fit_Summary"]]
         factor <- 5 # code for Control file
-        has_marginal <- fleet %in% replist[["agedbase"]][["fleet"]]
-        has_conditional <- fleet %in% replist[["condbase"]][["fleet"]]
+        has_marginal <- fleet %in% replist[["agedbase"]][["Fleet"]]
+        has_conditional <- fleet %in% replist[["condbase"]][["Fleet"]]
       }
       if (type == "size") {
         # table of info from SS3
         tunetable <- replist[["Size_Comp_Fit_Summary"]]
         factor <- 7 # code for Control file
-        has_marginal <- fleet %in% replist[["sizedbase"]][["fleet"]]
+        has_marginal <- fleet %in% replist[["sizedbase"]][["Fleet"]]
         has_conditional <- FALSE
       }
       if (has_marginal & has_conditional) {
@@ -643,10 +643,10 @@ get_tuning_table <- function(replist, fleets,
         # current value
         Curr_Var_Adj <- NA
         if ("Curr_Var_Adj" %in% names(tunetable)) {
-          Curr_Var_Adj <- tunetable[["Curr_Var_Adj"]][tunetable[["fleet"]] == fleet]
+          Curr_Var_Adj <- tunetable[["Curr_Var_Adj"]][tunetable[["Fleet"]] == fleet]
         }
         if ("Var_Adj" %in% names(tunetable)) {
-          Curr_Var_Adj <- tunetable[["Var_Adj"]][tunetable[["fleet"]] == fleet]
+          Curr_Var_Adj <- tunetable[["Var_Adj"]][tunetable[["Fleet"]] == fleet]
         }
         if (is.na(Curr_Var_Adj)) {
           stop("Model output missing required values, perhaps due to an older version of SS3")
@@ -656,21 +656,21 @@ get_tuning_table <- function(replist, fleets,
         # that will later be multiplied by Curr_Var_Adj to get "New_MI"
         MI_mult <- NA
         if ("HarMean(effN)/mean(inputN*Adj)" %in% names(tunetable)) {
-          MI_mult <- tunetable$"HarMean(effN)/mean(inputN*Adj)"[tunetable[["fleet"]] == fleet]
+          MI_mult <- tunetable$"HarMean(effN)/mean(inputN*Adj)"[tunetable[["Fleet"]] == fleet]
         }
         if ("MeaneffN/MeaninputN" %in% names(tunetable)) {
-          MI_mult <- tunetable$"MeaneffN/MeaninputN"[tunetable[["fleet"]] == fleet]
+          MI_mult <- tunetable$"MeaneffN/MeaninputN"[tunetable[["Fleet"]] == fleet]
         }
         if ("factor" %in% names(tunetable)) {
           # starting with version 3.30.12
-          MI_mult <- tunetable[["Recommend_var_adj"]][tunetable[["fleet"]] == fleet] /
-            tunetable[["Curr_Var_Adj"]][tunetable[["fleet"]] == fleet]
+          MI_mult <- tunetable[["Recommend_var_adj"]][tunetable[["Fleet"]] == fleet] /
+            tunetable[["Curr_Var_Adj"]][tunetable[["Fleet"]] == fleet]
         }
-        if (all(c("factor", "HarMean", "mean_Nsamp_adj") %in% names(tunetable))) {
+        if (all(c("HarMean", "mean_Nsamp_adj") %in% names(tunetable))) {
           # starting with version 3.30.16?
           MI_mult <-
-            tunetable[["HarMean"]][tunetable[["fleet"]] == fleet] /
-              tunetable[["mean_Nsamp_adj"]][tunetable[["fleet"]] == fleet]
+            tunetable[["HarMean"]][tunetable[["Fleet"]] == fleet] /
+              tunetable[["mean_Nsamp_adj"]][tunetable[["Fleet"]] == fleet]
         }
         if (is.na(MI_mult)) {
           stop("Model output missing required values, perhaps due to an older version of SS3")


### PR DESCRIPTION
Change variable names to coincide with variable names changes in ss3:
Fleet > fleet
yr > year
Data_type > factor
Value > value

Changes in readctl, readpar, and tunecomps files. 

Partial work towards consistent variable names - issue #141