### PR TITLE
institute pause for jitter

### DIFF
--- a/R/jitter.R
+++ b/R/jitter.R
@@ -60,12 +60,15 @@ SS_RunJitter <-
 #' computing, see [future::plan()]
 #'
 #' Note that random number generation occurs outside of R directly in stock synthesis.
-#' When running jitters in parallel (i.e. `future` strategy is not `sequential`), no
+#' When running jitters in parallel (i.e. `future` strategy is not `sequential`), no formal
 #' steps are taken to ensure independence of random numbers generated across
-#' cores. While the likelihood of the cores using the exact same seed is infinitesimal,
-#' random numbers may not technically be considered statistically independent. If
-#' jitter results are only used  as a general heuristic for model convergence, this
-#' mild lack of independence should not matter much.
+#' cores. However, when running in parallel, there is a pause of i seconds before the 
+#' ith jitter starts. The stock synthesis random number seed is based on the 
+#' system time down to the second, so this is intended to produce random numbers 
+#' from different seeds for each jitter. Random numbers may still not technically 
+#' be considered statistically independent. If jitter results are only used as a
+#' general heuristic for model convergence, this mild lack of independence should
+#' not matter much.
 #'
 #' When running models in parallel, the transfer of large files leads to expensive
 #' overheads and parallel processing may not be faster. Covariance files are

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -275,6 +275,11 @@ iterate_jitter <- function(i,
     message(paste0("Starting run of jitter", i))
   }
 
+  # pause briefly when running in parallel to ensure seeds differ
+  if(!is(future::plan(), "sequential")) {
+    Sys.sleep(i)
+  }
+  
   # run model
   r4ss::run(dir = jitter_dir, exe = exe, verbose = verbose, extras = extras, ...)
   # Only save stuff if it converged

--- a/man/jitter.Rd
+++ b/man/jitter.Rd
@@ -74,12 +74,15 @@ will run sequentially. To run multiple models simultaneously using parallel
 computing, see \code{\link[future:plan]{future::plan()}}
 
 Note that random number generation occurs outside of R directly in stock synthesis.
-When running jitters in parallel (i.e. \code{future} strategy is not \code{sequential}), no
+When running jitters in parallel (i.e. \code{future} strategy is not \code{sequential}), no formal
 steps are taken to ensure independence of random numbers generated across
-cores. While the likelihood of the cores using the exact same seed is infinitesimal,
-random numbers may not technically be considered statistically independent. If
-jitter results are only used  as a general heuristic for model convergence, this
-mild lack of independence should not matter much.
+cores. However, when running in parallel, there is a pause of i seconds before the
+ith jitter starts. The stock synthesis random number seed is based on the
+system time down to the second, so this is intended to produce random numbers
+from different seeds for each jitter. Random numbers may still not technically
+be considered statistically independent. If jitter results are only used as a
+general heuristic for model convergence, this mild lack of independence should
+not matter much.
 
 When running models in parallel, the transfer of large files leads to expensive
 overheads and parallel processing may not be faster. Covariance files are


### PR DESCRIPTION
An [issue from the ss3 repository](https://github.com/nmfs-ost/ss3-source-code/issues/643#issuecomment-2479425005) clarified that the clock SS3 uses to set the jitter seeds is only accurate to the second. The means that, if running jitters in parallel, there is actually a very high likelihood that some seeds get reused, unlike as was originally believed. 

This implements a pause, if jitters are detected to be running in parallel, where the system pauses for `i` seconds for the `i`th jitter.