### PR TITLE
Solve mac api issue in get_ss3_exe() testthat

### DIFF
--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -35,7 +35,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
 
   # Get latest release if version not specified
   if (is.null(version)) {
-    if (dir == "/Users/runner/work/r4ss/r4ss" || grepl("/var/folders", dir)) {
+    if (grepl("/Users/runner/work/r4ss/r4ss", dir) || grepl("/var/folders", dir)) {
       latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1)
     } else {
       latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = NA_character_)

--- a/tests/testthat/test-get_ss3_exe.R
+++ b/tests/testthat/test-get_ss3_exe.R
@@ -1,6 +1,5 @@
 # example_path <- system.file("extdata", package = "r4ss")
 temp_path <- file.path(tempdir(), "test_ss3_exe")
-temp_path
 dir.create(temp_path, showWarnings = FALSE)
 # remove all artifacts created from testing. (developers: simply comment out
 # the line below if you want to keep artifacts for troubleshooting purposes)
@@ -11,7 +10,9 @@ test_that("executables are downloading default latest version", {
   download_filepath <- gsub(".*: ", "", download_loc)
   exe_name <- gsub(paste0(temp_path, "/"), "", download_filepath, fixed = TRUE)
   dir_temp <- file.path(temp_path, exe_name)
-  file.remove(download_filepath)
+  if (file.exists(download_filepath)) {
+    file.remove(download_filepath)
+  }
 
   expect_equal(dir_temp, download_filepath)
 })

--- a/tests/testthat/test-get_ss3_exe.R
+++ b/tests/testthat/test-get_ss3_exe.R
@@ -40,14 +40,14 @@ test_that("executables are able to run simple_small model", {
   file.remove(download_filepath)
 })
 
-test_that("version warning", {
-  expect_warning(try(get_ss3_exe(dir = temp_path, version = "v3.30.188"), silent = TRUE))
-})
+# test_that("version warning", {
+#   expect_warning(try(get_ss3_exe(dir = temp_path, version = "v3.30.188"), silent = TRUE))
+# })
 
-test_that("check working directory", {
-  capture_output(getwd(), print = TRUE)
-  expect_equal(getwd(), "/Users/runner/work/r4ss/r4ss")
-})
+# test_that("check working directory", {
+#   capture_output(getwd(), print = TRUE)
+#   expect_equal(getwd(), "/Users/runner/work/r4ss/r4ss")
+# })
 
 test_that("working directory message", {
   expect_message(download_loc <- get_ss3_exe())

--- a/tests/testthat/test-get_ss3_exe.R
+++ b/tests/testthat/test-get_ss3_exe.R
@@ -44,8 +44,12 @@ test_that("version warning", {
   expect_warning(try(get_ss3_exe(dir = temp_path, version = "v3.30.188"), silent = TRUE))
 })
 
+test_that("check working directory", {
+  capture_output(getwd(), print = TRUE)
+  expect_equal(getwd(), "/Users/runner/work/r4ss/r4ss")
+})
+
 test_that("working directory message", {
-  dir <- getwd()
   expect_message(download_loc <- get_ss3_exe())
   download_filepath <- gsub(".*: ", "", download_loc)
   file.remove(download_filepath)

--- a/tests/testthat/test-get_ss3_exe.R
+++ b/tests/testthat/test-get_ss3_exe.R
@@ -40,15 +40,6 @@ test_that("executables are able to run simple_small model", {
   file.remove(download_filepath)
 })
 
-# test_that("version warning", {
-#   expect_warning(try(get_ss3_exe(dir = temp_path, version = "v3.30.188"), silent = TRUE))
-# })
-
-# test_that("check working directory", {
-#   capture_output(getwd(), print = TRUE)
-#   expect_equal(getwd(), "/Users/runner/work/r4ss/r4ss")
-# })
-
 test_that("working directory message", {
   expect_message(download_loc <- get_ss3_exe())
   download_filepath <- gsub(".*: ", "", download_loc)

--- a/tests/testthat/test-get_ss3_exe.R
+++ b/tests/testthat/test-get_ss3_exe.R
@@ -1,5 +1,6 @@
 # example_path <- system.file("extdata", package = "r4ss")
 temp_path <- file.path(tempdir(), "test_ss3_exe")
+temp_path
 dir.create(temp_path, showWarnings = FALSE)
 # remove all artifacts created from testing. (developers: simply comment out
 # the line below if you want to keep artifacts for troubleshooting purposes)

--- a/tests/testthat/test-get_ss3_exe.R
+++ b/tests/testthat/test-get_ss3_exe.R
@@ -10,9 +10,6 @@ test_that("executables are downloading default latest version", {
   download_filepath <- gsub(".*: ", "", download_loc)
   exe_name <- gsub(paste0(temp_path, "/"), "", download_filepath, fixed = TRUE)
   dir_temp <- file.path(temp_path, exe_name)
-  if (file.exists(download_filepath)) {
-    file.remove(download_filepath)
-  }
 
   expect_equal(dir_temp, download_filepath)
 })
@@ -22,7 +19,9 @@ test_that("executables are downloading with version", {
   download_filepath <- gsub(".*: ", "", download_loc)
   exe_name <- gsub(paste0(temp_path, "/"), "", download_filepath, fixed = TRUE)
   dir_temp <- file.path(temp_path, exe_name)
-  file.remove(download_filepath)
+  if (file.exists(download_filepath)) {
+    file.remove(download_filepath)
+  }
 
   expect_equal(dir_temp, download_filepath)
 })
@@ -46,6 +45,7 @@ test_that("version warning", {
 })
 
 test_that("working directory message", {
+  dir <- getwd()
   expect_message(download_loc <- get_ss3_exe())
   download_filepath <- gsub(".*: ", "", download_loc)
   file.remove(download_filepath)


### PR DESCRIPTION
Testthat was causing an error for the get_ss3_exe() function for the macos-latest runner when run more than once for a particular branch. This PR **should** fix that once and for all after figuring out an additional directory being used later in the test file for that function.

I also updated the test for the function to get rid of a warning that came up.