### PR TITLE
Generalize the gh command to look for any github actions runner

### DIFF
--- a/R/get_ss3_exe.r
+++ b/R/get_ss3_exe.r
@@ -35,7 +35,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
 
   # Get latest release if version not specified
   if (is.null(version)) {
-    if (grepl("/Users/runner/work/r4ss/r4ss", dir) || grepl("/var/folders", dir)) {
+    if (grepl("/Users/runner/work/", dir) || grepl("/var/folders", dir)) {
       latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1)
     } else {
       latest_release <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/releases/latest", page = 1, .token = NA_character_)
@@ -43,7 +43,7 @@ get_ss3_exe <- function(dir = NULL, version = NULL) {
     tag <- latest_release[["tag_name"]]
   } else {
     # Otherwise get specified version
-    if (dir == "/Users/runner/work/r4ss/r4ss" || grepl("/var/folders", dir)) {
+    if (grepl("/Users/runner/work/", dir) || grepl("/var/folders", dir)) {
       all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags")
     } else {
       all_tags <- gh::gh("GET /repos/nmfs-ost/ss3-source-code/tags", .token = NA_character_)


### PR DESCRIPTION
The if statement before gh() looks for the r4ss github actions runner so that it uses a token when on that runner (this had to be done for macs). I also needed this for a new gha in the ss3-source-code repo which uses r4ss and so I made changed it to make it look for github actions runners generally instead of just looking for the r4ss runner.