### PR TITLE
Fix SS_output() to use URLs

### DIFF
--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -91,11 +91,12 @@ SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
   if (mylist[["Forecast"]] > 0 | writeAll) {
     if (mylist[["Forecast"]] <= 0 & is.null(mylist[["eof"]])) {
       # only continue beyond this point if Forecast is not 0 or writeAll==TRUE,
-      # so dont do other processing.
+      # so do not do other processing.
       warning(
-        "Even though writeAll == TRUE, cannot write past list element ",
-        "Forecast because inputs past this are not available. Output ",
-        "still be a usable SS forecast file."
+        "Even though writeAll == TRUE, {r4ss} cannot write past ",
+        "mylist[['Forecast']] because needed list elements past Forecast ",
+        "in mylist are not available. But, the saved file will still be a ",
+        "useable Stock Synthesis forecast file."
       )
     } else {
       wl("Nforecastyrs")


### PR DESCRIPTION
I noticed in the petrale case study in FIMS that there was a note that you could not read the report file from the URL and had to save things to your computer and create an RDS file. So, I thought I would investigate. Functions like `file.info()` and `file.exists()` do not work with a URL. This PR could be made better by using a function to check if the file exists that incorporates URL and file checks rather than rewriting the code over and over.

Note that, this was not fixed for the log file because I do not know what to do when there are multiple files. This branch works for petrale now in the FIMS case study.