### PR TITLE
Plot fixed M at age

### DIFF
--- a/R/SS_readwtatage.R
+++ b/R/SS_readwtatage.R
@@ -49,7 +49,7 @@ SS_readwtatage <- function(file = "wtatage.ss", verbose = TRUE) {
     }
     return(NULL)
   }
-  
+
   # check for NA is first 2 rows of 2nd column as indicator of version
   # prior to 3.30 where old models had additional number of lines input
   skip <- 1

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -1453,7 +1453,7 @@ SSplotBiology <-
       # run function if requested to write figure to PNG file
       if (print & 21 %in% subplots) {
         file <- "bio21_natmort.png"
-        caption <- "Natural mortality"
+        caption <- "Natural mortality at age"
         plotinfo <- save_png(
           plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
           pheight = pheight, punits = punits, res = res, ptsize = ptsize,

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -1406,67 +1406,61 @@ SSplotBiology <-
       growdatM <- growdat[growdat[["Morph"]] == morphs[2], ]
       MatAge_M <- growdatM[["M"]]
     }
-    # not sure what role M2 is playing here
-    M2 <- MGparmAdj[, c(1, grep("NatM", names(MGparmAdj)))]
-    # not sure when you could have ncol(M2) = NULL
-    if (!is.null(ncol(M2))) {
-      M2f <- M2[, c(1, grep("Fem", names(M2)))]
-      if (min(MatAge) != max(MatAge) & 21 %in% subplots) {
-        ymax <- 1.1 * max(MatAge)
-        if (nsexes > 1) {
-          ymax <- 1.1 * max(MatAge, MatAge_M)
+    if (min(MatAge) != max(MatAge) & 21 %in% subplots) {
+      ymax <- 1.1 * max(MatAge)
+      if (nsexes > 1) {
+        ymax <- 1.1 * max(MatAge, MatAge_M)
+      }
+
+      # function to plut natural mortality
+      mfunc <- function(add_uncertainty = TRUE) {
+        if (!add) {
+          plot(growdatF[["Age_Beg"]], MatAge,
+            col = colvec[col_index1], lwd = 2,
+            ylim = c(0, ymax), yaxs = "i", type = "n",
+            ylab = labels[7], xlab = labels[2], las = 1
+          )
+        }
+        lines(growdatF[["Age_Beg"]], MatAge, col = colvec[col_index1], lwd = 2, type = "o")
+
+        # add uncertainty in M-at-age (if available from derived_quants)
+        if (add_uncertainty) {
+          add_uncertainty_fn(std_table = NatM_std, sex = 1, age_offset = 0.0)
         }
 
-        # function to plut natural mortality
-        mfunc <- function(add_uncertainty = TRUE) {
-          if (!add) {
-            plot(growdatF[["Age_Beg"]], MatAge,
-              col = colvec[col_index1], lwd = 2,
-              ylim = c(0, ymax), yaxs = "i", type = "n",
-              ylab = labels[7], xlab = labels[2], las = 1
-            )
-          }
-          lines(growdatF[["Age_Beg"]], MatAge, col = colvec[col_index1], lwd = 2, type = "o")
+        if (nsexes > 1) {
+          growdatM <- growdat[growdat[["Morph"]] == morphs[2], ]
+          lines(growdatM[["Age_Beg"]], growdatM[["M"]],
+            lty = ltyvec[2], col = colvec[2],
+            lwd = 2, type = "o"
+          )
+          legend("bottomleft",
+            bty = "n", c("Females", "Males"), lty = ltyvec, lwd = 2,
+            col = c(colvec[col_index1], colvec[2])
+          )
 
           # add uncertainty in M-at-age (if available from derived_quants)
           if (add_uncertainty) {
-            add_uncertainty_fn(std_table = NatM_std, sex = 1, age_offset = 0.0)
-          }
-
-          if (nsexes > 1) {
-            growdatM <- growdat[growdat[["Morph"]] == morphs[2], ]
-            lines(growdatM[["Age_Beg"]], growdatM[["M"]],
-              lty = ltyvec[2], col = colvec[2],
-              lwd = 2, type = "o"
-            )
-            legend("bottomleft",
-              bty = "n", c("Females", "Males"), lty = ltyvec, lwd = 2,
-              col = c(colvec[col_index1], colvec[2])
-            )
-
-            # add uncertainty in M-at-age (if available from derived_quants)
-            if (add_uncertainty) {
-              add_uncertainty_fn(std_table = NatM_std, sex = 2, age_offset = 0.0)
-            }
+            add_uncertainty_fn(std_table = NatM_std, sex = 2, age_offset = 0.0)
           }
         }
+      }
 
-        # run function if requested to make plot
-        if (plot & 21 %in% subplots) {
-          mfunc()
-        }
-        # run function if requested to write figure to PNG file
-        if (print & 21 %in% subplots) {
-          file <- "bio21_natmort.png"
-          caption <- "Natural mortality"
-          plotinfo <- save_png(
-            plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
-            pheight = pheight, punits = punits, res = res, ptsize = ptsize,
-            caption = caption
-          )
-          mfunc()
-          dev.off()
-        }
+      # run function if requested to make plot
+      if (plot & 21 %in% subplots) {
+        mfunc()
+      }
+      # run function if requested to write figure to PNG file
+      if (print & 21 %in% subplots) {
+        file <- "bio21_natmort.png"
+        caption <- "Natural mortality"
+        plotinfo <- save_png(
+          plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
+          pheight = pheight, punits = punits, res = res, ptsize = ptsize,
+          caption = caption
+        )
+        mfunc()
+        dev.off()
       }
     }
 


### PR DESCRIPTION
This code change removes a filter that tested for whether M-at-age was a fixed input or a parameter. It's been in r4ss for at least 10 years and a comment from years ago indicated that I wasn't sure what role it was playing here.

Thanks to @akatan999 for asking why these plots aren't getting created.  

With this Pull Request, if you input a vector of M at age using natural mortality options 3 (age specific) or 4 (age specific with seasonal interpolation), then you will get the same plot you would see with any of the parametric setups of age-dependent M.

![image](https://github.com/user-attachments/assets/c3c9bdaa-7a31-4489-abfe-fb724bfc184f)
