### PR TITLE
Fix open connection spacing in SS_writestarter

### DIFF
--- a/R/SS_varadjust.R
+++ b/R/SS_varadjust.R
@@ -199,7 +199,7 @@ SS_varadjust <- function(dir = "C:/myfiles/mymodels/myrun/",
   }
 
   # open connection to file
-  if (verbose) message("opening connection to", newctlfile)
+  if (verbose) message("opening connection to ", newctlfile)
   zz <- file(newctlfile, open = "at")
   sink(zz)
   # change maximum number of columns

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -47,7 +47,7 @@ SS_writectl_3.24 <- function(ctllist, outfile, overwrite = FALSE,
   oldmax.print <- options()[["max.print"]]
   options(width = 5000, max.print = 9999999)
 
-  if (verbose) message("opening connection to", outfile)
+  if (verbose) message("opening connection to ", outfile)
   zz <- file(outfile, open = "at")
   #  on.exit({if(sink.number()>0) sink();close(zz)})
   on.exit(close(zz))

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -49,7 +49,7 @@ SS_writeforecast <- function(mylist, dir = NULL, file = "forecast.ss",
   oldwidth <- options()[["width"]]
   options(width = 1000)
 
-  if (verbose) message("opening connection to", outfile)
+  if (verbose) message("opening connection to ", outfile)
   zz <- file(outfile, open = "at")
   sink(zz)
   wl <- function(name) {

--- a/R/SS_writestarter.R
+++ b/R/SS_writestarter.R
@@ -47,14 +47,14 @@ SS_writestarter <- function(mylist, dir = NULL, file = "starter.ss",
       file.remove(outfile)
     }
   } else {
-    if (verbose) message("writing new file:", outfile)
+    if (verbose) message("writing new file: ", outfile)
   }
 
   # record current max characters per line and then expand in case of long lines
   oldwidth <- options()[["width"]]
   options(width = 1000)
 
-  if (verbose) message("opening connection to", outfile)
+  if (verbose) message("opening connection to ", outfile)
   zz <- file(outfile, open = "at")
   sink(zz)
 

--- a/R/SS_writewtatage.R
+++ b/R/SS_writewtatage.R
@@ -52,7 +52,7 @@ SS_writewtatage <- function(mylist, dir = NULL, file = "wtatage.ss",
   oldwidth <- options()[["width"]]
   options(width = 1000)
 
-  if (verbose) message("opening connection to", outfile, "\n")
+  if (verbose) message("opening connection to ", outfile, "\n")
   zz <- file(outfile, open = "at")
   on.exit(close(zz))
   sink(zz, split = verbose)

--- a/R/SSmakeMmatrix.R
+++ b/R/SSmakeMmatrix.R
@@ -55,7 +55,7 @@ SSmakeMmatrix <- function(mat, startyr, outfile = NULL,
 
   # open file connection if requested
   if (!is.null(outfile)) {
-    message("opening connection to", outfile)
+    message("opening connection to ", outfile)
     zz <- file(outfile, open = "at")
     sink(zz)
   }


### PR DESCRIPTION
See issue #995 to fix the spacing in the console output of SS_writestarter().