### PR TITLE
Fix to SSsummarize

### DIFF
--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -621,7 +621,9 @@ SSsummarize <- function(biglist,
     if (length(NA_yrs) > 0) {
       # filter years to only include those with NA values
       SmryBio[SmryBio[["Yr"]] %in% NA_yrs, imodel] <- ts |>
-        dplyr::filter(Yr %in% NA_yrs & Seas == 1) |>
+        dplyr::filter(Yr %in% NA_yrs) |>
+        dplyr::group_by(Yr) |>
+        dplyr::summarize(Bio_smry = sum(Bio_smry)) |>
         dplyr::pull(Bio_smry)
     }
   }


### PR DESCRIPTION
Fixes issue #996 by combining areas and sexes to get the SmryBio output. This now works and provides the sum(SmryBio) that we expect from the time_series table in the report file, though you might want to test it a bit more than I can right now, so I have included this as a draft PR. 