### PR TITLE
fix: add discard parameters for age-based model

### DIFF
--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1175,8 +1175,8 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   # pattern 17 is a special case of number of params, so account for here.
   age_selex_Nparms <- ifelse(age_patterns == "17" &
     ctllist[["age_selex_types"]][, "Special"] > 0,
-    ctllist[["age_selex_types"]][, "Special"] + 1,
-    age_selex_Nparms
+  ctllist[["age_selex_types"]][, "Special"] + 1,
+  age_selex_Nparms
   )
 
   age_selex_label <- vector("list", length = Nfleets)
@@ -1239,7 +1239,7 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
         make_sel_lab("a", "PRet", 1:7, jn, j)
       )
     }
-    
+
     if (ctllist[["age_selex_types"]][j, "Discard"] %in% c(2, 4)) { # add 4 discard mortality parameters
       age_selex_label[[j]] <- c(
         age_selex_label[[j]],
@@ -1345,8 +1345,9 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   if (any(ctllist[["size_selex_parms"]][, c("env_var&link", "dev_link", "Block")] != 0) &
     ctllist[["time_vary_auto_generation"]][5] != 0) {
     tmp_parlab <- get_tv_parlabs(
-      full_parms = ctllist[["size_selex_parms"]], 
-      block_design = ctllist[["Block_Design"]])
+      full_parms = ctllist[["size_selex_parms"]],
+      block_design = ctllist[["Block_Design"]]
+    )
     ctllist <- add_df(ctllist,
       name = "size_selex_parms_tv",
       nrow = length(tmp_parlab),
@@ -1358,8 +1359,9 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   if (any(ctllist[["age_selex_parms"]][, c("env_var&link", "dev_link", "Block")] != 0) &
     ctllist[["time_vary_auto_generation"]][5] != 0) {
     tmp_parlab <- get_tv_parlabs(
-      full_parms = ctllist[["age_selex_parms"]], 
-      block_design = ctllist[["Block_Design"]])
+      full_parms = ctllist[["age_selex_parms"]],
+      block_design = ctllist[["Block_Design"]]
+    )
     ctllist <- add_df(ctllist,
       name = "age_selex_parms_tv",
       nrow = length(tmp_parlab),

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -1175,8 +1175,8 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   # pattern 17 is a special case of number of params, so account for here.
   age_selex_Nparms <- ifelse(age_patterns == "17" &
     ctllist[["age_selex_types"]][, "Special"] > 0,
-  ctllist[["age_selex_types"]][, "Special"] + 1,
-  age_selex_Nparms
+    ctllist[["age_selex_types"]][, "Special"] + 1,
+    age_selex_Nparms
   )
 
   age_selex_label <- vector("list", length = Nfleets)
@@ -1224,6 +1224,27 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
         )
       }
       # Note that age_selex_Nparams[j] not used beyond this point.
+    }
+    # do extra retention parameters (4 extra parameters)
+    if (ctllist[["age_selex_types"]][j, "Discard"] %in% 1:2) { # add 4 retention parameters
+      age_selex_label[[j]] <- c(
+        age_selex_label[[j]],
+        make_sel_lab("a", "PRet", 1:4, jn, j)
+      )
+    }
+    # note that for Discard = 3, no extra parameters are needed.
+    if (ctllist[["age_selex_types"]][j, "Discard"] == 4) { # add 7 dome shaped retention parameters
+      age_selex_label[[j]] <- c(
+        age_selex_label[[j]],
+        make_sel_lab("a", "PRet", 1:7, jn, j)
+      )
+    }
+    
+    if (ctllist[["age_selex_types"]][j, "Discard"] %in% c(2, 4)) { # add 4 discard mortality parameters
+      age_selex_label[[j]] <- c(
+        age_selex_label[[j]],
+        make_sel_lab("a", "PDis", 1:4, jn, j)
+      )
     }
     # do extra offset parameters
     if (ctllist[["age_selex_types"]][j, "Male"] == 1) {
@@ -1323,7 +1344,9 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   }
   if (any(ctllist[["size_selex_parms"]][, c("env_var&link", "dev_link", "Block")] != 0) &
     ctllist[["time_vary_auto_generation"]][5] != 0) {
-    tmp_parlab <- get_tv_parlabs(full_parms = ctllist[["size_selex_parms"]], ctllist[["Block_Design"]])
+    tmp_parlab <- get_tv_parlabs(
+      full_parms = ctllist[["size_selex_parms"]], 
+      block_design = ctllist[["Block_Design"]])
     ctllist <- add_df(ctllist,
       name = "size_selex_parms_tv",
       nrow = length(tmp_parlab),
@@ -1334,7 +1357,9 @@ SS_readctl_3.30 <- function(file, verbose = FALSE,
   }
   if (any(ctllist[["age_selex_parms"]][, c("env_var&link", "dev_link", "Block")] != 0) &
     ctllist[["time_vary_auto_generation"]][5] != 0) {
-    tmp_parlab <- get_tv_parlabs(full_parms = ctllist[["age_selex_parms"]], ctllist[["Block_Design"]])
+    tmp_parlab <- get_tv_parlabs(
+      full_parms = ctllist[["age_selex_parms"]], 
+      block_design = ctllist[["Block_Design"]])
     ctllist <- add_df(ctllist,
       name = "age_selex_parms_tv",
       nrow = length(tmp_parlab),
@@ -1716,7 +1741,7 @@ get_tv_parlabs <- function(full_parms,
         )
       )
     }
-  }
+  } # end loop_pars
   invisible(parlab)
 }
 


### PR DESCRIPTION
I found that the `SS_readctl_3.30()` was not reading the control file correctly for models with age-based discarding and retention.  I have not adding a similar fix to the `SS_readctl_3.24()` function since I don't think that is necessary, plus I don't think age-based retention was correctly implemented in 3.24 models. 