### PR TITLE
ghactions4r updates

### DIFF
--- a/.github/workflows/call-calc-cov-summaries.yml
+++ b/.github/workflows/call-calc-cov-summaries.yml
@@ -1,18 +1,17 @@
 # call a workflow that runs covr::codecov() to calculate code coverage
-name: call-calc_coverage
+name: call-calc_cov-summaries
 # on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 # The default is to run the workflow on every push or pull request to every branch.
 on:
   workflow_dispatch:
-  # temporarily turn off
-  # push:
-  #   paths-ignore:
-  #     - '.github/**'
-  #     - 'README.md'
-  # pull_request:
-  #   paths-ignore:
-  #     - '.github/**'
-  #     - 'README.md'
+  push:
+    branches:
+      - main
+  pull_request:
+    types: 
+      - opened
+    branches:
+      - main
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/calc-coverage.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/calc-cov-summaries.yml@main

--- a/.github/workflows/call-create-cov-badge.yml
+++ b/.github/workflows/call-create-cov-badge.yml
@@ -1,0 +1,14 @@
+# Reusable workflow to calculate coverage add it to a badge that is stored on 
+# a branch in the repo called badges.
+# note that this has only been tested to build a badge with the main branch
+# coverage; it may not work to calculate coverage from other branches.
+name: call-create-cov-badge
+# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+# other option would be to run this on a schedule. Other build trigger options may not work well.
+on:
+  push:
+    branches:
+      - main
+jobs:
+  call-workflow:
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/create-cov-badge.yml@main

--- a/.github/workflows/call-doc-and-style-r.yml
+++ b/.github/workflows/call-doc-and-style-r.yml
@@ -15,7 +15,7 @@ on:
 name: call-doc-and-style-r
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/doc-and-style-r.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/doc-and-style-r.yml@main
     with: 
       run-rm_dollar_sign: true
       commit-directly: true

--- a/.github/workflows/call-r-cmd-check.yml
+++ b/.github/workflows/call-r-cmd-check.yml
@@ -10,7 +10,7 @@ on:
   
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/r-cmd-check.yml@main
     with:
       additional_args_ubuntu: |
         sudo apt-get update

--- a/.github/workflows/call-spell-check.yml
+++ b/.github/workflows/call-spell-check.yml
@@ -12,4 +12,4 @@ on:
   workflow_dispatch:
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/spell-check.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/spell-check.yml@main

--- a/.github/workflows/call-update-pkgdown.yml
+++ b/.github/workflows/call-update-pkgdown.yml
@@ -9,7 +9,7 @@ on:
     tags: ['*']
 jobs:
   call-workflow:
-    uses: nmfs-fish-tools/ghactions4r/.github/workflows/update-pkgdown.yml@main
+    uses: nmfs-ost/ghactions4r/.github/workflows/update-pkgdown.yml@main
     with:
       additional_args_ubuntu: |
         sudo apt-get update


### PR DESCRIPTION
ghactions4r has changed some of their workflows (the calc-cov one), added a workflow to create a badge showing coverage, and will be moving the repo to the nmfs-ost org on May 16 (see discussion [here](https://github.com/nmfs-fish-tools/ghactions4r/issues/159#issuecomment-2840460572))

As Kelli notes below, there is a fork on nmfs-ost already so this can be merged.