### PR TITLE
add log-scale plot of discard rates

### DIFF
--- a/R/SSplotDiscard.R
+++ b/R/SSplotDiscard.R
@@ -4,7 +4,7 @@
 #'
 #'
 #' @template replist
-#' @param subplots Vector of which plots to make 
+#' @param subplots Vector of which plots to make
 #' \itemize{
 #'   \item 1 data only
 #'   \item 2 data with fit
@@ -181,28 +181,30 @@ SSplotDiscard <-
           subplots <- setdiff(subplots, c(1, 3)) # don't do subplot 1 if datplot=FALSE
         }
         for (isubplot in subplots) { # loop over subplots (data only or with fit)
-          if (isubplot %in% c(1,3)) {
+          if (isubplot %in% c(1, 3)) {
             addfit <- FALSE
           } else {
             addfit <- TRUE
+          }
+          # file and caption not needed if print = FALSE, but easier to do it here
+          # since title2 is always needed
+          if (!addfit) {
+            file <- paste0("discard_data", FleetName, ".png")
+          } else {
+            file <- paste0("discard_fit", FleetName, ".png")
+          }
+          if (isubplot %in% 3:4) {
+            file <- gsub("discard_", "discard_log_", file)
+            caption2 <- gsub("fraction for", "fraction on a log scale for", caption)
+            title2 <- gsub("fraction for", "fraction on a log scale for", title)
+          } else {
+            caption2 <- caption
+            title2 <- title
           }
           if (plot) {
             dfracfunc(addfit = addfit, log = ifelse(isubplot %in% 3:4, TRUE, FALSE))
           }
           if (print) {
-            if (!addfit) {
-              file <- paste0("discard_data", FleetName, ".png")
-            } else {
-              file <- paste0("discard_fit", FleetName, ".png")
-            }
-            if (isubplot %in% 3:4) {
-              file <- gsub("discard_", "discard_log_", file)
-              caption2 <- gsub("fraction for", "fraction on a log scale for", caption)
-              title2 <- gsub("fraction for", "fraction on a log scale for", title)
-            } else {
-              caption2 <- caption
-              title2 <- title
-            }
             plotinfo <- save_png(
               plotinfo = plotinfo, file = file, plotdir = plotdir, pwidth = pwidth,
               pheight = pheight, punits = punits, res = res, ptsize = ptsize,

--- a/R/plotCI.R
+++ b/R/plotCI.R
@@ -17,10 +17,11 @@
 #' @param ymax Additional input for Upper limit of y range.
 #' @param add Add points and intervals to existing plot? Default=FALSE.
 #' @param col Color for the points and lines.
+#' @param log Logarithmic scale for the y-axis? Should be "" or "y".
 #' @author Bill Venables, Ian Stewart, Ian Taylor, John Wallace
 plotCI <-
   function(x, y = NULL, uiw, liw = uiw, ylo = NULL, yhi = NULL,
-           ..., sfrac = 0.01, ymax = NULL, add = FALSE, col = "black") {
+           ..., sfrac = 0.01, ymax = NULL, add = FALSE, col = "black", log = "") {
     # Written by Venables; modified for access to ylim, contents, and color
     if (is.list(x)) {
       y <- x[["y"]]
@@ -36,8 +37,12 @@ plotCI <-
     ui <- y + uiw
     li <- y - liw
     ylim <- range(c(y, ui, li, ylo, yhi))
+    # avoid -Inf ylim if log scale
+    if (log == "y") {
+      ylim[1] <- max(ylim[1], 0.0001)
+    }
     if (!is.null(ymax)) ylim[2] <- ymax
-    if (!add) plot(x, y, type = "n", ylim = ylim, col = col, ...)
+    if (!add) plot(x, y, type = "n", ylim = ylim, col = col, log = log, ...)
     segments(x, li, x, ui, col = col)
     smidge <- diff(par("usr")[1:2]) * sfrac
     x2 <- c(x, x)

--- a/man/SSplotDiscard.Rd
+++ b/man/SSplotDiscard.Rd
@@ -6,7 +6,7 @@
 \usage{
 SSplotDiscard(
   replist,
-  subplots = 1:2,
+  subplots = 1:4,
   plot = TRUE,
   print = FALSE,
   plotdir = "default",
@@ -30,8 +30,14 @@ SSplotDiscard(
 \arguments{
 \item{replist}{A list object created by \code{\link{SS_output}()}.}
 
-\item{subplots}{Vector of which plots to make (1 = data only, 2 = with fit).
-If \code{plotdat = FALSE} then subplot 1 is not created, regardless of
+\item{subplots}{Vector of which plots to make
+\itemize{
+\item 1 data only
+\item 2 data with fit
+\item 3 data only (log scale)
+\item 4 data with fit (log scale)
+}
+If \code{plotdat = FALSE} then subplots 1 and 3 are not created, regardless of
 choice of \code{subplots}.}
 
 \item{plot}{Plot to active plot device?}

--- a/man/plotCI.Rd
+++ b/man/plotCI.Rd
@@ -15,7 +15,8 @@ plotCI(
   sfrac = 0.01,
   ymax = NULL,
   add = FALSE,
-  col = "black"
+  col = "black",
+  log = ""
 )
 }
 \arguments{
@@ -41,6 +42,8 @@ plotCI(
 \item{add}{Add points and intervals to existing plot? Default=FALSE.}
 
 \item{col}{Color for the points and lines.}
+
+\item{log}{Logarithmic scale for the y-axis? Should be "" or "y".}
 }
 \description{
 Given a set of x and y values and upper and lower bounds, this function


### PR DESCRIPTION
This PR adds plots of the discard rate or amount with and without model expectation to the set created by `SSplotDiscard()` (called by `SS_plots()`). This helps in cases where discard is in tons with a large range, making small values hard to see. It can also help in cases where discard data is a fraction but some values are small (as in example below from 2017 yellowtail rockfish assessment). In cases where the uncertainty intervals were truncated at 0, I've replaced that with 0.0001 to avoid -Inf in the log-scale plot.

![image](https://github.com/user-attachments/assets/e6008739-a4c3-454e-aadc-346a63f975d5)
