### PR TITLE
Fix table in table_exec_summary() for multi-area models

### DIFF
--- a/R/table_exec_summary.R
+++ b/R/table_exec_summary.R
@@ -441,13 +441,25 @@ table_exec_summary <- function(
   catch <- dead <- total.dead <- 0
   for (i in 1:nfleets) {
     name <- paste0("retain(B):_", i)
-    input.catch <- replist[["timeseries"]][replist[["timeseries"]][["Yr"]] %in% years_minus_final, name]
-    catch <- cbind(catch, input.catch)
+    if (name %in% colnames(replist[["timeseries"]])) {
+      input.catch <- replist[["timeseries"]] |> 
+        dplyr::filter(Yr %in% years_minus_final) |> 
+        dplyr::group_by(Yr) |> 
+        dplyr::summarize(input.catch = sum(get(name))) |>
+        dplyr::pull(input.catch)
+      catch <- cbind(catch, input.catch)
+    }
 
     name <- paste0("dead(B):_", i)
-    dead <- replist[["timeseries"]][replist[["timeseries"]][["Yr"]] %in% years_minus_final, name]
-    if (!is.null(dead)) {
-      total.dead <- total.dead + dead
+    if (name %in% colnames(replist[["timeseries"]])) {
+      dead <- replist[["timeseries"]] |> 
+        dplyr::filter(Yr %in% years_minus_final) |> 
+        dplyr::group_by(Yr) |> 
+        dplyr::summarize(dead = sum(get(name))) |>
+        dplyr::pull(dead)
+      if (!is.null(dead)) {
+        total.dead <- total.dead + dead
+      }
     }
   }
   total.catch <- apply(catch, 1, sum)

--- a/R/table_exec_summary.R
+++ b/R/table_exec_summary.R
@@ -438,31 +438,21 @@ table_exec_summary <- function(
   abc <- rep(NA, length(years) - 1)
   acl <- rep(NA, length(years) - 1)
 
-  catch <- dead <- total.dead <- 0
-  for (i in 1:nfleets) {
-    name <- paste0("retain(B):_", i)
-    if (name %in% colnames(replist[["timeseries"]])) {
-      input.catch <- replist[["timeseries"]] |> 
-        dplyr::filter(Yr %in% years_minus_final) |> 
-        dplyr::group_by(Yr) |> 
-        dplyr::summarize(input.catch = sum(get(name))) |>
-        dplyr::pull(input.catch)
-      catch <- cbind(catch, input.catch)
-    }
+  total.catch <- replist[["timeseries"]] |> 
+    dplyr::filter(Yr %in% years_minus_final) |> 
+    dplyr::select(Yr, dplyr::starts_with("retain(B):_")) |> 
+    dplyr::group_by(Yr) |> 
+    dplyr::summarize(dplyr::across(dplyr::everything(), sum)) |> 
+    dplyr::select(-Yr) |> 
+    rowSums()
 
-    name <- paste0("dead(B):_", i)
-    if (name %in% colnames(replist[["timeseries"]])) {
-      dead <- replist[["timeseries"]] |> 
-        dplyr::filter(Yr %in% years_minus_final) |> 
-        dplyr::group_by(Yr) |> 
-        dplyr::summarize(dead = sum(get(name))) |>
-        dplyr::pull(dead)
-      if (!is.null(dead)) {
-        total.dead <- total.dead + dead
-      }
-    }
-  }
-  total.catch <- apply(catch, 1, sum)
+  total.dead <- replist[["timeseries"]] |> 
+    dplyr::filter(Yr %in% years_minus_final) |> 
+    dplyr::select(Yr, dplyr::starts_with("dead(B):_")) |> 
+    dplyr::group_by(Yr) |> 
+    dplyr::summarize(dplyr::across(dplyr::everything(), sum)) |> 
+    dplyr::select(-Yr) |> 
+    rowSums()
 
   if (sum(total.catch) != sum(total.dead)) {
     es.f <- data.frame(years_minus_final, ofl, abc, acl, total.catch, total.dead)

--- a/R/table_exec_summary.R
+++ b/R/table_exec_summary.R
@@ -438,20 +438,20 @@ table_exec_summary <- function(
   abc <- rep(NA, length(years) - 1)
   acl <- rep(NA, length(years) - 1)
 
-  total.catch <- replist[["timeseries"]] |> 
-    dplyr::filter(Yr %in% years_minus_final) |> 
-    dplyr::select(Yr, dplyr::starts_with("retain(B):_")) |> 
-    dplyr::group_by(Yr) |> 
-    dplyr::summarize(dplyr::across(dplyr::everything(), sum)) |> 
-    dplyr::select(-Yr) |> 
+  total.catch <- replist[["timeseries"]] |>
+    dplyr::filter(Yr %in% years_minus_final) |>
+    dplyr::select(Yr, dplyr::starts_with("retain(B):_")) |>
+    dplyr::group_by(Yr) |>
+    dplyr::summarize(dplyr::across(dplyr::everything(), sum)) |>
+    dplyr::select(-Yr) |>
     rowSums()
 
-  total.dead <- replist[["timeseries"]] |> 
-    dplyr::filter(Yr %in% years_minus_final) |> 
-    dplyr::select(Yr, dplyr::starts_with("dead(B):_")) |> 
-    dplyr::group_by(Yr) |> 
-    dplyr::summarize(dplyr::across(dplyr::everything(), sum)) |> 
-    dplyr::select(-Yr) |> 
+  total.dead <- replist[["timeseries"]] |>
+    dplyr::filter(Yr %in% years_minus_final) |>
+    dplyr::select(Yr, dplyr::starts_with("dead(B):_")) |>
+    dplyr::group_by(Yr) |>
+    dplyr::summarize(dplyr::across(dplyr::everything(), sum)) |>
+    dplyr::select(-Yr) |>
     rowSums()
 
   if (sum(total.catch) != sum(total.dead)) {


### PR DESCRIPTION
@e-perl-NOAA noted in https://github.com/pfmc-assessments/Assessment_Class/discussions/77#discussioncomment-13135991 that the `recent_management` table created by `table_exec_summary()` wasn't working right for the yelloweye model which was a result of not aggregating across areas.

@chantelwetzel-noaa, as the primary author of the function, do you want to take a quick look at the change? It's producing the same results as before for yellowtail, and now producing correct results for yelloweye (no extra rows of NA for area 2).