### PR TITLE
"fix SS_changepars() input string matching"

### DIFF
--- a/R/SS_changepars.R
+++ b/R/SS_changepars.R
@@ -17,7 +17,10 @@
 #'   parameters to be modified. This is an alternative to `linenums`.
 #'   `strings` correspond to the commented parameter names included in
 #'   `control.ss_new`, or whatever is written as comment at the end
-#'   of the 14 number parameter lines. Default=NULL.
+#'   of the 14 number parameter lines. If `strings` is an exact match to a parameter 
+#'   name in `control.ss_new`, this parameter will be modified, otherwise
+#'   the function will check for parameters that are a partial match to
+#'    `strings.` Default=NULL.
 #' @param newvals Vector of new parameter values. Default=NULL.
 #'   The vector can contain `NA` values, which will assign the original
 #'   value to the given parameter but change the remainder parameters, where
@@ -143,8 +146,15 @@ SS_changepars <-
       if (!is.null(strings)) {
         # loop over vector of strings to add to goodnames vector
         for (i in seq_along(strings)) {
-          # fixed matching on string
-          goodnames[[i]] <- allnames[grep(strings[i], allnames, fixed = TRUE)]
+          if( #Check is string matches a par exactly, if not check partial match
+            strings[i] %in% allnames
+          ){ #string is an exact match to par file
+            goodnames[[i]] <- allnames[allnames == strings[i]]
+            #string is not exact match - look for partial
+          } else {
+            goodnames[[i]] <- allnames[grep(strings[i], allnames, 
+                                            fixed = TRUE)]
+          }
         }
         # remove duplicates and print some feedback
         if (

--- a/man/SS_changepars.Rd
+++ b/man/SS_changepars.Rd
@@ -39,7 +39,10 @@ the \code{strings} argument are needed. Default=NULL.}
 parameters to be modified. This is an alternative to \code{linenums}.
 \code{strings} correspond to the commented parameter names included in
 \code{control.ss_new}, or whatever is written as comment at the end
-of the 14 number parameter lines. Default=NULL.}
+of the 14 number parameter lines. If \code{strings} is an exact match to a parameter
+name in \code{control.ss_new}, this parameter will be modified, otherwise
+the function will check for parameters that are a partial match to
+\code{strings.} Default=NULL.}
 
 \item{newvals}{Vector of new parameter values. Default=NULL.
 The vector can contain \code{NA} values, which will assign the original


### PR DESCRIPTION
Adjusted `SS_changepars()` function to check whether `strings` input is an exact match to a parameter name in `control.ss_new`. If it is, the matching parameter will be modified by the function. If no exact match is found, the the function will check for parameter names which partially match `strings` and modify these. 