### PR TITLE
Switch to sequential tests for extra testing to calculate code coverage

### DIFF
--- a/.github/workflows/r4ss-extra-tests.yml
+++ b/.github/workflows/r4ss-extra-tests.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Get the latest SS3 executable and move to expected location
         run: |
-          wget -O ss3 https://github.com/nmfs-ost/ss3-source-code/releases/latest/download/ss3_linux
+          wget -O ss3 https://github.com/nmfs-ost/ss3-source-code/releases/download/v3.30.24-prerel/ss3_linux
           sudo chmod a+x ss3
           cp ss3 inst/extdata/simple_small/ss3
           rm ss3

--- a/tests/testthat/test-test-models.R
+++ b/tests/testthat/test-test-models.R
@@ -1,83 +1,82 @@
 context("Read output and make plots for all test-models")
 
-test_that("test-models work with SS_output() and SS_plots()", {
-  skip_if(
-    !file.exists(system.file("extdata", "models", package = "r4ss")),
-    message = "No 'models' folder in 'extdata'"
-  )
-  # skip if no executable in simple_small path
-  # (should have been loaded there by
-  # .github\workflows\r4ss-extra-tests.yml)
+# temporary directory
+mod_path <- file.path(tempdir(check = TRUE), "test-test-models")
+download_models(dir = mod_path)
+mods <- list.dirs(
+  file.path(mod_path, "models"),
+  full.names = FALSE,
+  recursive = FALSE
+)
 
-  # find simple_small
-  dir_exe <- system.file("extdata", "simple_small", package = "r4ss")
-  skip_if(
-    (!file.exists(file.path(dir_exe, "ss3")) &
-      !file.exists(file.path(dir_exe, "ss3.exe"))),
-    message = paste("skipping test: no exe called 'ss3' found in", dir_exe)
-  )
-  # temporary directory
-  mod_path <- file.path(tempdir(check = TRUE), "test-test-models")
-  on.exit(unlink(mod_path, recursive = TRUE), add = TRUE)
-  dir.create(mod_path, showWarnings = FALSE)
-  # copy all test models to temporary directory
-  orig_mod_path <- system.file("extdata", "models", package = "r4ss")
-  file.copy(orig_mod_path, mod_path, recursive = TRUE)
-  all_mods <- list.dirs(
-    file.path(mod_path, "models"),
-    full.names = TRUE,
-    recursive = FALSE
-  )
+# run models
+for (i in seq_along(all_mods)) {
+  test_that(
+    glue::glue(
+      "run SS_output() and SS_plots() on test model: {mods[i]}"
+    ),
+    {
+      skip_if(
+        !file.exists(system.file("extdata", "models", package = "r4ss")),
+        message = "No 'models' folder in 'extdata'"
+      )
+      # skip if no executable in simple_small path
+      # (should have been loaded there by
+      # .github\workflows\r4ss-extra-tests.yml)
 
-  # run models without estimation and then run r4ss functions
-  message(
-    "Will run SS_output() and SS_plots() on models:\n  ",
-    paste(basename(all_mods), collapse = ",\n  ")
-  )
+      # find simple_small
+      dir_exe <- system.file("extdata", "simple_small", package = "r4ss")
+      skip_if(
+        (!file.exists(file.path(dir_exe, "ss3")) &
+          !file.exists(file.path(dir_exe, "ss3.exe"))),
+        message = paste("skipping test: no exe called 'ss3' found in", dir_exe)
+      )
+      # copy all test models to temporary directory
+      orig_mod_path <- system.file("extdata", "models", package = "r4ss")
+      orig_all_mods <- list.dirs(
+        file.path(mod_path, "models"),
+        full.names = TRUE,
+        recursive = FALSE
+      )
+      mod <- basename(orig_all_mods[i])
+      file.copy(orig_all_mods[i], file.path(mod_path, mod))
 
-  # make empty list to store output
-  all_output <- rep(list(NULL), length(all_mods))
+      cli::cli_alert_info(
+        "Now running without estimation: {mod}"
+      )
+      run(
+        all_mods[i],
+        exe = file.path(dir_exe, "ss3"),
+        extras = "-stopph 0 -nohess"
+      )
 
-  # run models
-  for (i in seq_along(all_mods)) {
-    cli::cli_alert_info(
-      "Now running without estimation: {basename(all_mods[i])}"
-    )
-    run(
-      all_mods[i],
-      exe = file.path(dir_exe, "ss3"),
-      extras = "-stopph 0 -nohess"
-    )
+      if (!"Report.sso" %in% dir(all_mods[i])) {
+        cli::cli_alert_warning("No Report.sso file in {all_mods[i]}")
+      } else {
+        #### Checks related to SS_output()
+        message("Running SS_output()")
+        output <- SS_output(
+          all_mods[i],
+          verbose = FALSE,
+          printstats = FALSE
+        )
+      }
+      expect_true(!is.null(output))
+      expect_true("inputs" %in% names(output))
 
-    if (!"Report.sso" %in% dir(all_mods[i])) {
-      cli::cli_alert_warning("No Report.sso file in {all_mods[i]}")
-    } else {
-      #### Checks related to SS_output()
-      message("Running SS_output()")
-      all_output[[i]] <- SS_output(
-        all_mods[[i]],
-        verbose = FALSE,
-        printstats = FALSE
+      cli::cli_alert_info(
+        "Running SS_plots() for model {mod}"
+      )
+      SS_plots(output, verbose = FALSE)
+      expect_true("data_plot2.png" %in% dir(file.path(all_mods[i], "plots")))
+
+      cli::cli_alert_info(
+        "Running table_all() for model {mod}"
+      )
+      table_all(output, verbose = TRUE)
+      expect_true(
+        "table_parcounts.rda" %in% dir(file.path(all_mods[i], "tables"))
       )
     }
-  }
-
-  # confirm that there are no NULL outputs
-  expect_true(all(!sapply(all_output, is.null)))
-
-  expect_true(all(unlist(lapply(all_output, function(x) {
-    tail(names(x), 1) == "inputs"
-  }))))
-
-  for (i in seq_along(all_output)) {
-    cli::cli_alert_info("Running SS_plots() for model {basename(all_mods[i])}")
-    SS_plots(all_output[[i]], verbose = FALSE)
-    expect_true("data_plot2.png" %in% file.path(all_mods[i], "plots"))
-  }
-
-  for (i in seq_along(all_output)) {
-    cli::cli_alert_info("Running table_all() for model {basename(all_mods[i])}")
-    table_all(all_output[[i]], verbose = TRUE)
-    expect_true("table_parcounts.rda" %in% file.path(all_mods[i], "tables"))
-  }
-})
+  ) # end testthat
+} # end loop over models

--- a/tests/testthat/test-test-models.R
+++ b/tests/testthat/test-test-models.R
@@ -1,29 +1,21 @@
 context("Read output and make plots for all test-models")
 
-# temporary directory
-mod_path <- file.path(tempdir(check = TRUE), "test-test-models")
-download_models(dir = mod_path)
+# download models to a temporary directory
+models_path <- file.path(tempdir(check = TRUE), "test-test-models")
+download_models(dir = models_path)
 mods <- list.dirs(
-  file.path(mod_path, "models"),
+  file.path(models_path, "models"),
   full.names = FALSE,
   recursive = FALSE
 )
 
 # run models
-for (i in seq_along(all_mods)) {
+for (i in seq_along(mods)) {
   test_that(
     glue::glue(
       "run SS_output() and SS_plots() on test model: {mods[i]}"
     ),
     {
-      skip_if(
-        !file.exists(system.file("extdata", "models", package = "r4ss")),
-        message = "No 'models' folder in 'extdata'"
-      )
-      # skip if no executable in simple_small path
-      # (should have been loaded there by
-      # .github\workflows\r4ss-extra-tests.yml)
-
       # find simple_small
       dir_exe <- system.file("extdata", "simple_small", package = "r4ss")
       skip_if(
@@ -31,32 +23,25 @@ for (i in seq_along(all_mods)) {
           !file.exists(file.path(dir_exe, "ss3.exe"))),
         message = paste("skipping test: no exe called 'ss3' found in", dir_exe)
       )
-      # copy all test models to temporary directory
-      orig_mod_path <- system.file("extdata", "models", package = "r4ss")
-      orig_all_mods <- list.dirs(
-        file.path(mod_path, "models"),
-        full.names = TRUE,
-        recursive = FALSE
-      )
-      mod <- basename(orig_all_mods[i])
-      file.copy(orig_all_mods[i], file.path(mod_path, mod))
-
+      mod <- basename(mods[i])
+      mod_path <- file.path(models_path, "models", mod)
+      
       cli::cli_alert_info(
         "Now running without estimation: {mod}"
       )
       run(
-        all_mods[i],
+        mod_path,
         exe = file.path(dir_exe, "ss3"),
         extras = "-stopph 0 -nohess"
       )
 
-      if (!"Report.sso" %in% dir(all_mods[i])) {
-        cli::cli_alert_warning("No Report.sso file in {all_mods[i]}")
+      if (!"Report.sso" %in% dir(mod_path)) {
+        cli::cli_alert_warning("No Report.sso file in {mod_path}")
       } else {
         #### Checks related to SS_output()
         message("Running SS_output()")
         output <- SS_output(
-          all_mods[i],
+          mod_path,
           verbose = FALSE,
           printstats = FALSE
         )
@@ -67,15 +52,16 @@ for (i in seq_along(all_mods)) {
       cli::cli_alert_info(
         "Running SS_plots() for model {mod}"
       )
-      SS_plots(output, verbose = FALSE)
-      expect_true("data_plot2.png" %in% dir(file.path(all_mods[i], "plots")))
+      # make low-resolution plots to save time
+      SS_plots(output, verbose = FALSE, res = 50)
+      expect_true("data_plot2.png" %in% dir(file.path(mod_path, "plots")))
 
       cli::cli_alert_info(
         "Running table_all() for model {mod}"
       )
       table_all(output, verbose = TRUE)
       expect_true(
-        "table_parcounts.rda" %in% dir(file.path(all_mods[i], "tables"))
+        "table_parcounts.rda" %in% dir(file.path(mod_path, "tables"))
       )
     }
   ) # end testthat

--- a/tests/testthat/test-test-models.R
+++ b/tests/testthat/test-test-models.R
@@ -25,7 +25,7 @@ for (i in seq_along(mods)) {
       )
       mod <- basename(mods[i])
       mod_path <- file.path(models_path, "models", mod)
-      
+
       cli::cli_alert_info(
         "Now running without estimation: {mod}"
       )
@@ -46,23 +46,25 @@ for (i in seq_along(mods)) {
           printstats = FALSE
         )
       }
-      expect_true(!is.null(output))
-      expect_true("inputs" %in% names(output))
+      expect_true(exists("output"))
+      if (exists("output")) {
+        expect_true("inputs" %in% names(output))
 
-      cli::cli_alert_info(
-        "Running SS_plots() for model {mod}"
-      )
-      # make low-resolution plots to save time
-      SS_plots(output, verbose = FALSE, res = 50)
-      expect_true("data_plot2.png" %in% dir(file.path(mod_path, "plots")))
+        cli::cli_alert_info(
+          "Running SS_plots() for model {mod}"
+        )
+        # make low-resolution plots to save time
+        SS_plots(output, verbose = FALSE, res = 50)
+        expect_true("data_plot2.png" %in% dir(file.path(mod_path, "plots")))
 
-      cli::cli_alert_info(
-        "Running table_all() for model {mod}"
-      )
-      table_all(output, verbose = TRUE)
-      expect_true(
-        "table_parcounts.rda" %in% dir(file.path(mod_path, "tables"))
-      )
+        cli::cli_alert_info(
+          "Running table_all() for model {mod}"
+        )
+        table_all(output, verbose = TRUE)
+        expect_true(
+          "table_parcounts.rda" %in% dir(file.path(mod_path, "tables"))
+        )
+      }
     }
   ) # end testthat
 } # end loop over models


### PR DESCRIPTION
This test rewrites the test-test-models.R script called by the r4ss-extra-tests.yml workflow with two goals:
1. speed up the code coverage calculations conducted by codecov. It thus fixed #950. I have no idea why, but running the code on models in sequence instead of parallel (with {furrr}) improved the speed from > 6 hours to about 4.5 hours.
2. provide more informative messages about which model is failing when there's a failure. Because the tests are run in sequence, I could put the call to `test_that()` inside the loop and have the test description include the model name. The resulting message below (copied from https://github.com/r4ss/r4ss/actions/runs/16503548011/job/46668255127#step:12:535) made it easy to diagnose that the problem was caused by running the test-models with the "latest" SS3 release (version 3.30.23.2), on a test model that had been modified to include an extra input line required to test a feature included in the 3.30.24 prerelease.

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error ('test-test-models.R:49:7'): run SS_output() and SS_plots() on test model: growth_timevary ──
Error in `eval(code, test_env)`: object 'output' not found
```

Tagging @k-doering-NOAA and @Bai-Li-NOAA in case you find this interesting since you both are involved in test configurations.