### PR TITLE
Improve support for two-sex format in comp2long()

### DIFF
--- a/R/comp2long.R
+++ b/R/comp2long.R
@@ -140,7 +140,7 @@ age2long <- function(x, expand = FALSE, zero = TRUE) {
   names(x)[-seq(cols)] <- gsub("[a-z]", "", names(x)[-seq(cols)])
 
   # Shuffle data frame if two sexes
-  if (all(x[["sex"]] == 3)) {
+  if (all(x[["sex"]] %in% c(0, 3))) {
     ncomp <- (ncol(x) - length(cols)) / 2
     f <- x[seq(length(cols) + 1, length = ncomp)]
     f <- cbind(x[cols], f)
@@ -240,7 +240,7 @@ size2long <- function(x, measure = NULL, zero = TRUE) {
   names(x)[-seq(cols)] <- gsub("[a-z]", "", names(x)[-seq(cols)])
 
   # Shuffle data frame if two sexes
-  if (all(x[["sex"]] == 3)) {
+  if (all(x[["sex"]] %in% c(0, 3))) {
     ncomp <- (ncol(x) - length(cols)) / 2
     f <- x[seq(length(cols) + 1, length = ncomp)]
     f <- cbind(x[cols], f)


### PR DESCRIPTION
Hi! Just a basic improvement in the comp2long() function.

Noticed a shortcoming while working with two-sex formatted composition data in the ongoing work on the [SW Pacific swordfish assessment](https://github.com/PacificCommunity/ofp-sam-swo-2025-diagnostic). The comp2long() conversion works well with this fix.