### PR TITLE
Improve support for two-sex format in comp2long()

### DIFF
--- a/R/comp2long.R
+++ b/R/comp2long.R
@@ -139,8 +139,8 @@ age2long <- function(x, expand = FALSE, zero = TRUE) {
   # Simplify column names
   names(x)[-seq(cols)] <- gsub("[a-z]", "", names(x)[-seq(cols)])
 
-  # Shuffle data frame if two sexes
-  if (all(x[["sex"]] %in% c(0, 3))) {
+  # Restructure data frame if the two sexes are side by side
+  if (any(duplicated(grepv("^.[0-9]", names(x))))) {
     ncomp <- (ncol(x) - length(cols)) / 2
     f <- x[seq(length(cols) + 1, length = ncomp)]
     f <- cbind(x[cols], f)
@@ -239,8 +239,8 @@ size2long <- function(x, measure = NULL, zero = TRUE) {
   # Simplify column names
   names(x)[-seq(cols)] <- gsub("[a-z]", "", names(x)[-seq(cols)])
 
-  # Shuffle data frame if two sexes
-  if (all(x[["sex"]] %in% c(0, 3))) {
+  # Restructure data frame if the two sexes are side by side
+  if (any(duplicated(grepv("^.[0-9]", names(x))))) {
     ncomp <- (ncol(x) - length(cols)) / 2
     f <- x[seq(length(cols) + 1, length = ncomp)]
     f <- cbind(x[cols], f)


### PR DESCRIPTION
My pull request from 2 days ago was an improvement, but it turns out it was still not a reliable approach for detecting whether the input composition data frame was in two-sex side-by-side format or not.

With this pull request, instead of using sex = 0, 1, 2, or 3 to determine whether the comp data are in two-sex format, I simply read the column names and check if bin names are repeated (for each sex) or not.