### PR TITLE
Improve support for two-sex format in comp2long()

### DIFF
--- a/R/comp2long.R
+++ b/R/comp2long.R
@@ -140,7 +140,7 @@ age2long <- function(x, expand = FALSE, zero = TRUE) {
   names(x)[-seq(cols)] <- gsub("[a-z]", "", names(x)[-seq(cols)])
 
   # Restructure data frame if the two sexes are side by side
-  if (any(duplicated(grepv("^.[0-9]", names(x))))) {
+  if (any(duplicated(grepv("^[0-9]+$", names(x))))) {
     ncomp <- (ncol(x) - length(cols)) / 2
     f <- x[seq(length(cols) + 1, length = ncomp)]
     f <- cbind(x[cols], f)
@@ -240,7 +240,7 @@ size2long <- function(x, measure = NULL, zero = TRUE) {
   names(x)[-seq(cols)] <- gsub("[a-z]", "", names(x)[-seq(cols)])
 
   # Restructure data frame if the two sexes are side by side
-  if (any(duplicated(grepv("^.[0-9]", names(x))))) {
+  if (any(duplicated(grepv("^[0-9]+$", names(x))))) {
     ncomp <- (ncol(x) - length(cols)) / 2
     f <- x[seq(length(cols) + 1, length = ncomp)]
     f <- cbind(x[cols], f)


### PR DESCRIPTION
Sorry for taking three pull requests to improve comp2long(), which we're using in a production stock assessment (SW Pacific swordfish) for the first time.

A small but important enhancement of the regular expression, as the first character of bin names had already been shaved off.

Warm wishes from the WCPFC SC meeting in Tonga, where the NOAA Honolulu team is teaching us all the cool r4ss tricks :)