### PR TITLE
Use modelnames throughout the comparison functions

### DIFF
--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -15,9 +15,7 @@
 #' @param forecast Choice to read or not read forecast quantities.
 #' Default=FALSE.
 #' @template verbose
-#' @param ncols Deprecated. Value is now calculated automatically.
-#' @param listlists Save output from each model as a element of a list (i.e.
-#' make a list of lists). Default = TRUE.
+#' @param listlists Deprecated argument that wasn't working.
 #' @param underscore Add an underscore '_' between any file names and any keys
 #' in keyvec. Default=FALSE.
 #' @param save.lists Save each list of parsed output as a .Rdata file (with default
@@ -25,26 +23,35 @@
 #' @inheritParams SS_output
 #' @author Ian Taylor
 #' @export
-#' @seealso [SS_output()] [SSsummarize()]
+#' @seealso [SS_output()]
+#' @family model comparison functions
+#' @examples
+#' # contrived example where the same model is read twice
+#' mydir <- file.path(
+#'   path.package("r4ss"),
+#'   file.path("extdata", "simple_small")
+#' )
+#' models <- SSgetoutput(
+#'   dirvec = c(mydir, mydir),
+#'   modelnames = c("simple_small", "simple_small_again")
+#' )
 SSgetoutput <-
   function(
-    keyvec = NULL,
-    dirvec = NULL,
-    getcovar = TRUE,
-    getcomp = TRUE,
-    forecast = TRUE,
-    verbose = TRUE,
-    ncols = lifecycle::deprecated(),
-    listlists = TRUE,
-    underscore = FALSE,
-    save.lists = FALSE,
-    SpawnOutputLabel = "Spawning output"
-  ) {
-    if (lifecycle::is_present(ncols)) {
-      lifecycle::deprecate_warn(
-        when = "1.46.2",
-        what = "SSgetoutput(ncols)",
-        Details = "ncols now calculated automatically by SS_output()"
+      keyvec = NULL,
+      dirvec = NULL,
+      getcovar = TRUE,
+      getcomp = TRUE,
+      forecast = TRUE,
+      verbose = TRUE,
+      listlists = lifecycle::deprecated(),
+      underscore = FALSE,
+      save.lists = FALSE,
+      SpawnOutputLabel = "Spawning output",
+      modelnames = NULL) {
+    if (lifecycle::is_present(listlists)) {
+      lifecycle::deprecate_stop(
+        when = "1.52.1",
+        what = "SSgetoutput(listlists)"
       )
     }
 
@@ -58,9 +65,7 @@ SSgetoutput <-
     }
 
     # change inputs so that keyvec and dirvec have matching lengths or keyvec=NULL
-    if (listlists) {
-      biglist <- list()
-    }
+    biglist <- list()
     n1 <- length(keyvec)
     n2 <- length(dirvec)
     if (n1 > 1 & n2 > 1 & n1 != n2) {
@@ -68,14 +73,32 @@ SSgetoutput <-
     } else {
       n <- max(1, n1, n2) # n=1 or n=length of either optional input vector
     }
+
+    # apply optional input of modelnames
+    if (!is.null(modelnames)) {
+      if (length(modelnames) == n) {
+        objectnames <- modelnames
+      } else {
+        cli::cli_abort(
+          "length of modelnames input ({length(modelnames)}) does not match number of models ({n})"
+        )
+      }
+    }
+
+    # if keyvec is length 1, recycled to length n
     if (n1 == 1) {
       keyvec <- rep(keyvec, n)
     }
-    objectnames <- paste("replist", keyvec, sep = "")
-    if (n1 == 0) {
-      objectnames <- paste("replist", 1:n, sep = "")
+    # default model names if not provided by user
+    if (is.null(modelnames)) {
+      objectnames <- paste("replist", keyvec, sep = "")
+      if (n1 == 0) {
+        # if keyvec is NULL, use sequential numbering
+        objectnames <- paste("replist", 1:n, sep = "")
+      }
     }
 
+    # working directory is defult if dirvec not provided
     if (n2 == 0) {
       dirvec <- getwd()
     }
@@ -158,10 +181,9 @@ SSgetoutput <-
       if (verbose) {
         message("added element '", newobject, "' to list")
       }
-      if (listlists) {
-        biglist[[newobject]] <- output
-      }
+      biglist[[newobject]] <- output
 
+      # IGT (Aug 2025): not clear if the option to save Rdata files is useful
       if (save.lists) {
         biglist.file <- paste(
           "biglist",
@@ -173,6 +195,7 @@ SSgetoutput <-
         )
         save(biglist, file = biglist.file)
       }
-    }
+    } # end loop over models
+
     return(invisible(biglist))
   }

--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -104,7 +104,7 @@
 #' values (implemented as `adjustcolor(col=col, alpha.f=shadealpha)`)
 #' @template legend
 #' @param legendlabels Optional vector of labels to include in legend. Default
-#' is 'model1','model2',etc.
+#' is `summaryoutput[["modelnames"]]`.
 #' @template legendloc
 #' @param legendorder Optional vector of model numbers that can be used to have
 #' the legend display the model names in an order that is different than that
@@ -163,8 +163,7 @@
 #' useful to turn off. Defaults to TRUE.
 #' @author Ian G. Taylor, John R. Wallace
 #' @export
-#' @seealso [SS_plots()], [SSsummarize()],
-#' [SS_output()], [SSgetoutput()]
+#' @family model comparison functions
 #' @examples
 #' \dontrun{
 #' # directories where models were run need to be defined
@@ -333,36 +332,6 @@ SSplotComparisons <-
       }
       par(par)
     }
-
-    # subfunction to add legend
-    # legendfun <- function(legendlabels, cumulative = FALSE) {
-    #   if (cumulative) {
-    #     legendloc <- "topleft"
-    #   }
-    #   if (is.numeric(legendloc)) {
-    #     Usr <- par()[["usr"]]
-    #     legendloc <- list(
-    #       x = Usr[1] + legendloc[1] * (Usr[2] - Usr[1]),
-    #       y = Usr[3] + legendloc[2] * (Usr[4] - Usr[3])
-    #     )
-    #   }
-    #
-    #   # if type input is "l" then turn off points on top of lines in legend
-    #   legend.pch <- pch
-    #   if (type == "l") {
-    #     legend.pch <- rep(NA, length(pch))
-    #   }
-    #   legend(legendloc,
-    #     legend = legendlabels[legendorder],
-    #     col = col[legendorder],
-    #     lty = lty[legendorder],
-    #     seg.len = 2,
-    #     lwd = lwd[legendorder],
-    #     pch = legend.pch[legendorder],
-    #     bty = "n",
-    #     ncol = legendncol
-    #   )
-    # }
 
     # get stuff from summary output
     n <- summaryoutput[["n"]]
@@ -648,7 +617,7 @@ SSplotComparisons <-
     }
 
     if (!is.expression(legendlabels[1]) && is.null(legendlabels)) {
-      legendlabels <- paste("model", 1:nlines)
+      legendlabels <- summaryoutput[["modelnames"]]
     }
 
     # open new window if requested

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -30,7 +30,7 @@
 #' @template verbose
 #' @author Ian Taylor
 #' @export
-#' @seealso [SSgetoutput()]
+#' @family model comparison functions
 SSsummarize <- function(
   biglist,
   sizeselfactor = "Lsel",

--- a/R/SStableComparisons.R
+++ b/R/SStableComparisons.R
@@ -17,7 +17,7 @@
 #' @param digits Optional vector of the number of decimal digits to use in
 #' reporting each quantity.
 #' @param modelnames optional vector of labels to use as column names. Default
-#' is 'model1','model2',etc.
+#' is `summaryoutput[["modelnames"]]`.
 #' @param csv write resulting table to CSV file?
 #' @param csvdir directory for optional CSV file
 #' @param csvfile filename for CSV file
@@ -25,8 +25,7 @@
 #' @param mcmc summarize MCMC output in table?
 #' @author Ian Taylor
 #' @export
-#' @seealso [SSsummarize()], [SSplotComparisons()],
-#' [SS_output()]
+#' @family model comparison functions
 SStableComparisons <- function(
   summaryoutput,
   models = "all",
@@ -50,7 +49,7 @@ SStableComparisons <- function(
     "SPRratio_2024"
   ),
   digits = NULL,
-  modelnames = "default",
+  modelnames = NULL,
   csv = FALSE,
   csvdir = "workingdirectory",
   csvfile = "parameter_comparison_table.csv",
@@ -76,8 +75,8 @@ SStableComparisons <- function(
   ncols <- length(models)
   nsexes <- nsexes[models]
 
-  if (modelnames[1] == "default") {
-    modelnames <- paste("model", 1:ncols, sep = "")
+  if (is.null(modelnames)) {
+    modelnames <- summaryoutput[["modelnames"]]
   }
   tab <- as.data.frame(matrix(NA, nrow = 0, ncol = ncols + 1))
 

--- a/man/SSgetoutput.Rd
+++ b/man/SSgetoutput.Rd
@@ -11,11 +11,11 @@ SSgetoutput(
   getcomp = TRUE,
   forecast = TRUE,
   verbose = TRUE,
-  ncols = lifecycle::deprecated(),
-  listlists = TRUE,
+  listlists = lifecycle::deprecated(),
   underscore = FALSE,
   save.lists = FALSE,
-  SpawnOutputLabel = "Spawning output"
+  SpawnOutputLabel = "Spawning output",
+  modelnames = NULL
 )
 }
 \arguments{
@@ -37,10 +37,7 @@ Default=FALSE.}
 \item{verbose}{A logical value specifying if output should be printed
 to the screen.}
 
-\item{ncols}{Deprecated. Value is now calculated automatically.}
-
-\item{listlists}{Save output from each model as a element of a list (i.e.
-make a list of lists). Default = TRUE.}
+\item{listlists}{Deprecated argument that wasn't working.}
 
 \item{underscore}{Add an underscore '_' between any file names and any keys
 in keyvec. Default=FALSE.}
@@ -59,9 +56,24 @@ fecundity parameters which are calculated outside of the SS3 model.}
 Apply the function \code{\link[=SS_output]{SS_output()}} multiple times and save output as
 individual objects or a list of lists.
 }
+\examples{
+# contrived example where the same model is read twice
+mydir <- file.path(
+  path.package("r4ss"),
+  file.path("extdata", "simple_small")
+)
+models <- SSgetoutput(
+  dirvec = c(mydir, mydir),
+  modelnames = c("simple_small", "simple_small_again")
+)
+}
 \seealso{
-\code{\link[=SS_output]{SS_output()}} \code{\link[=SSsummarize]{SSsummarize()}}
+Other model comparison functions: 
+\code{\link{SSplotComparisons}()},
+\code{\link{SSsummarize}()},
+\code{\link{SStableComparisons}()}
 }
 \author{
 Ian Taylor
 }
+\concept{model comparison functions}

--- a/man/SSgetoutput.Rd
+++ b/man/SSgetoutput.Rd
@@ -68,6 +68,8 @@ models <- SSgetoutput(
 )
 }
 \seealso{
+\code{\link[=SS_output]{SS_output()}}
+
 Other model comparison functions: 
 \code{\link{SSplotComparisons}()},
 \code{\link{SSsummarize}()},

--- a/man/SSplotComparisons.Rd
+++ b/man/SSplotComparisons.Rd
@@ -208,7 +208,7 @@ values (implemented as \code{adjustcolor(col=col, alpha.f=shadealpha)})}
 \item{legend}{Add a legend?}
 
 \item{legendlabels}{Optional vector of labels to include in legend. Default
-is 'model1','model2',etc.}
+is \code{summaryoutput[["modelnames"]]}.}
 
 \item{legendloc}{Location of legend. Either a string like "topleft" or a
 vector of two numeric values representing the fraction of the maximum in
@@ -342,9 +342,12 @@ SSplotComparisons(mod.sum,
 
 }
 \seealso{
-\code{\link[=SS_plots]{SS_plots()}}, \code{\link[=SSsummarize]{SSsummarize()}},
-\code{\link[=SS_output]{SS_output()}}, \code{\link[=SSgetoutput]{SSgetoutput()}}
+Other model comparison functions: 
+\code{\link{SSgetoutput}()},
+\code{\link{SSsummarize}()},
+\code{\link{SStableComparisons}()}
 }
 \author{
 Ian G. Taylor, John R. Wallace
 }
+\concept{model comparison functions}

--- a/man/SSsummarize.Rd
+++ b/man/SSsummarize.Rd
@@ -61,8 +61,12 @@ If the models have incompatible dimensions, some quantities can't be
 compared via this function, such as selectivity.
 }
 \seealso{
-\code{\link[=SSgetoutput]{SSgetoutput()}}
+Other model comparison functions: 
+\code{\link{SSgetoutput}()},
+\code{\link{SSplotComparisons}()},
+\code{\link{SStableComparisons}()}
 }
 \author{
 Ian Taylor
 }
+\concept{model comparison functions}

--- a/man/SStableComparisons.Rd
+++ b/man/SStableComparisons.Rd
@@ -11,7 +11,7 @@ SStableComparisons(
   names = c("Recr_Virgin", "R0", "steep", "NatM", "L_at_Amax", "VonBert_K", "SSB_Virg",
     "Bratio_2025", "SPRratio_2024"),
   digits = NULL,
-  modelnames = "default",
+  modelnames = NULL,
   csv = FALSE,
   csvdir = "workingdirectory",
   csvfile = "parameter_comparison_table.csv",
@@ -37,7 +37,7 @@ match substring of labels in \code{summaryoutput[["pars"]]} or
 reporting each quantity.}
 
 \item{modelnames}{optional vector of labels to use as column names. Default
-is 'model1','model2',etc.}
+is \code{summaryoutput[["modelnames"]]}.}
 
 \item{csv}{write resulting table to CSV file?}
 
@@ -56,9 +56,12 @@ reduction of the full information in various parts of the list created using
 the \code{SSsummarize} function.
 }
 \seealso{
-\code{\link[=SSsummarize]{SSsummarize()}}, \code{\link[=SSplotComparisons]{SSplotComparisons()}},
-\code{\link[=SS_output]{SS_output()}}
+Other model comparison functions: 
+\code{\link{SSgetoutput}()},
+\code{\link{SSplotComparisons}()},
+\code{\link{SSsummarize}()}
 }
 \author{
 Ian Taylor
 }
+\concept{model comparison functions}


### PR DESCRIPTION
As suggested by @okenk in #1050, this improves functionality of the model comparisons functions by 
1. adding a `modelnames` argument to `SSgetoutput()`,
2. that argument is used by `SSsummarize()` and now passed from there to `SStableComparisons() and `SSplotComparisons()` (where it is used as the default for `legendlabels`)

Other minor changes
* add example to documentation of `SSgetoutput()`
* improve internal links between documentation of all comparison functions
* remove long-ago deprecated argument to `SSgetoutput()` and newly deprecate an non-functioning argument

@okenk, it would be great if you could check if these change works the way you were hoping they would