### PR TITLE
clean up read of SPAWN_RECRUIT table

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -2290,14 +2290,14 @@ SS_output <-
     rmse_table <- NULL
     breakpoints_for_bias_adjustment_ramp <- NULL
     sigma_R_in <- parameters["SR_sigmaR", "Value"]
-
+    recruit <- NULL
     # read new expanded SPAWN_RECRUIT table header (3.30.24)
     if (
       !is.na(match_report_line("timevary_bio_4SRR", obj = rawrep[, 3])) &
         length(grep("SPAWN_RECRUIT", rawrep[, 1])) <= 1
+      # NOTE: this part excludes reading the new table in the beta versions that
+      # had both old and new tables
     ) {
-      # beta version had duplicate tables
-
       srhead <- match_report_table(
         "SPAWN_RECRUIT",
         adjust1 = 0,
@@ -2479,10 +2479,7 @@ SS_output <-
     }
 
     # clean up STOCK_RECRUIT table
-    if (is.null(recruit) && is.null(raw_recruit)) {
-      recruit <- NULL
-    }
-    if (is.null(recruit) && is.null(raw_recruit)) {
+    if (is.null(recruit) && !is.null(raw_recruit)) {
       # process old SPAWN_RECRUIT table
       names(raw_recruit) <- raw_recruit[1, ]
       raw_recruit[raw_recruit == "_"] <- NA

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -2291,11 +2291,13 @@ SS_output <-
     breakpoints_for_bias_adjustment_ramp <- NULL
     sigma_R_in <- parameters["SR_sigmaR", "Value"]
 
-    # read new expanded SPAWN_RECRUIT table header (3.30.23)
-    if (!is.na(match_report_line("#Expanded_Spawn_Recr_report"))) {
+    # read new expanded SPAWN_RECRUIT table header (3.30.24)
+    if (!is.na(match_report_line("timevary_bio_4SRR", obj = rawrep[,3])) &
+      length(grep("SPAWN_RECRUIT", rawrep[,1])) <= 1) { # beta version had duplicate tables
+
       srhead <- match_report_table(
-        "#Expanded_Spawn_Recr_report",
-        adjust1 = 2,
+        "SPAWN_RECRUIT",
+        adjust1 = 0,
         which_blank = 1,
         blank_lines = rep_blank_lines
       )
@@ -2469,10 +2471,11 @@ SS_output <-
       }
     }
 
-    if (is.null(raw_recruit)) {
+    if (is.null(recruit) && is.null(raw_recruit)) {
       recruit <- NULL
-    } else {
-      # process SPAWN_RECRUIT table
+    } 
+    if (is.null(recruit) && is.null(raw_recruit)) {
+      # process old SPAWN_RECRUIT table
       names(raw_recruit) <- raw_recruit[1, ]
       raw_recruit[raw_recruit == "_"] <- NA
       raw_recruit <- raw_recruit[-(1:2), ] # remove header rows

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -2292,8 +2292,11 @@ SS_output <-
     sigma_R_in <- parameters["SR_sigmaR", "Value"]
 
     # read new expanded SPAWN_RECRUIT table header (3.30.24)
-    if (!is.na(match_report_line("timevary_bio_4SRR", obj = rawrep[,3])) &
-      length(grep("SPAWN_RECRUIT", rawrep[,1])) <= 1) { # beta version had duplicate tables
+    if (
+      !is.na(match_report_line("timevary_bio_4SRR", obj = rawrep[, 3])) &
+        length(grep("SPAWN_RECRUIT", rawrep[, 1])) <= 1
+    ) {
+      # beta version had duplicate tables
 
       srhead <- match_report_table(
         "SPAWN_RECRUIT",
@@ -2359,6 +2362,10 @@ SS_output <-
         matchcol1 = 13,
         header = TRUE
       )
+      recruit[recruit == "_"] <- NA
+      # TODO: remove the filtering below and modify plotting functions instead
+      recruit <- recruit[-(1:2), ] # remove rows for Virg and Init)
+      recruit <- type.convert(recruit, as.is = TRUE)
     } else {
       # read old SPAWN_RECRUIT table header
 
@@ -2471,9 +2478,10 @@ SS_output <-
       }
     }
 
+    # clean up STOCK_RECRUIT table
     if (is.null(recruit) && is.null(raw_recruit)) {
       recruit <- NULL
-    } 
+    }
     if (is.null(recruit) && is.null(raw_recruit)) {
       # process old SPAWN_RECRUIT table
       names(raw_recruit) <- raw_recruit[1, ]


### PR DESCRIPTION
Beta versions of 3.30.24 had both old and new (expanded) SPAWN_RECRUIT table
Change here allow read of 
* old table only in 3.30.23 and previous
* new table only in 3.30.24 release
* old table in 3.30.24 beta versions where both tables were present