### PR TITLE
Refactor YPR_timeseries function to use SPR or YPR

### DIFF
--- a/R/SSplotYield.R
+++ b/R/SSplotYield.R
@@ -366,7 +366,7 @@ SSplotYield <-
         col = "blue",
         yaxs = "i"
       )
-    } # end YPR_timeseries function# end YPR_timeseries function
+    } # end YPR_timeseries function
 
     if (3 %in% subplots) {
       if (plot) {


### PR DESCRIPTION
See SS3 PR [#750](https://github.com/nmfs-ost/ss3-source-code/pull/750) for change in spr series to use "SPR" instead of "YPR".

Add ability to find "SPR" in table while retaining backwards compatibility with "YPR"