### PR TITLE
retro to return invisibly the vector of run paths for SSgetoutput

### DIFF
--- a/R/retro.R
+++ b/R/retro.R
@@ -173,4 +173,5 @@ retro <- function(
       warning("The retrospective model run failed in ", newdir_iyr)
     }
   })
+  invisible(file.path(dir, newsubdir, subdirnames))
 }


### PR DESCRIPTION
`retro` is made here to return a vector of paths, assembled via `file.path(dir, newsubdir, subdirnames)` that can then be used in a call to `SSgetoutput()`.