### PR TITLE
Fix read of selectivity deviation parameters in output

### DIFF
--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -1779,7 +1779,7 @@ SS_output <-
       # separate the numeric year value and bin number
       seldev_label_info <- do.call(
         rbind,
-        lapply(strsplit(seldev_pars[["Label"]], split = "_AR"), rbind)
+        lapply(strsplit(seldev_pars[["Label"]], split = "_ARDEV_"), rbind)
       )
 
       seldev_label_info2 <- strsplit(seldev_label_info[, 2], split = "_")


### PR DESCRIPTION
Thanks to @peterkuriyama for reported a bug in `SS_output()` for a model "with varying numbers of underscores in the fleet names and estimation of 2dAR age selectivity" and shared a change to the code to make it work. 

This PR also avoids a warning message about "NAs introduced by coercion" that was due to some unexpected formatting in the output in the SPAWN_RECRUIT section.