### PR TITLE
change cli_inform() to cli_alert_*() functions

### DIFF
--- a/R/PinerPlot.R
+++ b/R/PinerPlot.R
@@ -187,7 +187,7 @@ PinerPlot <-
       )
     }
     parvec <- as.numeric(pars[pars[["Label"]] == parlabel, models])
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Parameter matching profile.string = '{profile.string}': '{parlabel}'. Parameter values (after subsetting based on input 'models'): {paste(parvec, collapse = ', ')}"
     )
     if (xlim[1] == "default") {
@@ -251,7 +251,7 @@ PinerPlot <-
     column.max <- apply(data.frame(prof.table[, -c(1:3)]), 2, max, na.rm = TRUE)
     change.fraction <- column.max / max(prof.table[, 3], na.rm = TRUE)
     include <- change.fraction >= minfraction
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Fleet-specific likelihoods showing max change as fraction of total change. To change which components are included, change input 'minfraction'. {paste(utils::capture.output(print(data.frame(
           frac_change = round(change.fraction, 4),
           include = include

--- a/R/SSMethod.Cond.TA1.8.R
+++ b/R/SSMethod.Cond.TA1.8.R
@@ -117,7 +117,7 @@ SSMethod.Cond.TA1.8 <-
     if (is.null(seas)) {
       seas <- "comb"
       if (length(unique(dbase[["Seas"]])) > 1) {
-        cli::cli_inform("Combining data from multiple seasons")
+        cli::cli_alert_info("Combining data from multiple seasons")
       }
     }
 

--- a/R/SSMethod.TA1.8.R
+++ b/R/SSMethod.TA1.8.R
@@ -160,7 +160,7 @@ SSMethod.TA1.8 <-
     if (is.null(seas)) {
       seas <- "comb"
       if (length(unique(dbase[["Seas"]])) > 1) {
-        cli::cli_inform("Combining data from multiple seasons")
+        cli::cli_alert_info("Combining data from multiple seasons")
       }
     }
     # if generalized size comp is used, check for mix of units
@@ -210,7 +210,7 @@ SSMethod.TA1.8 <-
     if (length(uindx) == 1) {
       # presumably the method is meaningless of there's only 1 point,
       # but it's good to be able to have the function play through
-      cli::cli_inform("Only one point to plot")
+      cli::cli_alert_info("Only one point to plot")
       return()
     }
 

--- a/R/SS_changepars.R
+++ b/R/SS_changepars.R
@@ -167,7 +167,7 @@ SS_changepars <-
         }
         goodnames <- unique(unlist(goodnames))
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Parameter names in control file matching input vector 'strings' (n={length(goodnames)}): {paste(goodnames, collapse = ', ')}"
           )
         }
@@ -188,7 +188,7 @@ SS_changepars <-
     }
     ctlsubset <- ctl[linenums]
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "line numbers in control file (n={length(linenums)}): {paste(linenums, collapse = ', ')}"
       )
     }
@@ -365,7 +365,7 @@ SS_changepars <-
     }
     if (verbose) {
       results_text <- paste(utils::capture.output(results), collapse = "\n")
-      cli::cli_inform(
+      cli::cli_alert_success(
         "Wrote new file to {newctlfile} with the following changes:\n{results_text}"
       )
     }

--- a/R/SS_fitbiasramp.R
+++ b/R/SS_fitbiasramp.R
@@ -126,7 +126,7 @@ SS_fitbiasramp <-
       )
     }
     if (verbose) {
-      cli::cli_inform("startvalues = {paste(startvalues, collapse = ', ')}")
+      cli::cli_alert_info("startvalues = {paste(startvalues, collapse = ', ')}")
     }
 
     makeoffsets <- function(values) {
@@ -154,7 +154,7 @@ SS_fitbiasramp <-
       startvalues <- makeoffsets(startvalues)
     }
     if (verbose & transform) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "transformed startvalues = {paste(startvalues, collapse = ', ')}"
       )
     }
@@ -321,7 +321,7 @@ SS_fitbiasramp <-
     # test for presence of estimated recruitment deviations
     if (max(val) == 0 | length(val) == 0) {
       if (verbose) {
-        cli::cli_inform("No rec devs estimated in this model")
+        cli::cli_alert_warning("No rec devs estimated in this model")
       }
       return()
     }
@@ -331,7 +331,7 @@ SS_fitbiasramp <-
 
     ylim <- range(recdev_hi, recdev_lo)
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Now estimating alternative recruitment bias adjustment fraction..."
       )
     }
@@ -440,7 +440,7 @@ SS_fitbiasramp <-
         cli::cli_warn("Problem with convergence, here is output from 'optim':")
         print(newbias)
       }
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Estimated values: {paste(utils::capture.output(df), collapse = '\n')}"
       )
     }
@@ -517,7 +517,7 @@ SS_fitbiasramp <-
       # write new file
       writeLines(ctlfile, newctl)
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_success(
           "wrote new file to {newctl} with values {paste(newvals, collapse = ', ')}"
         )
       }

--- a/R/SS_html.R
+++ b/R/SS_html.R
@@ -36,7 +36,7 @@ SS_html <- function(
   verbose = TRUE
 ) {
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Running 'SS_html': By default, this function will look in the directory where PNG files were created for CSV files with the name 'plotInfoTable...' written by 'SS_plots.' HTML files are written to link to these plots and put in the same directory."
     )
   }
@@ -92,7 +92,7 @@ SS_html <- function(
       # loop over duplicates and remove rows for older instance
       if (length(duplicates) > 0) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Removing duplicate rows in combined plotInfoTable based on multiple CSV files"
           )
         }
@@ -136,7 +136,7 @@ SS_html <- function(
       htmlfile <- file.path(plotdir, "_SS_output.html")
       htmlhome <- htmlfile
       if (verbose) {
-        cli::cli_inform("Home HTML file with output will be: {htmlhome}")
+        cli::cli_alert_info("Home HTML file with output will be: {htmlhome}")
       }
     } else {
       category <- categories[icat]
@@ -475,7 +475,7 @@ SS_html <- function(
   # thanks John Wallace for finding the browseURL command
   if (openfile) {
     if (verbose) {
-      cli::cli_inform("Opening HTML file in your default web-browser.")
+      cli::cli_alert_info("Opening HTML file in your default web-browser.")
     }
     # check for presence of file
     # alternative location for file in the path is relative to the working directory

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -508,7 +508,7 @@ SS_output <-
     if (!is.na(btarg) & btarg == 0.25) {
       if (verbose) {
         cli::cli_alert_info(
-          "Setting minimum biomass threshhold to 0.125 based on US west coast assumption associated with flatfish target of 0.25 (can replace or override in SS_plots by setting 'minbthresh')"
+          "Setting minimum biomass threshold to 0.125 based on US west coast assumption associated with flatfish target of 0.25 (can replace or override in SS_plots by setting 'minbthresh')"
         )
       }
       minbthresh <- 0.125 # west coast assumption for flatfish
@@ -4070,7 +4070,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
     ) {
       if (verbose) {
         cli::cli_alert_info(
-          "Setting minimum biomass threshhold to 0.10 because this looks like the Pacific Hake model. You can replace or override in SS_plots via the 'minbthresh' input."
+          "Setting minimum biomass threshold to 0.10 because this looks like the Pacific Hake model. You can replace or override in SS_plots via the 'minbthresh' input."
         )
       }
       minbthresh <- 0.1 # treaty value for hake

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -500,7 +500,7 @@ SS_output <-
     if (!is.na(btarg) & btarg == 0.4) {
       if (verbose) {
         cli::cli_alert_info(
-          "Setting minimum biomass threshhold to 0.25 based on US west coast assumption associated with biomass target of 0.4 (can replace or override in SS_plots by setting 'minbthresh')"
+          "Setting minimum biomass threshold to 0.25 based on US west coast assumption associated with biomass target of 0.4 (can replace or override in SS_plots by setting 'minbthresh')"
         )
       }
       minbthresh <- 0.25 # west coast assumption for non flatfish

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -244,7 +244,7 @@ SS_output <-
 
     if (is.na(parfile)) {
       if (!hidewarn) {
-        cli::cli_inform("Some stats skipped because the .par file not found.")
+        cli::cli_alert_warning("Some stats skipped because the .par file not found.")
       }
     }
 
@@ -283,7 +283,7 @@ SS_output <-
       )
     } else {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "This function tested on SS versions 3.24 and 3.30.  You are using {strsplit(SS_version, split = ';')[[1]][1]} which SHOULD work with this package."
         )
       }
@@ -300,14 +300,14 @@ SS_output <-
     }
     repfiletime <- findtime(rephead)
     if (verbose) {
-      cli::cli_inform("Report file time: {repfiletime}")
+      cli::cli_alert_info("Report file time: {repfiletime}")
     }
 
     # time check for CompReport file
     comp <- FALSE
     if (is.null(compfile)) {
       if (verbose) {
-        cli::cli_inform("Skipping CompReport because 'compfile = NULL'")
+        cli::cli_alert_warning("Skipping CompReport because 'compfile = NULL'")
       }
     } else {
       compfile <- file.path(dir, compfile)
@@ -317,7 +317,7 @@ SS_output <-
         compskip <- grep("Composition_Database", comphead)
         if (length(compskip) == 0) {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "No composition data, possibly because detailed output is turned off in the starter file."
             )
           }
@@ -329,12 +329,12 @@ SS_output <-
           }
           comptime <- findtime(comphead)
           if (is.null(comptime) || is.null(repfiletime)) {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "problem comparing the file creation times: Report.sso: {repfiletime} CompReport.sso: {comptime}"
             )
           } else {
             if (comptime != repfiletime) {
-              cli::cli_inform("CompReport time: {comptime}")
+              cli::cli_alert_info("CompReport time: {comptime}")
               cli::cli_abort(
                 "{shortrepfile} and {compfile} were from different model runs."
               )
@@ -350,7 +350,7 @@ SS_output <-
               "Missing {compfile}. Change the 'compfile' input, rerun model to get the file, or change input to 'NoCompOK = TRUE'"
             )
           } else {
-            cli::cli_inform("Composition file not found: {compfile}")
+            cli::cli_alert_info("Composition file not found: {compfile}")
           }
         }
       }
@@ -358,7 +358,7 @@ SS_output <-
 
     # read report file
     if (verbose) {
-      cli::cli_inform("Reading full report file")
+      cli::cli_alert_info("Reading full report file")
     }
     flush.console()
 
@@ -399,11 +399,11 @@ SS_output <-
 
     if (verbose) {
       if ((maxnonblank + 1) < ncols) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Got all columns. To speed code, use ncols = {maxnonblank + 1} in the future."
         )
       }
-      cli::cli_inform("Got Report file")
+      cli::cli_alert_success("Got Report file")
     }
     flush.console()
 
@@ -414,7 +414,7 @@ SS_output <-
       forecastname <- file.path(dir, forefile)
       if (file_is_empty(forecastname)) {
         if (verbose) {
-          cli::cli_inform("Forecast-report.sso file is missing or empty.")
+          cli::cli_alert_warning("Forecast-report.sso file is missing or empty.")
         }
       } else {
         # read the file
@@ -478,7 +478,7 @@ SS_output <-
       }
     } else {
       if (verbose) {
-        cli::cli_inform("You skipped the forecast file.")
+        cli::cli_alert_warning("You skipped the forecast file.")
       }
     }
     if (!exists("btarg")) {
@@ -486,8 +486,8 @@ SS_output <-
       sprtarg <- -999
       btarg <- -999
       if (verbose) {
-        cli::cli_inform(
-          "  setting SPR target and Biomass target to -999.  Lines won't be drawn for these targets by SS_plots unless  'sprtarg' and 'btarg' are provided as inputs."
+        cli::cli_alert_info(
+          "  setting SPR target and Biomass target to -999. Lines won't be drawn for these targets by SS_plots unless 'sprtarg' and 'btarg' are provided as inputs."
         )
       }
     }
@@ -495,16 +495,16 @@ SS_output <-
     minbthresh <- -999
     if (!is.na(btarg) & btarg == 0.4) {
       if (verbose) {
-        cli::cli_inform(
-          "Setting minimum biomass threshhold to 0.25  based on US west coast assumption associated with biomass target of 0.4.  (can replace or override in SS_plots by setting 'minbthresh')"
+        cli::cli_alert_info(
+          "Setting minimum biomass threshhold to 0.25 based on US west coast assumption associated with biomass target of 0.4 (can replace or override in SS_plots by setting 'minbthresh')"
         )
       }
       minbthresh <- 0.25 # west coast assumption for non flatfish
     }
     if (!is.na(btarg) & btarg == 0.25) {
       if (verbose) {
-        cli::cli_inform(
-          "Setting minimum biomass threshhold to 0.125  based on US west coast assumption associated with flatfish target of 0.25.  (can replace or override in SS_plots by setting 'minbthresh')"
+        cli::cli_alert_info(
+          "Setting minimum biomass threshhold to 0.125 based on US west coast assumption associated with flatfish target of 0.25 (can replace or override in SS_plots by setting 'minbthresh')"
         )
       }
       minbthresh <- 0.125 # west coast assumption for flatfish
@@ -518,7 +518,7 @@ SS_output <-
       filetimes <- file.info(file.path(dir, logfile_name))[["mtime"]]
       logfile_name <- logfile_name[filetimes == max(filetimes)]
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Multiple files in directory match pattern *.log choosing most recently modified file: {logfile_name}"
         )
       }
@@ -546,18 +546,18 @@ SS_output <-
         maxtemp <- max(logfile[["Size"]])
         if (verbose) {
           if (maxtemp == 0) {
-            cli::cli_inform(
+            cli::cli_alert_success(
               "Got log file. There were NO temporary files were written in this run."
             )
           } else {
-            cli::cli_inform("Temporary files were written in this run.")
+            cli::cli_alert_warning("Temporary files were written in this run.")
           }
         }
       }
     } else {
       logfile <- NA
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "No non-empty log file in directory or too many files  matching pattern *.log"
         )
       }
@@ -568,7 +568,7 @@ SS_output <-
       warnname <- file.path(dir, warnfile)
       if (file_is_empty(warnname)) {
         # no warnings.sso file
-        cli::cli_inform("{warnfile} file not found")
+        cli::cli_alert_warning("{warnfile} file not found")
         warnrows <- NA
         warnlines <- NA
       } else {
@@ -578,19 +578,19 @@ SS_output <-
         # detect empty file
         warnrows <- length(warnlines)
         if (verbose && warnrows > 0) {
-          cli::cli_inform("Got warning file. Final line: {tail(warnlines, 1)}")
+          cli::cli_alert_success("Got warning file. Final line: {tail(warnlines, 1)}")
         }
       }
     } else {
       # chose not to read warning.sso file
       if (verbose) {
-        cli::cli_inform("You skipped the warnings file")
+        cli::cli_alert_warning("You skipped the warnings file")
       }
       warnrows <- NA
       warnlines <- NA
     }
     if (verbose) {
-      cli::cli_inform("Finished reading files")
+      cli::cli_alert_success("Finished reading files")
     }
     flush.console()
 
@@ -944,7 +944,7 @@ SS_output <-
         2
       ])
       if (compend == compskip + 2) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "It appears that there is no composition data in CompReport.sso"
         )
         comp <- FALSE # turning off switch to function doesn't look for comp data later on
@@ -991,7 +991,7 @@ SS_output <-
           dplyr::select(-Cum_obs, -Cum_exp) |>
           duplicated()
         if (verbose & sum(duplicates) > 0) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Removing {sum(duplicates)} out of {nrow(compdbase)} rows in CompReport.sso which are duplicates."
           )
         }
@@ -1016,7 +1016,7 @@ SS_output <-
         # make correction to tag output associated with 3.24f (fixed in later versions)
         if (substr(SS_version, 1, 9) == "SS-V3.24f") {
           if (!hidewarn) {
-            cli::cli_inform(
+            cli::cli_alert_info(
               "Correcting for bug in tag data output associated with SSv3.24f"
             )
           }
@@ -1187,8 +1187,8 @@ SS_output <-
 
           if (any(sizedbase[["units"]] %in% c("lb", "in"))) {
             if (verbose) {
-              cli::cli_inform(
-                "Note: converting bins in generalized size comp data  in sizedbase back to the original units of lbs or inches."
+              cli::cli_alert_info(
+                "Note: converting bins in generalized size comp data in sizedbase back to the original units of lbs or inches."
               )
             }
           }
@@ -1369,7 +1369,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
     }
 
     if (verbose) {
-      cli::cli_inform("Finished dimensioning")
+      cli::cli_alert_success("Finished dimensioning")
     }
     flush.console()
 
@@ -1574,7 +1574,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
     # fix for issue with SSv3.21f
     if (SS_versionNumeric == 3.21) {
       temp <- names(parameters)
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Inserting new 13th column heading in parameters sectiondue to error in Report.sso in SSv3.21f"
       )
       temp <- c(temp[1:12], "PR_type_code", temp[-(1:12)])
@@ -1831,7 +1831,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
     if (covar) {
       covarfile <- file.path(dir, covarfile)
       if (!file.exists(covarfile)) {
-        cli::cli_inform("covar file not found, input 'covar' changed to FALSE")
+        cli::cli_alert_warning("covar file not found, input 'covar' changed to FALSE")
         covar <- FALSE
       } else {
         # time check for CoVar file
@@ -1840,12 +1840,12 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
         covartime <- findtime(covarhead)
         # the conversion to R time class below may no longer be necessary as strings should match
         if (is.null(covartime) || is.null(repfiletime)) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "problem comparing the file creation times: Report.sso: {repfiletime} covar.sso: {covartime}"
           )
         } else {
           if (covartime != repfiletime) {
-            cli::cli_inform("covar time: {covartime}")
+            cli::cli_alert_info("covar time: {covartime}")
             cli::cli_abort(
               "{shortrepfile} and {covarfile} were from different model runs. Change input to covar=FALSE"
             )
@@ -1872,7 +1872,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
         skip = covarskip
       )
       if (verbose) {
-        cli::cli_inform("Got covar file.")
+        cli::cli_alert_success("Got covar file.")
       }
       stdtable <- CoVar[CoVar[["Par..j"]] == "Std", c(7, 9, 5)]
       names(stdtable) <- c("name", "std", "type")
@@ -1912,7 +1912,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
       }
     } else {
       if (verbose) {
-        cli::cli_inform("You skipped the covar file")
+        cli::cli_alert_warning("You skipped the covar file")
       }
     }
     flush.console()
@@ -1948,12 +1948,12 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
         if ("posteriors.sso" %in% dir(dir.mcmc.full)) {
           # run function to read posteriors.sso and derived_posteriors.sso
           if (verbose) {
-            cli::cli_inform("Running 'SSgetMCMC' to get MCMC output")
+            cli::cli_alert_info("Running 'SSgetMCMC' to get MCMC output")
           }
           mcmc <- SSgetMCMC(dir = dir.mcmc.full)
         } else {
           cli::cli_warn(
-            "skipping reading MCMC output because posterior.sso file not found in {dir.mcmc.full}"
+            "skipping reading MCMC output because posteriors.sso file not found in {dir.mcmc.full}"
           )
           mcmc <- NULL
         }
@@ -2887,7 +2887,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
         # figure out which fleet uses which parameter,
         # currently (as of SS version 3.30.10.00), requires reading data file
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Reading data.ss_new (or data_echo.ss_new) for info on Dirichlet-Multinomial parameters"
           )
         }
@@ -4061,7 +4061,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
         wtatage_switch
     ) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Setting minimum biomass threshhold to 0.10 because this looks like the Pacific Hake model. You can replace or override in SS_plots via the 'minbthresh' input."
         )
       }
@@ -4966,7 +4966,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
 
     # print list of statistics
     if (printstats) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Statistics shown below (to turn off, change input to printstats=FALSE)"
       )
 
@@ -4999,7 +4999,7 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
     returndat[["inputs"]] <- inputs
 
     if (verbose) {
-      cli::cli_inform("completed SS_output")
+      cli::cli_alert_success("completed SS_output")
     }
     invisible(returndat)
   } # end function

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -244,7 +244,9 @@ SS_output <-
 
     if (is.na(parfile)) {
       if (!hidewarn) {
-        cli::cli_alert_warning("Some stats skipped because the .par file not found.")
+        cli::cli_alert_warning(
+          "Some stats skipped because the .par file not found."
+        )
       }
     }
 
@@ -414,7 +416,9 @@ SS_output <-
       forecastname <- file.path(dir, forefile)
       if (file_is_empty(forecastname)) {
         if (verbose) {
-          cli::cli_alert_warning("Forecast-report.sso file is missing or empty.")
+          cli::cli_alert_warning(
+            "Forecast-report.sso file is missing or empty."
+          )
         }
       } else {
         # read the file
@@ -578,7 +582,9 @@ SS_output <-
         # detect empty file
         warnrows <- length(warnlines)
         if (verbose && warnrows > 0) {
-          cli::cli_alert_success("Got warning file. Final line: {tail(warnlines, 1)}")
+          cli::cli_alert_success(
+            "Got warning file. Final line: {tail(warnlines, 1)}"
+          )
         }
       }
     } else {
@@ -1831,7 +1837,9 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
     if (covar) {
       covarfile <- file.path(dir, covarfile)
       if (!file.exists(covarfile)) {
-        cli::cli_alert_warning("covar file not found, input 'covar' changed to FALSE")
+        cli::cli_alert_warning(
+          "covar file not found, input 'covar' changed to FALSE"
+        )
         covar <- FALSE
       } else {
         # time check for CoVar file

--- a/R/SS_plots.R
+++ b/R/SS_plots.R
@@ -370,13 +370,13 @@ SS_plots <-
       )
     }
     if (uncertainty & !inputs[["covar"]]) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "covar information unavailable, changing 'uncertainty' to FALSE"
       )
       uncertainty <- FALSE
     }
     if (forecastplot & max(timeseries[["Yr"]] > endyr + 1) == 0) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Changing 'forecastplot' input to FALSE because all years up to endyr+1 are included by default"
       )
       forecastplot <- FALSE
@@ -387,7 +387,7 @@ SS_plots <-
       fleets <- 1:nfleets
     } else {
       if (length(intersect(fleets, 1:nfleets)) != length(fleets)) {
-        return(
+        cli::cli_abort(
           "Input 'fleets' should be 'all' or a vector of values between 1 and nfleets."
         )
       }
@@ -396,14 +396,14 @@ SS_plots <-
       areas <- 1:nareas
     } else {
       if (length(intersect(areas, 1:nareas)) != length(areas)) {
-        return(
+        cli::cli_abort(
           "Input 'areas' should be 'all' or a vector of values between 1 and nareas."
         )
       }
     }
 
     if (verbose) {
-      cli::cli_inform("Finished defining objects")
+      cli::cli_alert_success("Finished defining objects")
     }
 
     # set fleet-specific names, and plotting parameters
@@ -443,7 +443,7 @@ SS_plots <-
     }
     if (nplots > 0 & !new) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Adding plots to existing plot window. Plot history not erased."
         )
       }
@@ -461,7 +461,7 @@ SS_plots <-
       dir.isdir <- file.info(dir)[["isdir"]]
       # create directory
       if (is.na(dir.isdir) | !dir.isdir) {
-        cli::cli_inform("Directory doesn't exist, attempting to create: {dir}")
+        cli::cli_alert_warning("Directory doesn't exist, attempting to create: {dir}")
         dir.create(dir)
       }
       # test again (even though failure to create dir should have already caused error)
@@ -488,7 +488,7 @@ SS_plots <-
         dir.create(plotdir)
       }
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Plots will be written to PNG files in the directory: {plotdir}"
         )
       }
@@ -513,7 +513,7 @@ SS_plots <-
           StartTimeName <- gsub(" ", "_", StartTimeName, fixed = TRUE)
           StartTimeName <- gsub("._", "_", StartTimeName, fixed = TRUE)
           plotdir.old <- file.path(dir, paste0("plots_", StartTimeName))
-          cli::cli_inform(
+          cli::cli_alert_info(
             "NOTE: the directory {plotdir} contains plots from a previous model run, renaming to {plotdir.old}"
           )
           file.rename(plotdir, plotdir.old)
@@ -535,7 +535,7 @@ SS_plots <-
       )
       pdf(file = pdffile, width = pwidth, height = pheight)
       if (verbose) {
-        cli::cli_inform("PDF file with plots will be: {pdffile}")
+        cli::cli_alert_info("PDF file with plots will be: {pdffile}")
       }
     }
 
@@ -595,7 +595,7 @@ SS_plots <-
     igroup <- 1
     if (igroup %in% plot | length(cohortlines) > 0) {
       if (verbose) {
-        cli::cli_inform("Starting biology plots (group {igroup})")
+        cli::cli_alert_info("Starting biology plots (group {igroup})")
       }
       plotinfo <- SSplotBiology(
         replist = replist,
@@ -624,7 +624,7 @@ SS_plots <-
     igroup <- 2
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Starting selectivity and retention plots (group {igroup})"
         )
       }
@@ -678,7 +678,7 @@ SS_plots <-
     igroup <- 3
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform("Starting timeseries plots (group {igroup})")
+        cli::cli_alert_info("Starting timeseries plots (group {igroup})")
       }
       # which subplots to make (those for spawn bio first)
       subplot_list <- c(7:10, 1:6, 11:15)
@@ -780,7 +780,7 @@ SS_plots <-
 
       ### add plot of Dynamic B0
       if (is.null(replist[["Dynamic_Bzero"]])) {
-        cli::cli_inform("Skipping dynamic B0 plot because output not available")
+        cli::cli_alert_warning("Skipping dynamic B0 plot because output not available")
       } else {
         # first get vector of years
         yrs <- replist[["startyr"]]:(replist[["endyr"]] + 1)
@@ -813,7 +813,7 @@ SS_plots <-
     igroup <- 4
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform("Starting recruitment deviation plots (group {igroup})")
+        cli::cli_alert_info("Starting recruitment deviation plots (group {igroup})")
       }
       plotinfo <-
         SSplotRecdevs(
@@ -860,7 +860,7 @@ SS_plots <-
     if (igroup %in% plot) {
       if (uncertainty) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Starting estimation of recruitment bias adjustment and associated plots (group {igroup})"
           )
         }
@@ -885,18 +885,18 @@ SS_plots <-
               plotInfoTable <- rbind(plotInfoTable, plotinfo)
             }
           } else {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "Skipping bias adjustment fit because root mean squared error of recruit devs is 0."
             )
           }
         } else {
-          cli::cli_inform(
-            "skipping bias adjustment fit because input list element 'rmse_table' has non-numeric 'RMSE' column"
+          cli::cli_alert_warning(
+            "Skipping bias adjustment fit because input list element 'rmse_table' has non-numeric 'RMSE' column"
           )
         }
       } else {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping estimation of recruitment bias adjustment (group {igroup}) because uncertainty=FALSE"
           )
         }
@@ -909,7 +909,7 @@ SS_plots <-
     igroup <- 6
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform("Starting spawner-recruit curve plot (group {igroup})")
+        cli::cli_alert_info("Starting spawner-recruit curve plot (group {igroup})")
       }
       plotinfo <-
         SSplotSpawnrecruit(
@@ -934,7 +934,7 @@ SS_plots <-
     igroup <- 7
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform("Starting catch plots (group {igroup})")
+        cli::cli_alert_info("Starting catch plots (group {igroup})")
       }
       temp <-
         SSplotCatch(
@@ -971,7 +971,7 @@ SS_plots <-
     igroup <- 8
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform("Starting SPR plots (group {igroup})")
+        cli::cli_alert_info("Starting SPR plots (group {igroup})")
       }
       plotinfo <-
         SSplotSPR(
@@ -1004,7 +1004,7 @@ SS_plots <-
           nrow(replist[["discard"]]) > 0
       ) {
         if (verbose) {
-          cli::cli_inform("Starting discard plot (group {igroup})")
+          cli::cli_alert_info("Starting discard plot (group {igroup})")
         }
         plotinfo <-
           SSplotDiscard(
@@ -1025,7 +1025,7 @@ SS_plots <-
         if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
       } else {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping discard plot (group {igroup}) because no discard data"
           )
         }
@@ -1043,7 +1043,7 @@ SS_plots <-
           nrow(replist[["mnwgt"]]) > 0
       ) {
         if (verbose) {
-          cli::cli_inform("Starting mean body weight plot (group {igroup})")
+          cli::cli_alert_info("Starting mean body weight plot (group {igroup})")
         }
         plotinfo <-
           SSplotMnwt(
@@ -1064,7 +1064,7 @@ SS_plots <-
         if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
       } else {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping mean weight plot (group {igroup}) because no mean weight data"
           )
         }
@@ -1078,7 +1078,7 @@ SS_plots <-
     if (igroup %in% plot) {
       if (!is.null(dim(replist[["cpue"]]))) {
         if (verbose) {
-          cli::cli_inform("Starting index plots (group {igroup})")
+          cli::cli_alert_info("Starting index plots (group {igroup})")
         }
         plotinfo <- SSplotIndices(
           replist = replist,
@@ -1102,7 +1102,7 @@ SS_plots <-
         if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
       } else {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping index plots (group {igroup}) because no indices in model (or are not reported)"
           )
         }
@@ -1116,7 +1116,7 @@ SS_plots <-
     if (igroup %in% plot) {
       if (!is.null(replist[["natage"]])) {
         if (verbose) {
-          cli::cli_inform("Starting numbers at age plots (group {igroup})")
+          cli::cli_alert_info("Starting numbers at age plots (group {igroup})")
         }
         plotinfo <-
           SSplotNumbers(
@@ -1141,7 +1141,7 @@ SS_plots <-
           plotInfoTable <- rbind(plotInfoTable, plotinfo)
         }
       } else {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Skipping numbers plots (group {igroup}) because numbers-at-age table not included in output"
         )
         # end check for numbers-at-age table available
@@ -1153,7 +1153,7 @@ SS_plots <-
     #
     # use of SSplotcomps function to make composition plots
     if (is.null(comp_data_exists) || !comp_data_exists) {
-      cli::cli_inform("No composition data, skipping all composition plots")
+      cli::cli_alert_warning("No composition data, skipping all composition plots")
     } else {
       lenCompDatGroup <- 13
       ageCompDatGroup <- 14
@@ -1166,7 +1166,7 @@ SS_plots <-
           )) >
             0
         ) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping plot groups {lenCompDatGroup}-{condCompDatGroup} (comp data without fit) because input 'datplot=FALSE'"
           )
         }
@@ -1174,7 +1174,7 @@ SS_plots <-
         if (lenCompDatGroup %in% plot) {
           # data only aspects
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_info(
               "Starting length comp data plots (group {lenCompDatGroup})"
             )
           }
@@ -1314,7 +1314,7 @@ SS_plots <-
         }
         if (ageCompDatGroup %in% plot) {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_info(
               "Starting age comp data plots (group {ageCompDatGroup})"
             )
           }
@@ -1448,7 +1448,7 @@ SS_plots <-
         }
         if (condCompDatGroup %in% plot) {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_info(
               "Starting conditional comp data plots (group {condCompDatGroup})"
             )
           }
@@ -1515,7 +1515,7 @@ SS_plots <-
       igroup <- 16
       if (igroup %in% plot) {
         if (verbose) {
-          cli::cli_inform("Starting fit to length comp plots (group {igroup})")
+          cli::cli_alert_info("Starting fit to length comp plots (group {igroup})")
         }
         # regular length comps
         plotinfo <-
@@ -1717,7 +1717,7 @@ SS_plots <-
       igroup <- 17
       if (igroup %in% plot) {
         if (verbose) {
-          cli::cli_inform("Starting fit to age comp plots (group {igroup})")
+          cli::cli_alert_info("Starting fit to age comp plots (group {igroup})")
         }
         # normal marginal ages
         plotinfo <-
@@ -1858,7 +1858,7 @@ SS_plots <-
       igroup <- 18
       if (igroup %in% plot) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Starting fit to conditional age-at-length comp plots (group {igroup})"
           )
         }
@@ -2024,13 +2024,13 @@ SS_plots <-
         if (nrow(replist[["condbase"]]) > 0) {
           if (replist[["nagebins"]] == 1) {
             if (verbose) {
-              cli::cli_inform(
+              cli::cli_alert_warning(
                 "Skipping conditional age-at-length diagnostic plots (group {igroup}) due to only 1 age bin"
               )
             }
           } else {
             if (verbose) {
-              cli::cli_inform(
+              cli::cli_alert_info(
                 "Starting conditional age-at-length diagnostic plots (group {igroup})"
               )
             }
@@ -2086,7 +2086,7 @@ SS_plots <-
           }
         } else {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "Skipping conditional A@L plots (group {igroup}) because no such data in model"
             )
           }
@@ -2099,7 +2099,7 @@ SS_plots <-
       igroup <- 20
       if (igroup %in% plot) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Starting mean length-at-age and mean weight-at-age plots (group {igroup})"
           )
         }
@@ -2287,13 +2287,13 @@ SS_plots <-
           is.null(replist[["tagdbase2"]]) || nrow(replist[["tagdbase2"]]) == 0
         ) {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "Skipping tag plots (group {igroup}) because no tag data in model"
             )
           }
         } else {
           if (verbose) {
-            cli::cli_inform("Starting tag plots (group {igroup})")
+            cli::cli_alert_info("Starting tag plots (group {igroup})")
           }
           plotinfo <-
             SSplotTags(
@@ -2329,7 +2329,7 @@ SS_plots <-
     igroup <- 22
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform("Starting yield plots (group {igroup})")
+        cli::cli_alert_info("Starting yield plots (group {igroup})")
       }
       plotinfo <-
         SSplotYield(
@@ -2355,7 +2355,7 @@ SS_plots <-
     if (igroup %in% plot) {
       if (!is.null(replist[["movement"]]) && nrow(replist[["movement"]]) > 0) {
         if (verbose) {
-          cli::cli_inform("Starting movement rate plots (group {igroup})")
+          cli::cli_alert_info("Starting movement rate plots (group {igroup})")
         }
         plotinfo <- NULL
         temp <-
@@ -2375,7 +2375,7 @@ SS_plots <-
         if (!is.null(plotinfo)) plotInfoTable <- rbind(plotInfoTable, plotinfo)
       } else {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping movement plots (group {igroup}) because no movement in model"
           )
         }
@@ -2388,7 +2388,7 @@ SS_plots <-
     igroup <- 24
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform("Starting data range plots (group {igroup})")
+        cli::cli_alert_info("Starting data range plots (group {igroup})")
       }
       plotinfo <- NULL
       temp <-
@@ -2421,7 +2421,7 @@ SS_plots <-
     igroup <- 25
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Starting parameter distribution plots (group {igroup})"
         )
       }
@@ -2457,7 +2457,7 @@ SS_plots <-
       dev.off()
     } # close PDF file if it was open
     if (verbose) {
-      cli::cli_inform("Finished all requested plots in SS_plots function")
+      cli::cli_alert_success("Finished all requested plots in SS_plots function")
     }
 
     ##########################################
@@ -2467,18 +2467,18 @@ SS_plots <-
     if (igroup %in% plot) {
       if (nrow(replist[["estimated_non_dev_parameters"]]) == 0) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping diagnostic tables (group {igroup}) because there are no estimated non-dev parameters"
           )
         }
       } else {
         if (!png) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping diagnostic tables (group {igroup}) because png=FALSE"
           )
         } else {
           if (verbose) {
-            cli::cli_inform("Starting diagnostic tables (group {igroup})")
+            cli::cli_alert_info("Starting diagnostic tables (group {igroup})")
           }
 
           plotinfo <- NULL
@@ -2523,7 +2523,7 @@ SS_plots <-
       }
       write.csv(plotInfoTable, csvname, row.names = FALSE)
       if (verbose) {
-        cli::cli_inform("Wrote table of info on PNG files to: {csvname}")
+        cli::cli_alert_success("Wrote table of info on PNG files to: {csvname}")
       }
       # write HTML files to display the images
       if (html) {

--- a/R/SS_plots.R
+++ b/R/SS_plots.R
@@ -461,7 +461,9 @@ SS_plots <-
       dir.isdir <- file.info(dir)[["isdir"]]
       # create directory
       if (is.na(dir.isdir) | !dir.isdir) {
-        cli::cli_alert_warning("Directory doesn't exist, attempting to create: {dir}")
+        cli::cli_alert_warning(
+          "Directory doesn't exist, attempting to create: {dir}"
+        )
         dir.create(dir)
       }
       # test again (even though failure to create dir should have already caused error)
@@ -780,7 +782,9 @@ SS_plots <-
 
       ### add plot of Dynamic B0
       if (is.null(replist[["Dynamic_Bzero"]])) {
-        cli::cli_alert_warning("Skipping dynamic B0 plot because output not available")
+        cli::cli_alert_warning(
+          "Skipping dynamic B0 plot because output not available"
+        )
       } else {
         # first get vector of years
         yrs <- replist[["startyr"]]:(replist[["endyr"]] + 1)
@@ -813,7 +817,9 @@ SS_plots <-
     igroup <- 4
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_alert_info("Starting recruitment deviation plots (group {igroup})")
+        cli::cli_alert_info(
+          "Starting recruitment deviation plots (group {igroup})"
+        )
       }
       plotinfo <-
         SSplotRecdevs(
@@ -909,7 +915,9 @@ SS_plots <-
     igroup <- 6
     if (igroup %in% plot) {
       if (verbose) {
-        cli::cli_alert_info("Starting spawner-recruit curve plot (group {igroup})")
+        cli::cli_alert_info(
+          "Starting spawner-recruit curve plot (group {igroup})"
+        )
       }
       plotinfo <-
         SSplotSpawnrecruit(
@@ -1153,7 +1161,9 @@ SS_plots <-
     #
     # use of SSplotcomps function to make composition plots
     if (is.null(comp_data_exists) || !comp_data_exists) {
-      cli::cli_alert_warning("No composition data, skipping all composition plots")
+      cli::cli_alert_warning(
+        "No composition data, skipping all composition plots"
+      )
     } else {
       lenCompDatGroup <- 13
       ageCompDatGroup <- 14
@@ -1515,7 +1525,9 @@ SS_plots <-
       igroup <- 16
       if (igroup %in% plot) {
         if (verbose) {
-          cli::cli_alert_info("Starting fit to length comp plots (group {igroup})")
+          cli::cli_alert_info(
+            "Starting fit to length comp plots (group {igroup})"
+          )
         }
         # regular length comps
         plotinfo <-
@@ -2457,7 +2469,9 @@ SS_plots <-
       dev.off()
     } # close PDF file if it was open
     if (verbose) {
-      cli::cli_alert_success("Finished all requested plots in SS_plots function")
+      cli::cli_alert_success(
+        "Finished all requested plots in SS_plots function"
+      )
     }
 
     ##########################################

--- a/R/SS_readctl_3.24.R
+++ b/R/SS_readctl_3.24.R
@@ -66,7 +66,7 @@ SS_readctl_3.24 <- function(
   # function to read Stock Synthesis data files
 
   if (verbose) {
-    cli::cli_inform("running SS_readctl_3.24")
+    cli::cli_alert_info("running SS_readctl_3.24")
   }
   dat <- readLines(file, warn = FALSE)
 
@@ -118,7 +118,7 @@ SS_readctl_3.24 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{name}, i = {ctllist[['.i']]}: {paste(ctllist[name], sep = '', collapse = '\n')}"
       )
     }
@@ -148,7 +148,7 @@ SS_readctl_3.24 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{name}, i = {ctllist[['.i']]}: {paste(ctllist[[which(names(ctllist) == name)]], sep = '', collapse = '\n')}"
       )
     }
@@ -164,7 +164,7 @@ SS_readctl_3.24 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{name}, i = {ctllist[['.i']]} ;{ctllist[[which(names(ctllist) == name)]]}"
       )
     }
@@ -185,7 +185,7 @@ SS_readctl_3.24 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform("{name}, i = {ctllist[['.i']]}")
+      cli::cli_alert_info("{name}, i = {ctllist[['.i']]}")
     }
     return(ctllist)
   }
@@ -277,7 +277,7 @@ SS_readctl_3.24 <- function(
   )
   srt_par_colnames <- c("LO", "HI", "INIT", "PRIOR", "PR_type", "SD", "PHASE")
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "SS_readctl_3.24 - read version = {ctllist[['ReadVersion']]}"
     )
   }
@@ -391,7 +391,7 @@ SS_readctl_3.24 <- function(
     )
   }
   if (verbose) {
-    cli::cli_inform("N_natMparms = {N_natMparms}")
+    cli::cli_alert_info("N_natMparms = {N_natMparms}")
   }
   # growth setup ----
   ctllist <- add_elem(ctllist, name = "GrowthModel")
@@ -1452,7 +1452,7 @@ SS_readctl_3.24 <- function(
     }
   }
   if (verbose) {
-    cli::cli_inform("Read size and age selectivity setup")
+    cli::cli_alert_info("Read size and age selectivity setup")
   }
   # Selex parlines ----
   # _LO HI INIT PRIOR PR_type SD PHASE env-var use_dev dev_minyr dev_maxyr dev_stddev Block Block_Fxn
@@ -1830,11 +1830,11 @@ SS_readctl_3.24 <- function(
   }
   if (ctllist$".dat"[ctllist$".i"] == 999) {
     if (verbose) {
-      cli::cli_inform("read of control file complete (final value = 999)")
+      cli::cli_alert_info("read of control file complete (final value = 999)")
     }
     ctllist[["eof"]] <- TRUE
   } else {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Error: final value is {ctllist[['.dat']][ctllist[['.i']]]}, but should be 999"
     )
     ctllist[["eof"]] <- FALSE

--- a/R/SS_readctl_3.30.R
+++ b/R/SS_readctl_3.30.R
@@ -58,7 +58,7 @@ SS_readctl_3.30 <- function(
 
   # function to read Stock Synthesis data files
   if (verbose) {
-    cli::cli_inform("running SS_readctl_3.30")
+    cli::cli_alert_info("running SS_readctl_3.30")
   }
   dat <- readLines(file, warn = FALSE)
   ctl_with_cmts <- dat # save original read in file with commemts
@@ -109,7 +109,7 @@ SS_readctl_3.30 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform("{name}, i={ctllist[['.i']]}")
+      cli::cli_alert_info("{name}, i={ctllist[['.i']]}")
     }
     return(ctllist)
   }
@@ -179,7 +179,7 @@ SS_readctl_3.30 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform("{name},i={ctllist[['.i']]}")
+      cli::cli_alert_info("{name},i={ctllist[['.i']]}")
     }
     return(ctllist)
   }
@@ -194,7 +194,7 @@ SS_readctl_3.30 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{name},i={ctllist[['.i']]} ;{ctllist[[which(names(ctllist) == name)]]}"
       )
     }
@@ -215,7 +215,7 @@ SS_readctl_3.30 <- function(
       names(ctllist)[names(ctllist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform("{name},i={ctllist[['.i']]}")
+      cli::cli_alert_info("{name},i={ctllist[['.i']]}")
     }
     return(ctllist)
   }
@@ -327,7 +327,7 @@ SS_readctl_3.30 <- function(
   ctllist[["eof"]] <- FALSE
 
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "SS_readctl_3.30 - read version = {ctllist[['ReadVersion']]}"
     )
   }
@@ -451,7 +451,7 @@ SS_readctl_3.30 <- function(
     )
   }
   if (verbose) {
-    cli::cli_inform("N_natMparms ={N_natMparms}")
+    cli::cli_alert_info("N_natMparms ={N_natMparms}")
   }
 
   # growth setup ----
@@ -793,7 +793,7 @@ SS_readctl_3.30 <- function(
           flt
         })
         pred_indices <- unlist(tmp_pred_flts)
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Based on control file parameter names, assuming there are {length(pred_indices)} predation mortality parameters in MGparms."
         )
       } else {
@@ -938,7 +938,7 @@ SS_readctl_3.30 <- function(
       "SR_autocorr"
     )
   } else {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "SR_function = {ctllist[['SR_function']]} is not supported yet."
     )
     return(ctllist)
@@ -1689,7 +1689,7 @@ SS_readctl_3.30 <- function(
     }
   }
   if (verbose) {
-    cli::cli_inform("Read size and age selectivity setup.")
+    cli::cli_alert_info("Read size and age selectivity setup.")
   }
   # Selex parameters
   if (sum(length(unlist(size_selex_label))) > 0) {
@@ -2146,7 +2146,7 @@ SS_readctl_3.30 <- function(
   }
   if (ctllist$".dat"[ctllist$".i"] == 999) {
     if (verbose) {
-      cli::cli_inform("read of control file complete (final value = 999)")
+      cli::cli_alert_info("read of control file complete (final value = 999)")
     }
     ctllist[["eof"]] <- TRUE
   } else {
@@ -2360,7 +2360,7 @@ translate_3.30_to_3.24_Q_setup <- function(
       }
     }
   } else {
-    cli::cli_inform("Q_options was NULL, so could not determine Q_setup.")
+    cli::cli_alert_info("Q_options was NULL, so could not determine Q_setup.")
     Q_setup <- NULL
   }
   Q_setup

--- a/R/SS_readdat_2.00.R
+++ b/R/SS_readdat_2.00.R
@@ -42,7 +42,7 @@ SS_readdat_2.00 <- function(
   }
 
   if (verbose) {
-    cli::cli_inform("running SS_readdat_2.00")
+    cli::cli_alert_info("running SS_readdat_2.00")
   }
   dat <- readLines(file, warn = FALSE)
 
@@ -92,7 +92,7 @@ SS_readdat_2.00 <- function(
   datlist[["type"]] <- "Stock_Synthesis_data_file"
   datlist[["ReadVersion"]] <- "2.00"
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "SS_readdat_2.00 - read version = {datlist[['ReadVersion']]}"
     )
   }
@@ -167,8 +167,8 @@ SS_readdat_2.00 <- function(
   datlist[["areas"]] <- 1
   areas <- datlist[["areas"]]
   if (verbose) {
-    cli::cli_inform("areas: {areas}")
-    cli::cli_inform(
+    cli::cli_alert_info("areas: {areas}")
+    cli::cli_alert_info(
       "fleet info: {paste(utils::capture.output(
           data.frame(
             fleet = 1:Ntypes,
@@ -200,7 +200,7 @@ SS_readdat_2.00 <- function(
 
   # catch
   if (verbose) {
-    cli::cli_inform("N_catch ={N_catch}")
+    cli::cli_alert_info("N_catch ={N_catch}")
   }
   Nvals <- N_catch * (Nfleet)
   catch <- data.frame(matrix(
@@ -222,7 +222,7 @@ SS_readdat_2.00 <- function(
   datlist[["N_cpue"]] <- N_cpue <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_cpue ={N_cpue}")
+    cli::cli_alert_info("N_cpue ={N_cpue}")
   }
   if (N_cpue > 0) {
     CPUEinfo <- data.frame(matrix(
@@ -256,7 +256,7 @@ SS_readdat_2.00 <- function(
   i <- i + 1
 
   if (verbose) {
-    cli::cli_inform("N_discard ={N_discard}")
+    cli::cli_alert_info("N_discard ={N_discard}")
   }
   if (N_discard > 0) {
     # discard data
@@ -296,7 +296,7 @@ SS_readdat_2.00 <- function(
   datlist[["N_meanbodywt"]] <- N_meanbodywt <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_meanbodywt ={N_meanbodywt}")
+    cli::cli_alert_info("N_meanbodywt ={N_meanbodywt}")
   }
 
   if (N_meanbodywt > 0) {
@@ -340,7 +340,7 @@ SS_readdat_2.00 <- function(
   i <- i + 1
 
   if (verbose) {
-    cli::cli_inform("N_lencomp ={N_lencomp}")
+    cli::cli_alert_info("N_lencomp ={N_lencomp}")
   }
 
   if (N_lencomp > 0) {
@@ -379,7 +379,7 @@ SS_readdat_2.00 <- function(
   datlist[["N_agebins"]] <- N_agebins <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_agebins ={N_agebins}")
+    cli::cli_alert_info("N_agebins ={N_agebins}")
   }
   if (N_agebins > 0) {
     agebin_vector <- allnums[i:(i + N_agebins - 1)]
@@ -409,7 +409,7 @@ SS_readdat_2.00 <- function(
   datlist[["N_agecomp"]] <- N_agecomp <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_agecomp ={N_agecomp}")
+    cli::cli_alert_info("N_agecomp ={N_agecomp}")
   }
 
   datlist[["Lbin_method"]] <- NULL
@@ -460,7 +460,7 @@ SS_readdat_2.00 <- function(
   datlist[["N_MeanSize_at_Age_obs"]] <- N_MeanSize_at_Age_obs <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_MeanSize_at_Age_obs ={N_MeanSize_at_Age_obs}")
+    cli::cli_alert_info("N_MeanSize_at_Age_obs ={N_MeanSize_at_Age_obs}")
   }
   if (N_MeanSize_at_Age_obs > 0) {
     Ncols <- 2 * N_agebins * datlist[["Nsexes"]] + 7
@@ -533,7 +533,7 @@ SS_readdat_2.00 <- function(
 
   if (allnums[i] == 999) {
     if (verbose) {
-      cli::cli_inform("read of data file 2.00 complete (final value = 999)")
+      cli::cli_alert_info("read of data file 2.00 complete (final value = 999)")
     }
     datlist[["eof"]] <- TRUE
   } else {

--- a/R/SS_readdat_3.00.R
+++ b/R/SS_readdat_3.00.R
@@ -43,7 +43,7 @@ SS_readdat_3.00 <- function(
   }
 
   if (verbose) {
-    cli::cli_inform("running SS_readdat_3.00")
+    cli::cli_alert_info("running SS_readdat_3.00")
   }
   dat <- readLines(file, warn = FALSE)
 
@@ -122,7 +122,7 @@ SS_readdat_3.00 <- function(
   datlist[["type"]] <- "Stock_Synthesis_data_file"
   datlist[["ReadVersion"]] <- "3.00"
   if (verbose) {
-    cli::cli_inform("SS_readdat_3.00 - SS version = {datlist[['ReadVersion']]}")
+    cli::cli_alert_info("SS_readdat_3.00 - SS version = {datlist[['ReadVersion']]}")
   }
 
   # model dimensions
@@ -172,8 +172,8 @@ SS_readdat_3.00 <- function(
   datlist[["areas"]] <- areas <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
   if (verbose) {
-    cli::cli_inform("areas: {areas}")
-    cli::cli_inform(
+    cli::cli_alert_info("areas: {areas}")
+    cli::cli_alert_info(
       "fleet info: {paste(utils::capture.output(
           data.frame(
             fleet = 1:Ntypes,
@@ -212,7 +212,7 @@ SS_readdat_3.00 <- function(
   datlist[["N_catch"]] <- N_catch <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_catch ={N_catch}")
+    cli::cli_alert_info("N_catch ={N_catch}")
   }
   Nvals <- N_catch * (Nfleet + 2)
   catch <- data.frame(matrix(
@@ -231,7 +231,7 @@ SS_readdat_3.00 <- function(
   datlist[["N_cpue"]] <- N_cpue <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_cpue ={N_cpue}")
+    cli::cli_alert_info("N_cpue ={N_cpue}")
   }
   if (N_cpue > 0) {
     CPUEinfo <- data.frame(matrix(
@@ -265,7 +265,7 @@ SS_readdat_3.00 <- function(
   i <- i + 1
 
   if (verbose) {
-    cli::cli_inform("N_discard ={N_discard}")
+    cli::cli_alert_info("N_discard ={N_discard}")
   }
   if (N_discard > 0) {
     # discard data
@@ -330,7 +330,7 @@ SS_readdat_3.00 <- function(
   datlist[["lbin_method"]] <- lbin_method <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("lbin_method ={lbin_method}")
+    cli::cli_alert_info("lbin_method ={lbin_method}")
   }
   if (lbin_method == 2) {
     datlist[["binwidth"]] <- allnums[i]
@@ -349,7 +349,7 @@ SS_readdat_3.00 <- function(
     i <- i + 1
     datlist[["lbin_vector_pop"]] <- allnums[i:(i + N_lbinspop - 1)]
     i <- i + N_lbinspop
-    if (verbose) cli::cli_inform("N_lbinspop ={N_lbinspop} lbin_vector_pop:")
+    if (verbose) cli::cli_alert_info("N_lbinspop ={N_lbinspop} lbin_vector_pop:")
   } else {
     datlist[["N_lbinspop"]] <- NA
     datlist[["lbin_vector_pop"]] <- NA
@@ -411,7 +411,7 @@ SS_readdat_3.00 <- function(
   datlist[["N_agebins"]] <- N_agebins <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_agebins ={N_agebins}")
+    cli::cli_alert_info("N_agebins ={N_agebins}")
   }
   if (N_agebins > 0) {
     agebin_vector <- allnums[i:(i + N_agebins - 1)]
@@ -491,7 +491,7 @@ SS_readdat_3.00 <- function(
   datlist[["N_MeanSize_at_Age_obs"]] <- N_MeanSize_at_Age_obs <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_MeanSize_at_Age_obs ={N_MeanSize_at_Age_obs}")
+    cli::cli_alert_info("N_MeanSize_at_Age_obs ={N_MeanSize_at_Age_obs}")
   }
   if (N_MeanSize_at_Age_obs > 0) {
     Ncols <- 2 * N_agebins * datlist[["Nsexes"]] + 7
@@ -565,7 +565,7 @@ SS_readdat_3.00 <- function(
   datlist[["N_sizefreq_methods"]] <- N_sizefreq_methods <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_sizefreq_methods ={N_sizefreq_methods}")
+    cli::cli_alert_info("N_sizefreq_methods ={N_sizefreq_methods}")
   }
   if (N_sizefreq_methods > 0) {
     # get details of generalized size frequency methods
@@ -634,7 +634,7 @@ SS_readdat_3.00 <- function(
           }
         )
       if (verbose) {
-        cli::cli_inform("Method ={imethod} (first two rows, ten columns):")
+        cli::cli_alert_info("Method ={imethod} (first two rows, ten columns):")
         print(sizefreq_data_tmp[1:min(Nrows, 2), 1:min(Ncols, 10)])
       }
       if (any(sizefreq_data_tmp[["Method"]] != imethod)) {
@@ -659,7 +659,7 @@ SS_readdat_3.00 <- function(
   datlist[["do_tags"]] <- do_tags <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("do_tags ={do_tags}")
+    cli::cli_alert_info("do_tags ={do_tags}")
   }
 
   if (do_tags != 0) {
@@ -693,7 +693,7 @@ SS_readdat_3.00 <- function(
         "Nrelease"
       )
       if (verbose) {
-        cli::cli_inform("Head of tag release data:")
+        cli::cli_alert_info("Head of tag release data:")
         print(head(tag_releases))
       }
     } else {
@@ -713,7 +713,7 @@ SS_readdat_3.00 <- function(
       i <- i + N_recap_events * Ncols
       names(tag_recaps) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
       if (verbose) {
-        cli::cli_inform("Head of tag recapture data:")
+        cli::cli_alert_info("Head of tag recapture data:")
         print(head(tag_recaps))
       }
     } else {
@@ -725,16 +725,16 @@ SS_readdat_3.00 <- function(
   datlist[["morphcomp_data"]] <- do_morphcomps <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("do_morphcomps ={do_morphcomps}")
+    cli::cli_alert_info("do_morphcomps ={do_morphcomps}")
   }
 
   if (allnums[i] == 999) {
     if (verbose) {
-      cli::cli_inform("read of data file 3.00 complete (final value = 999)")
+      cli::cli_alert_info("read of data file 3.00 complete (final value = 999)")
     }
     datlist[["eof"]] <- TRUE
   } else {
-    cli::cli_inform("Error: final value is{allnums[i]} but should be 999")
+    cli::cli_alert_info("Error: final value is{allnums[i]} but should be 999")
     datlist[["eof"]] <- FALSE
   }
 

--- a/R/SS_readdat_3.00.R
+++ b/R/SS_readdat_3.00.R
@@ -122,7 +122,9 @@ SS_readdat_3.00 <- function(
   datlist[["type"]] <- "Stock_Synthesis_data_file"
   datlist[["ReadVersion"]] <- "3.00"
   if (verbose) {
-    cli::cli_alert_info("SS_readdat_3.00 - SS version = {datlist[['ReadVersion']]}")
+    cli::cli_alert_info(
+      "SS_readdat_3.00 - SS version = {datlist[['ReadVersion']]}"
+    )
   }
 
   # model dimensions
@@ -349,7 +351,9 @@ SS_readdat_3.00 <- function(
     i <- i + 1
     datlist[["lbin_vector_pop"]] <- allnums[i:(i + N_lbinspop - 1)]
     i <- i + N_lbinspop
-    if (verbose) cli::cli_alert_info("N_lbinspop ={N_lbinspop} lbin_vector_pop:")
+    if (verbose) {
+      cli::cli_alert_info("N_lbinspop ={N_lbinspop} lbin_vector_pop:")
+    }
   } else {
     datlist[["N_lbinspop"]] <- NA
     datlist[["lbin_vector_pop"]] <- NA

--- a/R/SS_readdat_3.24.R
+++ b/R/SS_readdat_3.24.R
@@ -118,7 +118,9 @@ SS_readdat_3.24 <- function(
   datlist[["type"]] <- "Stock_Synthesis_data_file"
   datlist[["SSversion"]] <- "3.24"
   if (verbose) {
-    cli::cli_alert_info("SS_readdat_3.24 - SS version = {datlist[['SSversion']]}")
+    cli::cli_alert_info(
+      "SS_readdat_3.24 - SS version = {datlist[['SSversion']]}"
+    )
   }
 
   # model dimensions

--- a/R/SS_readdat_3.24.R
+++ b/R/SS_readdat_3.24.R
@@ -41,7 +41,7 @@ SS_readdat_3.24 <- function(
   # function to read Stock Synthesis data files
 
   if (verbose) {
-    cli::cli_inform("running SS_readdat_3.24")
+    cli::cli_alert_info("running SS_readdat_3.24")
   }
   dat <- readLines(file, warn = FALSE)
 
@@ -118,7 +118,7 @@ SS_readdat_3.24 <- function(
   datlist[["type"]] <- "Stock_Synthesis_data_file"
   datlist[["SSversion"]] <- "3.24"
   if (verbose) {
-    cli::cli_inform("SS_readdat_3.24 - SS version = {datlist[['SSversion']]}")
+    cli::cli_alert_info("SS_readdat_3.24 - SS version = {datlist[['SSversion']]}")
   }
 
   # model dimensions
@@ -167,8 +167,8 @@ SS_readdat_3.24 <- function(
   datlist[["areas"]] <- areas <- allnums[i:(i + Ntypes - 1)]
   i <- i + Ntypes
   if (verbose) {
-    cli::cli_inform("areas: {areas}")
-    cli::cli_inform(
+    cli::cli_alert_info("areas: {areas}")
+    cli::cli_alert_info(
       "fleet info: {paste(utils::capture.output(
           data.frame(
             fleet = 1:Ntypes,
@@ -207,7 +207,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_catch"]] <- N_catch <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_catch ={N_catch}")
+    cli::cli_alert_info("N_catch ={N_catch}")
   }
   Nvals <- N_catch * (Nfleet + 2)
   catch <- data.frame(matrix(
@@ -224,7 +224,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_cpue"]] <- N_cpue <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_cpue ={N_cpue}")
+    cli::cli_alert_info("N_cpue ={N_cpue}")
   }
   CPUEinfo <- data.frame(matrix(
     allnums[i:(i + Ntypes * 3 - 1)],
@@ -254,7 +254,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_discard_fleets"]] <- N_discard_fleets <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_discard_fleets ={N_discard_fleets}")
+    cli::cli_alert_info("N_discard_fleets ={N_discard_fleets}")
   }
   N_discard <- 0 # temporarily set to 0
   if (N_discard_fleets > 0) {
@@ -274,7 +274,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_discard"]] <- N_discard <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_discard ={N_discard}")
+    cli::cli_alert_info("N_discard ={N_discard}")
   }
   if (N_discard > 0) {
     # discard data
@@ -297,7 +297,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_meanbodywt"]] <- N_meanbodywt <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_meanbodywt ={N_meanbodywt}")
+    cli::cli_alert_info("N_meanbodywt ={N_meanbodywt}")
   }
   datlist[["DF_for_meanbodywt"]] <- allnums[i]
   i <- i + 1
@@ -358,7 +358,7 @@ SS_readdat_3.24 <- function(
   i <- i + 1
 
   if (verbose) {
-    cli::cli_inform("N_lencomp ={N_lencomp}")
+    cli::cli_alert_info("N_lencomp ={N_lencomp}")
   }
 
   if (N_lencomp > 0) {
@@ -397,7 +397,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_agebins"]] <- N_agebins <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_agebins ={N_agebins}")
+    cli::cli_alert_info("N_agebins ={N_agebins}")
   }
   if (N_agebins > 0) {
     agebin_vector <- allnums[i:(i + N_agebins - 1)]
@@ -427,7 +427,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_agecomp"]] <- N_agecomp <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_agecomp ={N_agecomp}")
+    cli::cli_alert_info("N_agecomp ={N_agecomp}")
   }
 
   # note that Lbin_method below is related to the interpretation of
@@ -483,7 +483,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_MeanSize_at_Age_obs"]] <- N_MeanSize_at_Age_obs <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_MeanSize_at_Age_obs ={N_MeanSize_at_Age_obs}")
+    cli::cli_alert_info("N_MeanSize_at_Age_obs ={N_MeanSize_at_Age_obs}")
   }
   if (N_MeanSize_at_Age_obs > 0) {
     Ncols <- 2 * N_agebins * datlist[["Nsexes"]] + 7
@@ -557,7 +557,7 @@ SS_readdat_3.24 <- function(
   datlist[["N_sizefreq_methods"]] <- N_sizefreq_methods <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("N_sizefreq_methods ={N_sizefreq_methods}")
+    cli::cli_alert_info("N_sizefreq_methods ={N_sizefreq_methods}")
   }
   if (N_sizefreq_methods > 0) {
     # get details of generalized size frequency methods
@@ -582,7 +582,7 @@ SS_readdat_3.24 <- function(
     ]
     i <- i + N_sizefreq_methods
     if (verbose) {
-      cli::cli_inform("details of generalized size frequency methods:")
+      cli::cli_alert_info("details of generalized size frequency methods:")
       print(data.frame(
         method = 1:N_sizefreq_methods,
         nbins = nbins_per_method,
@@ -636,7 +636,7 @@ SS_readdat_3.24 <- function(
           }
         )
       if (verbose) {
-        cli::cli_inform("Method ={imethod} (first two rows, ten columns):")
+        cli::cli_alert_info("Method ={imethod} (first two rows, ten columns):")
         print(sizefreq_data_tmp[1:min(Nrows, 2), 1:min(Ncols, 10)])
       }
       if (any(sizefreq_data_tmp[["Method"]] != imethod)) {
@@ -661,7 +661,7 @@ SS_readdat_3.24 <- function(
   datlist[["do_tags"]] <- do_tags <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("do_tags ={do_tags}")
+    cli::cli_alert_info("do_tags ={do_tags}")
   }
 
   if (do_tags != 0) {
@@ -695,7 +695,7 @@ SS_readdat_3.24 <- function(
         "Nrelease"
       )
       if (verbose) {
-        cli::cli_inform("Head of tag release data:")
+        cli::cli_alert_info("Head of tag release data:")
         print(head(tag_releases))
       }
     } else {
@@ -715,7 +715,7 @@ SS_readdat_3.24 <- function(
       i <- i + N_recap_events * Ncols
       names(tag_recaps) <- c("TG", "Yr", "Season", "Fleet", "Nrecap")
       if (verbose) {
-        cli::cli_inform("Head of tag recapture data:")
+        cli::cli_alert_info("Head of tag recapture data:")
         print(head(tag_recaps))
       }
     } else {
@@ -727,12 +727,12 @@ SS_readdat_3.24 <- function(
   datlist[["morphcomp_data"]] <- do_morphcomps <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("do_morphcomps ={do_morphcomps}")
+    cli::cli_alert_info("do_morphcomps ={do_morphcomps}")
   }
 
   if (allnums[i] == 999) {
     if (verbose) {
-      cli::cli_inform("read of data file complete (final value = 999)")
+      cli::cli_alert_info("read of data file complete (final value = 999)")
     }
   } else {
     cli::cli_abort("Final value is{allnums[i]} but should be 999")

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -822,7 +822,9 @@ SS_readdat_3.30 <-
     eof <- get.val(dat, ind)
     if (verbose) {
       if (Nsections == 1) {
-        cli::cli_alert_success("Read of data file complete. Final value = {eof}")
+        cli::cli_alert_success(
+          "Read of data file complete. Final value = {eof}"
+        )
       } else {
         cli::cli_alert_success(
           "Read of section {section} of data file complete. Final value = {eof}"

--- a/R/SS_readdat_3.30.R
+++ b/R/SS_readdat_3.30.R
@@ -36,7 +36,7 @@ SS_readdat_3.30 <-
     }
 
     if (verbose) {
-      cli::cli_inform("Running SS_readdat_3.30")
+      cli::cli_alert_info("Running SS_readdat_3.30")
     }
     dat <- readLines(file, warn = FALSE)
     if (length(dat) < 20) {
@@ -74,7 +74,7 @@ SS_readdat_3.30 <-
     }
     if (is.null(section)) {
       if (Nsections > 1 & verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "The supplied data file has {Nsections}{ifelse(Nsections == 1, ' section. ', ' sections. ')} Using section = 1."
         )
       }
@@ -191,7 +191,7 @@ SS_readdat_3.30 <-
     datlist[["N_areas"]] <- get.val(dat, ind)
     datlist[["Nfleets"]] <- get.val(dat, ind)
     if (verbose) {
-      cli::cli_inform("Read general model dimensions.")
+      cli::cli_alert_info("Read general model dimensions.")
     }
     ## Fleet data ----
     datlist[["fleetinfo"]] <- get.df(dat, ind, datlist[["Nfleets"]])
@@ -219,7 +219,7 @@ SS_readdat_3.30 <-
       )
     }
     if (verbose) {
-      cli::cli_inform("Read fleet information.")
+      cli::cli_alert_info("Read fleet information.")
     }
 
     datlist[["fleetnames"]] <- datlist[["fleetinfo"]][["fleetname"]]
@@ -254,7 +254,7 @@ SS_readdat_3.30 <-
         ]
       )
       if (verbose) {
-        cli::cli_inform("Read bycatch data.")
+        cli::cli_alert_info("Read bycatch data.")
       }
     }
 
@@ -268,7 +268,7 @@ SS_readdat_3.30 <-
       "catch_se"
     )
     if (verbose) {
-      cli::cli_inform("Read catches.")
+      cli::cli_alert_info("Read catches.")
     }
     ## CPUE data  ----
     datlist[["CPUEinfo"]] <- get.df(dat, ind, datlist[["Nfleets"]])
@@ -280,7 +280,7 @@ SS_readdat_3.30 <-
     rownames(datlist[["CPUEinfo"]]) <- datlist[["fleetnames"]]
 
     if (verbose) {
-      cli::cli_inform("Read CPUE data.")
+      cli::cli_alert_info("Read CPUE data.")
     }
 
     ## CPUE data matrix
@@ -328,7 +328,7 @@ SS_readdat_3.30 <-
         "stderr"
       )
       if (verbose) {
-        cli::cli_inform("Read discards.")
+        cli::cli_alert_info("Read discards.")
       }
     } else {
       datlist[["discard_fleet_info"]] <- NULL
@@ -352,7 +352,7 @@ SS_readdat_3.30 <-
         )
       }
       if (verbose) {
-        cli::cli_inform("Read mean body weight.")
+        cli::cli_alert_info("Read mean body weight.")
       }
     } else {
       datlist[["DF_for_meanbodywt"]] <- NULL
@@ -466,7 +466,7 @@ SS_readdat_3.30 <-
       }
 
       if (verbose) {
-        cli::cli_inform("Read Length composition data.")
+        cli::cli_alert_info("Read Length composition data.")
       }
     }
 
@@ -560,7 +560,7 @@ SS_readdat_3.30 <-
       }
 
       if (verbose) {
-        cli::cli_inform("Read age composition data.")
+        cli::cli_alert_info("Read age composition data.")
       }
     }
     # check DM pars ----)
@@ -596,7 +596,7 @@ SS_readdat_3.30 <-
       xx <- dat[ind:endmwa]
       if (length(unique(sapply(strsplit(xx, "\\s+"), length))) > 1) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Format of MeanSize_at_Age_obs appears to have sample sizes on separate lines than other inputs."
           )
         }
@@ -675,7 +675,7 @@ SS_readdat_3.30 <-
       colnames(datlist[["envdat"]]) <- c("year", "variable", "value")
 
       if (verbose) {
-        cli::cli_inform("Read environmental variable data.")
+        cli::cli_alert_info("Read environmental variable data.")
       }
     } else {
       datlist[["envdat"]] <- NULL
@@ -749,7 +749,7 @@ SS_readdat_3.30 <-
         }
       }
       if (verbose) {
-        cli::cli_inform("Read size frequency data.")
+        cli::cli_alert_info("Read size frequency data.")
       }
     } else {
       datlist[["nbins_per_method"]] <- NULL
@@ -800,7 +800,7 @@ SS_readdat_3.30 <-
           "Nrecap"
         )
         if (verbose) {
-          cli::cli_inform("Read tag recapture data.")
+          cli::cli_alert_info("Read tag recapture data.")
         }
       } else {
         datlist[["tag_recaps"]] <- NULL
@@ -822,9 +822,9 @@ SS_readdat_3.30 <-
     eof <- get.val(dat, ind)
     if (verbose) {
       if (Nsections == 1) {
-        cli::cli_inform("Read of data file complete. Final value = {eof}")
+        cli::cli_alert_success("Read of data file complete. Final value = {eof}")
       } else {
-        cli::cli_inform(
+        cli::cli_alert_success(
           "Read of section {section} of data file complete. Final value = {eof}"
         )
       }

--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -37,7 +37,7 @@ SS_readforecast <- function(
   }
 
   if (verbose) {
-    cli::cli_inform("running SS_readforecast")
+    cli::cli_alert_info("running SS_readforecast")
   }
   dat <- readLines(file, warn = FALSE)
 
@@ -85,7 +85,7 @@ SS_readforecast <- function(
       names(forelist)[names(forelist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{name},i={forelist[['.i']]}: {paste(forelist[[name]], sep = '', collapse = '\n')}"
       )
     }
@@ -158,7 +158,7 @@ SS_readforecast <- function(
       names(forelist)[names(forelist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{name},i={forelist[['.i']]}: {paste(forelist[[which(names(forelist) == name)]], sep = '', collapse = '\n')}"
       )
     }
@@ -175,7 +175,7 @@ SS_readforecast <- function(
       names(forelist)[names(forelist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{name},i={forelist[['.i']]} ;{forelist[[which(names(forelist) == name)]]}"
       )
     }
@@ -196,7 +196,7 @@ SS_readforecast <- function(
       names(forelist)[names(forelist) == "temp"] <- name
     }
     if (verbose) {
-      cli::cli_inform("{name},i={forelist[['.i']]}")
+      cli::cli_alert_info("{name},i={forelist[['.i']]}")
     }
     return(forelist)
   }
@@ -246,13 +246,13 @@ SS_readforecast <- function(
     forelist <- add_vec(forelist, length = 10, name = "Bmark_years")
   }
   if (verbose) {
-    cli::cli_inform("Benchmark years: {forelist[['Bmark_years']]}")
+    cli::cli_alert_info("Benchmark years: {forelist[['Bmark_years']]}")
   }
   forelist <- add_elem(forelist, "Bmark_relF_Basis")
   forelist <- add_elem(forelist, "Forecast")
   if (forelist[["Forecast"]] %in% c(0, -1) & !readAll) {
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Forecast is {forelist[['Forecast']]} and input readAll=FALSE so skipping remainder of file"
       )
     }
@@ -266,7 +266,7 @@ SS_readforecast <- function(
     # stop reading if forecast 0 or -1 used, and no other lines present
     # (aside from 999), but readAll = TRUE.
     if (verbose) {
-      cli::cli_inform("Forecast = {forelist[['Forecast']]}")
+      cli::cli_alert_info("Forecast = {forelist[['Forecast']]}")
     }
     cli::cli_warn(
       "readAll selected as TRUE, but lines beyond Forecast are not present in the forecasting file, so skipping remainder of file"
@@ -274,7 +274,7 @@ SS_readforecast <- function(
   } else {
     # continue reading forecast
     if (verbose) {
-      cli::cli_inform("Forecast = {forelist[['Forecast']]}")
+      cli::cli_alert_info("Forecast = {forelist[['Forecast']]}")
     }
     forelist <- add_elem(forelist, "Nforecastyrs")
     # check for compatible input with forecast option 1.
@@ -308,7 +308,7 @@ SS_readforecast <- function(
       )
     }
     if (verbose) {
-      cli::cli_inform("Forecast years: {forelist[['Fcast_years']]}")
+      cli::cli_alert_info("Forecast years: {forelist[['Fcast_years']]}")
     }
     # 3.30 models that don't use the new table input above read
     # additional selectivity setting
@@ -318,7 +318,7 @@ SS_readforecast <- function(
     ) {
       forelist <- add_elem(forelist, "Fcast_selex")
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Forecast selectivity option: {forelist[['Fcast_selex']]}"
         )
       }
@@ -492,7 +492,7 @@ SS_readforecast <- function(
     }
     if (forelist$".dat"[forelist$".i"] == 999) {
       if (verbose) {
-        cli::cli_inform("read of forecast file complete (final value = 999)")
+        cli::cli_alert_info("read of forecast file complete (final value = 999)")
       }
       forelist[["eof"]] <- TRUE
     } else {

--- a/R/SS_readforecast.R
+++ b/R/SS_readforecast.R
@@ -492,7 +492,9 @@ SS_readforecast <- function(
     }
     if (forelist$".dat"[forelist$".i"] == 999) {
       if (verbose) {
-        cli::cli_alert_info("read of forecast file complete (final value = 999)")
+        cli::cli_alert_info(
+          "read of forecast file complete (final value = 999)"
+        )
       }
       forelist[["eof"]] <- TRUE
     } else {

--- a/R/SS_readpar_3.24.R
+++ b/R/SS_readpar_3.24.R
@@ -55,7 +55,7 @@ SS_readpar_3.24 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
 
   # function to read Stock Synthesis parameter files
   if (verbose) {
-    cli::cli_inform("running SS_readpar_3.24")
+    cli::cli_alert_info("running SS_readpar_3.24")
   }
   parvals <- readLines(parfile, warn = FALSE)
 

--- a/R/SS_readpar_3.30.R
+++ b/R/SS_readpar_3.30.R
@@ -51,7 +51,7 @@ SS_readpar_3.30 <- function(parfile, datsource, ctlsource, verbose = TRUE) {
 
   # function to read Stock Synthesis parameter files
   if (verbose) {
-    cli::cli_inform("running SS_readpar_3.30")
+    cli::cli_alert_info("running SS_readpar_3.30")
   }
   parvals <- readLines(parfile, warn = FALSE)
 

--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -132,7 +132,9 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   mylist[["converge_criterion"]] <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_alert_info("  converge_criterion = {mylist[['converge_criterion']]}")
+    cli::cli_alert_info(
+      "  converge_criterion = {mylist[['converge_criterion']]}"
+    )
   }
   mylist[["retro_yr"]] <- allnums[i]
   i <- i + 1
@@ -181,7 +183,9 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
     mylist[["ALK_tolerance"]] <- allnums[i]
     i <- i + 1
     if (verbose) {
-      cli::cli_alert_info("  MCMC_output_detail = {mylist[['MCMC_output_detail']]}")
+      cli::cli_alert_info(
+        "  MCMC_output_detail = {mylist[['MCMC_output_detail']]}"
+      )
       cli::cli_alert_info("  ALK_tolerance = {mylist[['ALK_tolerance']]}")
     }
   }
@@ -191,7 +195,9 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   i <- i + 1
   if (!is.na(final) && final %in% c(3.30, 999)) {
     if (verbose) {
-      cli::cli_alert_success("Read of starter file complete. Final value: {final}")
+      cli::cli_alert_success(
+        "Read of starter file complete. Final value: {final}"
+      )
     }
   } else {
     # read seed and check final value
@@ -208,7 +214,9 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
     }
     if (!is.na(final) && final %in% c(3.30, 999)) {
       if (verbose) {
-        cli::cli_alert_success("Read of starter file complete. Final value: {final}")
+        cli::cli_alert_success(
+          "Read of starter file complete. Final value: {final}"
+        )
       }
     } else {
       cli::cli_warn("Final value is {allnums[i]} but should be 3.30 or 999")

--- a/R/SS_readstarter.R
+++ b/R/SS_readstarter.R
@@ -21,7 +21,7 @@
 #' @family read/write functions
 SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   if (verbose) {
-    cli::cli_inform("running SS_readstarter")
+    cli::cli_alert_info("running SS_readstarter")
   }
 
   starter <- readLines(file, warn = FALSE)
@@ -56,7 +56,7 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   mylist[["datfile"]] <- strings[1]
   mylist[["ctlfile"]] <- strings[2]
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "  data, control files: {mylist[['datfile']]}, {mylist[['ctlfile']]}"
     )
   }
@@ -132,7 +132,7 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   mylist[["converge_criterion"]] <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("  converge_criterion = {mylist[['converge_criterion']]}")
+    cli::cli_alert_info("  converge_criterion = {mylist[['converge_criterion']]}")
   }
   mylist[["retro_yr"]] <- allnums[i]
   i <- i + 1
@@ -145,7 +145,7 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   mylist[["SPR_basis"]] <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("  SPR_basis = {mylist[['SPR_basis']]}")
+    cli::cli_alert_info("  SPR_basis = {mylist[['SPR_basis']]}")
   }
   mylist[["F_std_units"]] <- allnums[i]
   i <- i + 1
@@ -164,7 +164,7 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   mylist[["F_std_basis"]] <- allnums[i]
   i <- i + 1
   if (verbose) {
-    cli::cli_inform("  F_std_basis = {mylist[['F_std_basis']]}")
+    cli::cli_alert_info("  F_std_basis = {mylist[['F_std_basis']]}")
   }
 
   # last value in vector of numerical values
@@ -172,7 +172,7 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   if (i < i.final) {
     # file is probably 3.30
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Assuming version 3.30 based on number of numeric values."
       )
     }
@@ -181,8 +181,8 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
     mylist[["ALK_tolerance"]] <- allnums[i]
     i <- i + 1
     if (verbose) {
-      cli::cli_inform("  MCMC_output_detail = {mylist[['MCMC_output_detail']]}")
-      cli::cli_inform("  ALK_tolerance = {mylist[['ALK_tolerance']]}")
+      cli::cli_alert_info("  MCMC_output_detail = {mylist[['MCMC_output_detail']]}")
+      cli::cli_alert_info("  ALK_tolerance = {mylist[['ALK_tolerance']]}")
     }
   }
 
@@ -191,13 +191,13 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
   i <- i + 1
   if (!is.na(final) && final %in% c(3.30, 999)) {
     if (verbose) {
-      cli::cli_inform("Read of starter file complete. Final value: {final}")
+      cli::cli_alert_success("Read of starter file complete. Final value: {final}")
     }
   } else {
     # read seed and check final value
     mylist[["seed"]] <- mylist[["final"]]
     if (verbose) {
-      cli::cli_inform("Reading a random seed value: {mylist[['seed']]}")
+      cli::cli_alert_info("Reading a random seed value: {mylist[['seed']]}")
     }
 
     mylist[["final"]] <- final <- allnums[i]
@@ -208,7 +208,7 @@ SS_readstarter <- function(file = "starter.ss", verbose = TRUE) {
     }
     if (!is.na(final) && final %in% c(3.30, 999)) {
       if (verbose) {
-        cli::cli_inform("Read of starter file complete. Final value: {final}")
+        cli::cli_alert_success("Read of starter file complete. Final value: {final}")
       }
     } else {
       cli::cli_warn("Final value is {allnums[i]} but should be 3.30 or 999")

--- a/R/SS_readwtatage.R
+++ b/R/SS_readwtatage.R
@@ -26,7 +26,7 @@ SS_readwtatage <- function(file = "wtatage.ss", verbose = TRUE) {
   )
   if (test[1] == "No file" | length(test) <= 2) {
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Skipping weight-at-age file. File missing or empty: {file}"
       )
     }
@@ -47,7 +47,7 @@ SS_readwtatage <- function(file = "wtatage.ss", verbose = TRUE) {
   # if file only has one line, it may have been created during an MCMC run
   if (nrow(wtatagelines) == 1) {
     if (verbose) {
-      cli::cli_inform("wtatage file only contains one line: {file}")
+      cli::cli_alert_info("wtatage file only contains one line: {file}")
     }
     return(NULL)
   }

--- a/R/SS_recdevs.R
+++ b/R/SS_recdevs.R
@@ -97,7 +97,7 @@ SS_recdevs <-
     if (phase > 0) {
       newphase <- -abs(phase)
       if (verbose) {
-        cli::cli_inform("Changing recdev phase to negative: {newphase}")
+        cli::cli_alert_info("Changing recdev phase to negative: {newphase}")
       }
       ctl[grep("recdev phase", ctl)] <- paste(newphase, "#_recdev phase")
     }
@@ -135,7 +135,7 @@ SS_recdevs <-
         scaleyrs <- yrs %in% scaleyrs
       }
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Rescaling recdevs vector so yrs {min(yrs[scaleyrs])}: {max(yrs[scaleyrs])} have mean 0 and std. dev. = sigmaR = {sigmaR}"
         )
       }
@@ -176,7 +176,7 @@ SS_recdevs <-
     if (writectl) {
       writeLines(ctl, newctlfile)
       if (verbose) {
-        cli::cli_inform("Wrote new file: {newctlfile}")
+        cli::cli_alert_success("Wrote new file: {newctlfile}")
       }
     }
     # reset working directory

--- a/R/SS_splitdat.R
+++ b/R/SS_splitdat.R
@@ -109,7 +109,7 @@ SS_splitdat <-
         )
         outline <- paste("# Data file created from", infile, "to", outfile)
         if (verbose) {
-          cli::cli_inform(outline)
+          cli::cli_alert_info(outline)
         }
         writeLines(c(outline, filelines[starts[i]:ends[i]]), outfile)
       }
@@ -126,7 +126,7 @@ SS_splitdat <-
           paste("#C MLE data file created from", infile, "to", outfile)
         )
         if (verbose) {
-          cli::cli_inform("MLE data file created from {infile} to {outfile}")
+          cli::cli_alert_info("MLE data file created from {infile} to {outfile}")
         }
         writeLines(c(notes, filelines[MLEstart:MLEend]), outfile)
       }
@@ -142,7 +142,7 @@ SS_splitdat <-
           paste("#C data file created from", infile, "to", outfile)
         )
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "file with copies of input data created from {infile} to {outfile}"
           )
         }

--- a/R/SS_splitdat.R
+++ b/R/SS_splitdat.R
@@ -126,7 +126,9 @@ SS_splitdat <-
           paste("#C MLE data file created from", infile, "to", outfile)
         )
         if (verbose) {
-          cli::cli_alert_info("MLE data file created from {infile} to {outfile}")
+          cli::cli_alert_info(
+            "MLE data file created from {infile} to {outfile}"
+          )
         }
         writeLines(c(notes, filelines[MLEstart:MLEend]), outfile)
       }

--- a/R/SS_varadjust.R
+++ b/R/SS_varadjust.R
@@ -157,7 +157,7 @@ SS_varadjust <- function(
   options(warn = old_warn)
 
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Existing table of variance adjustments:
 {paste(utils::capture.output(ctl), sep = '', collapse = \"\\n\")}"
     )
@@ -165,7 +165,7 @@ SS_varadjust <- function(
 
   if (is.null(newrow) & is.null(newtable)) {
     if (verbose) {
-      cli::cli_inform("No new adjustments provided, so no file written.")
+      cli::cli_alert_warning("No new adjustments provided, so no file written.")
     }
     return(invisible(ctl))
   }
@@ -187,7 +187,7 @@ SS_varadjust <- function(
   }
 
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "New table of variance adjustments:
 {paste(utils::capture.output(ctl), sep = '', collapse = \"\\n\")}"
     )
@@ -213,7 +213,7 @@ SS_varadjust <- function(
 
   # open connection to file
   if (verbose) {
-    cli::cli_inform("opening connection to {newctlfile}")
+    cli::cli_alert_info("opening connection to {newctlfile}")
   }
   zz <- file(newctlfile, open = "at")
   sink(zz)
@@ -247,7 +247,7 @@ SS_varadjust <- function(
   sink()
   close(zz)
   if (verbose) {
-    cli::cli_inform("file written to {newctlfile}")
+    cli::cli_alert_info("file written to {newctlfile}")
   }
   # return table of values
   return(invisible(ctl))

--- a/R/SS_write.R
+++ b/R/SS_write.R
@@ -48,7 +48,7 @@ SS_write <- function(inputlist, dir = "", overwrite = FALSE, verbose = FALSE) {
   if (dir != "") {
     if (!dir.exists(dir)) {
       if (verbose) {
-        cli::cli_inform("Creating new directory: {dir}")
+        cli::cli_alert_info("Creating new directory: {dir}")
       }
       dir.create(dir, recursive = TRUE)
     }
@@ -136,6 +136,6 @@ SS_write <- function(inputlist, dir = "", overwrite = FALSE, verbose = FALSE) {
 
   # message noting that all files have been written
   if (verbose) {
-    cli::cli_inform("Wrote all input files to {dir}")
+    cli::cli_alert_success("Wrote all input files to {dir}")
   }
 }

--- a/R/SS_writectl.R
+++ b/R/SS_writectl.R
@@ -22,7 +22,7 @@ SS_writectl <- function(
 ) {
   # function to write Stock Synthesis data files
   if (verbose) {
-    cli::cli_inform("Running SS_writectl")
+    cli::cli_alert_info("Running SS_writectl")
   }
   # Check user inputs are valid to avoid issues with functions.
   # check ctllist

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -43,7 +43,9 @@ SS_writectl_3.24 <- function(
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning(
+        "File exists and input 'overwrite'=FALSE: {outfile}"
+      )
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writectl_3.24.R
+++ b/R/SS_writectl_3.24.R
@@ -32,7 +32,7 @@ SS_writectl_3.24 <- function(
 
   # function to write Stock Synthesis ctl files
   if (verbose) {
-    cli::cli_inform("running SS_writectl")
+    cli::cli_alert_info("running SS_writectl")
   }
 
   if (ctllist[["type"]] != "Stock_Synthesis_control_file") {
@@ -43,7 +43,7 @@ SS_writectl_3.24 <- function(
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_inform("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
       return()
     } else {
       file.remove(outfile)
@@ -55,7 +55,7 @@ SS_writectl_3.24 <- function(
   options(width = 5000, max.print = 9999999)
 
   if (verbose) {
-    cli::cli_inform("opening connection to {outfile}")
+    cli::cli_alert_info("opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at")
   #  on.exit({if(sink.number()>0) sink();close(zz)})
@@ -660,6 +660,6 @@ SS_writectl_3.24 <- function(
   writeLines("999", con = zz)
   options(width = oldwidth, max.print = oldmax.print)
   if (verbose) {
-    cli::cli_inform("File written to {outfile}")
+    cli::cli_alert_info("File written to {outfile}")
   }
 }

--- a/R/SS_writectl_3.30.R
+++ b/R/SS_writectl_3.30.R
@@ -22,7 +22,7 @@ SS_writectl_3.30 <- function(
   verbose = FALSE
 ) {
   if (verbose) {
-    cli::cli_inform("Running SS_writectl_3.30")
+    cli::cli_alert_info("Running SS_writectl_3.30")
   }
   # input checks
   if (ctllist[["ReadVersion"]] != "3.30") {
@@ -33,14 +33,14 @@ SS_writectl_3.30 <- function(
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_inform("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
       return()
     } else {
       file.remove(outfile)
     }
   }
   if (verbose) {
-    cli::cli_inform("Opening connection to {outfile}")
+    cli::cli_alert_info("Opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at") # open = "at" means open for appending in text mode.
   on.exit(close(zz)) # Needed in case the function exits early.
@@ -577,7 +577,7 @@ SS_writectl_3.30 <- function(
 
   if (ctllist[["recdev_adv"]] == 1) {
     if (verbose) {
-      cli::cli_inform("Writing 13 advanced SRR options")
+      cli::cli_alert_info("Writing 13 advanced SRR options")
     }
     wl(
       "recdev_early_start",
@@ -1056,5 +1056,5 @@ SS_writectl_3.30 <- function(
 
   # cleanup -----
   # options(width=oldwidth,max.print=oldmax.print)
-  if (verbose) cli::cli_inform("File written to {outfile}")
+  if (verbose) cli::cli_alert_info("File written to {outfile}")
 }

--- a/R/SS_writectl_3.30.R
+++ b/R/SS_writectl_3.30.R
@@ -33,7 +33,9 @@ SS_writectl_3.30 <- function(
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning(
+        "File exists and input 'overwrite'=FALSE: {outfile}"
+      )
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writedat.R
+++ b/R/SS_writedat.R
@@ -31,7 +31,7 @@ SS_writedat <- function(
     )
   }
   if (verbose) {
-    cli::cli_inform("running SS_writedat")
+    cli::cli_alert_info("running SS_writedat")
   }
 
   # check datlist

--- a/R/SS_writedat_3.24.R
+++ b/R/SS_writedat_3.24.R
@@ -35,7 +35,7 @@ SS_writedat_3.24 <- function(
   )
   # function to write Stock Synthesis data files
   if (verbose) {
-    cli::cli_inform("running SS_writedat_3.24")
+    cli::cli_alert_info("running SS_writedat_3.24")
   }
   if (lifecycle::is_present(faster)) {
     lifecycle::deprecate_warn(
@@ -55,7 +55,7 @@ SS_writedat_3.24 <- function(
   # check for existing file
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_inform("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
       return()
     } else {
       file.remove(outfile)
@@ -67,7 +67,7 @@ SS_writedat_3.24 <- function(
   options(width = 5000, max.print = 9999999)
 
   if (verbose) {
-    cli::cli_inform("opening connection to {outfile}")
+    cli::cli_alert_info("opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at")
   # sink(zz)
@@ -365,6 +365,6 @@ SS_writedat_3.24 <- function(
   #  sink()
   #  close(zz)
   if (verbose) {
-    cli::cli_inform("file written to {outfile}")
+    cli::cli_alert_info("file written to {outfile}")
   }
 }

--- a/R/SS_writedat_3.24.R
+++ b/R/SS_writedat_3.24.R
@@ -55,7 +55,9 @@ SS_writedat_3.24 <- function(
   # check for existing file
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning(
+        "File exists and input 'overwrite'=FALSE: {outfile}"
+      )
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writedat_3.30.R
+++ b/R/SS_writedat_3.30.R
@@ -51,7 +51,9 @@ SS_writedat_3.30 <- function(
   # check for existing file
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning(
+        "File exists and input 'overwrite'=FALSE: {outfile}"
+      )
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writedat_3.30.R
+++ b/R/SS_writedat_3.30.R
@@ -35,7 +35,7 @@ SS_writedat_3.30 <- function(
   }
 
   if (verbose) {
-    cli::cli_inform("running SS_writedat_3.30")
+    cli::cli_alert_info("running SS_writedat_3.30")
   }
 
   # rename datlist to shorten the code
@@ -51,7 +51,7 @@ SS_writedat_3.30 <- function(
   # check for existing file
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_inform("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
       return()
     } else {
       file.remove(outfile)
@@ -63,7 +63,7 @@ SS_writedat_3.30 <- function(
   options(width = 5000, max.print = 9999999)
 
   if (verbose) {
-    cli::cli_inform("opening connection to {outfile}")
+    cli::cli_alert_info("opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at")
   # sink(zz)
@@ -441,6 +441,6 @@ SS_writedat_3.30 <- function(
   writeComment("#", con = zz)
   writeLines("999", con = zz)
   if (verbose) {
-    cli::cli_inform("file written to {outfile}")
+    cli::cli_alert_success("file written to {outfile}")
   }
 }

--- a/R/SS_writeforecast.R
+++ b/R/SS_writeforecast.R
@@ -24,7 +24,7 @@ SS_writeforecast <- function(
 ) {
   # function to write Stock Synthesis forecast files
   if (verbose) {
-    cli::cli_inform("running SS_writeforecast")
+    cli::cli_alert_info("running SS_writeforecast")
   }
 
   if (!is.list(mylist) || mylist[["type"]] != "Stock_Synthesis_forecast_file") {
@@ -49,12 +49,12 @@ SS_writeforecast <- function(
       cli::cli_abort("file exists: {outfile} set overwrite=TRUE to replace")
     } else {
       if (verbose) {
-        cli::cli_inform("overwriting file: {outfile}")
+        cli::cli_alert_warning("overwriting file: {outfile}")
       }
       file.remove(outfile)
     }
   } else {
-    if (verbose) cli::cli_inform("writing new file: {outfile}")
+    if (verbose) cli::cli_alert_info("writing new file: {outfile}")
   }
 
   # preliminary setup
@@ -62,7 +62,7 @@ SS_writeforecast <- function(
   options(width = 1000)
 
   if (verbose) {
-    cli::cli_inform("opening connection to {outfile}")
+    cli::cli_alert_info("opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at")
   sink(zz)
@@ -79,7 +79,7 @@ SS_writeforecast <- function(
     # increase max.print
     if (nrow(dataframe) > 0.5 * getOption("max.print")) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "setting `options(max.print = {100 * nrow(dataframe) + 1})` to accommodate large output"
         )
       }
@@ -91,7 +91,7 @@ SS_writeforecast <- function(
     # restore old max.print
     if (exists("old.max.print")) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "restoring old value `options(max.print = {old.max.print})`"
         )
       }
@@ -311,5 +311,5 @@ SS_writeforecast <- function(
   options(width = oldwidth)
   sink()
   close(zz)
-  if (verbose) cli::cli_inform("file written to {outfile}")
+  if (verbose) cli::cli_alert_success("file written to {outfile}")
 }

--- a/R/SS_writepar_3.24.R
+++ b/R/SS_writepar_3.24.R
@@ -31,12 +31,12 @@ SS_writepar_3.24 <- function(
   )
   # function to write Stock Synthesis parameter files
   if (verbose) {
-    cli::cli_inform("running SS_writepar_3.24")
+    cli::cli_alert_info("running SS_writepar_3.24")
   }
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_inform("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
       return()
     } else {
       file.remove(outfile)
@@ -44,7 +44,7 @@ SS_writepar_3.24 <- function(
   }
 
   if (verbose) {
-    cli::cli_inform("Opening connection to {outfile}")
+    cli::cli_alert_info("Opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at") # open = "at" means open for appending in text mode.
   on.exit(close(zz)) # Needed in case the function exits early.

--- a/R/SS_writepar_3.24.R
+++ b/R/SS_writepar_3.24.R
@@ -36,7 +36,9 @@ SS_writepar_3.24 <- function(
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning(
+        "File exists and input 'overwrite'=FALSE: {outfile}"
+      )
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writepar_3.30.R
+++ b/R/SS_writepar_3.30.R
@@ -26,12 +26,12 @@ SS_writepar_3.30 <- function(
 ) {
   # function to write Stock Synthesis parameter files
   if (verbose) {
-    cli::cli_inform("running SS_writepar_3.30")
+    cli::cli_alert_info("running SS_writepar_3.30")
   }
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_inform("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
       return()
     } else {
       file.remove(outfile)
@@ -39,7 +39,7 @@ SS_writepar_3.30 <- function(
   }
 
   if (verbose) {
-    cli::cli_inform("Opening connection to {outfile}")
+    cli::cli_alert_info("Opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at") # open = "at" means open for appending in text mode.
   on.exit(close(zz)) # Needed in case the function exits early.

--- a/R/SS_writepar_3.30.R
+++ b/R/SS_writepar_3.30.R
@@ -31,7 +31,9 @@ SS_writepar_3.30 <- function(
 
   if (file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning(
+        "File exists and input 'overwrite'=FALSE: {outfile}"
+      )
       return()
     } else {
       file.remove(outfile)

--- a/R/SS_writestarter.R
+++ b/R/SS_writestarter.R
@@ -27,7 +27,7 @@ SS_writestarter <- function(
     )
   }
   if (verbose) {
-    cli::cli_inform("running SS_writestarter")
+    cli::cli_alert_info("running SS_writestarter")
   }
   if (mylist[["type"]] != "Stock_Synthesis_starter_file") {
     cli::cli_abort(
@@ -56,7 +56,7 @@ SS_writestarter <- function(
       file.remove(outfile)
     }
   } else {
-    if (verbose) cli::cli_inform("writing new file: {outfile}")
+    if (verbose) cli::cli_alert_info("writing new file: {outfile}")
   }
 
   # record current max characters per line and then expand in case of long lines
@@ -64,7 +64,7 @@ SS_writestarter <- function(
   options(width = 1000)
 
   if (verbose) {
-    cli::cli_inform("opening connection to {outfile}")
+    cli::cli_alert_info("opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at")
   sink(zz)
@@ -170,6 +170,6 @@ SS_writestarter <- function(
   sink()
   close(zz)
   if (verbose) {
-    cli::cli_inform("file written to {outfile}")
+    cli::cli_alert_info("file written to {outfile}")
   }
 }

--- a/R/SS_writewtatage.R
+++ b/R/SS_writewtatage.R
@@ -22,7 +22,7 @@ SS_writewtatage <- function(
   warn = lifecycle::deprecated()
 ) {
   if (verbose) {
-    cli::cli_inform("running SS_writewtatage")
+    cli::cli_alert_info("running SS_writewtatage")
   }
 
   if (lifecycle::is_present(warn)) {
@@ -52,7 +52,7 @@ SS_writewtatage <- function(
       file.remove(outfile)
     }
   } else {
-    if (verbose) cli::cli_inform("writing new file: {outfile}")
+    if (verbose) cli::cli_alert_info("writing new file: {outfile}")
   }
 
   # record current max characters per line and then expand in case of long lines
@@ -60,7 +60,7 @@ SS_writewtatage <- function(
   options(width = 1000)
 
   if (verbose) {
-    cli::cli_inform("opening connection to {outfile}")
+    cli::cli_alert_info("opening connection to {outfile}")
   }
   zz <- file(outfile, open = "at")
   on.exit(close(zz))
@@ -104,5 +104,5 @@ SS_writewtatage <- function(
   # restore printing width to whatever the user had before
   options(width = oldwidth)
   sink()
-  if (verbose) cli::cli_inform("file written to {outfile}")
+  if (verbose) cli::cli_alert_info("file written to {outfile}")
 }

--- a/R/SSbiologytables.R
+++ b/R/SSbiologytables.R
@@ -60,7 +60,7 @@ SSbiologytables <- function(
   if (is.na(plotdir.isdir) | !plotdir.isdir) {
     dir.create(plotdir)
   }
-  cli::cli_inform("writing files to {plotdir}")
+  cli::cli_alert_info("writing files to {plotdir}")
 
   # set fleet-specific names, and plotting parameters
   if (fleetnames[1] == "default") {

--- a/R/SSgetMCMC.R
+++ b/R/SSgetMCMC.R
@@ -56,7 +56,7 @@ SSgetMCMC <-
   ) {
     # get MCMC output
     if (verbose) {
-      cli::cli_inform("reading MCMC output in {dir}")
+      cli::cli_alert_info("reading MCMC output in {dir}")
     }
     # note: check.names = FALSE added to command below avoids
     # automatic conversion of some parameter labels such as
@@ -104,7 +104,7 @@ SSgetMCMC <-
       file1 <- file.path(dir, csv1)
       file2 <- file.path(dir, csv2)
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "writing subset of posteriors to files: {file1} {file2}"
         )
       }

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -74,7 +74,9 @@ SSgetoutput <-
     n1 <- length(keyvec)
     n2 <- length(dirvec)
     if (n1 > 1 & n2 > 1 & n1 != n2) {
-      cli::cli_alert_info("inputs 'keyvec' and 'dirvec' have unmatched lengths > 1")
+      cli::cli_alert_info(
+        "inputs 'keyvec' and 'dirvec' have unmatched lengths > 1"
+      )
     } else {
       n <- max(1, n1, n2) # n=1 or n=length of either optional input vector
     }

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -58,12 +58,12 @@ SSgetoutput <-
 
     if (verbose) {
       if (!is.null(keyvec)) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "length(keyvec) as input to SSgetoutput: {length(keyvec)}"
         )
       }
       if (!is.null(dirvec)) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "length(dirvec) as input to SSgetoutput: {length(dirvec)}"
         )
       }
@@ -74,7 +74,7 @@ SSgetoutput <-
     n1 <- length(keyvec)
     n2 <- length(dirvec)
     if (n1 > 1 & n2 > 1 & n1 != n2) {
-      cli::cli_inform("inputs 'keyvec' and 'dirvec' have unmatched lengths > 1")
+      cli::cli_alert_info("inputs 'keyvec' and 'dirvec' have unmatched lengths > 1")
     } else {
       n <- max(1, n1, n2) # n=1 or n=length of either optional input vector
     }
@@ -124,7 +124,7 @@ SSgetoutput <-
       newobject <- objectnames[i]
 
       if (verbose & !is.null(key)) {
-        cli::cli_inform("getting files with key = {key}")
+        cli::cli_alert_info("getting files with key = {key}")
       }
 
       repFileName <- paste("Report", key2, ".sso", sep = "")
@@ -143,7 +143,7 @@ SSgetoutput <-
 
       fullfile <- paste(mydir, repFileName, sep = "")
       if (verbose) {
-        cli::cli_inform("reading output from {fullfile}")
+        cli::cli_alert_info("reading output from {fullfile}")
       }
       repfilesize <- file.info(fullfile)[["size"]]
 
@@ -165,7 +165,7 @@ SSgetoutput <-
         )
         if (is.null(output)) {
           # for some reason covarfile exists, but is old so SS_output rejects
-          cli::cli_inform("output==NULL so trying again with covar=FALSE")
+          cli::cli_alert_info("output==NULL so trying again with covar=FALSE")
           output <- SS_output(
             dir = mydir,
             repfile = repFileName,
@@ -181,10 +181,10 @@ SSgetoutput <-
         }
         output[["key"]] <- as.character(key)
       } else {
-        cli::cli_inform("!repfile doesn't exists or is empty")
+        cli::cli_alert_warning("!repfile doesn't exists or is empty")
       }
       if (verbose) {
-        cli::cli_inform("added element '{newobject}' to list")
+        cli::cli_alert_info("added element '{newobject}' to list")
       }
       biglist[[newobject]] <- output
 

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -183,7 +183,7 @@ SSgetoutput <-
         }
         output[["key"]] <- as.character(key)
       } else {
-        cli::cli_alert_warning("!repfile doesn't exists or is empty")
+        cli::cli_alert_warning("!repfile doesn't exist or is empty")
       }
       if (verbose) {
         cli::cli_alert_info("added element '{newobject}' to list")

--- a/R/SSmakeMmatrix.R
+++ b/R/SSmakeMmatrix.R
@@ -40,7 +40,7 @@ SSmakeMmatrix <- function(
   # check for existing file
   if (!is.null(outfile) && file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_inform("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
       return()
     } else {
       file.remove(outfile)
@@ -60,7 +60,7 @@ SSmakeMmatrix <- function(
 
   # open file connection if requested
   if (!is.null(outfile)) {
-    cli::cli_inform("opening connection to {outfile}")
+    cli::cli_alert_info("opening connection to {outfile}")
     zz <- file(outfile, open = "at")
     sink(zz)
   }
@@ -73,7 +73,7 @@ SSmakeMmatrix <- function(
   maxage <- nrow(mat) - 1 # maximum age (assuming first age=0)
   ages <- 0:maxage # vector of ages
 
-  cli::cli_inform(
+  cli::cli_alert_info(
     "Calculating inputs to Stock Synthesis for a matrix of natural mortality values over the range of ages: {min(ages)} to {maxage}"
   )
 
@@ -90,7 +90,7 @@ SSmakeMmatrix <- function(
     )
   )
 
-  cli::cli_inform(Msetup)
+  cli::cli_alert_info(Msetup)
 
   # create data frame of parameter lines
   HI <- ceiling(max(mat) * 10) / 10
@@ -123,7 +123,7 @@ SSmakeMmatrix <- function(
     sep = ""
   )
 
-  cli::cli_inform(
+  cli::cli_alert_info(
     "Mortality params to paste into the first block of parameter lines:
 {paste(utils::capture.output(Mparams), sep = '', collapse = \"\\n\")}"
   )
@@ -151,7 +151,7 @@ SSmakeMmatrix <- function(
     sep = ""
   )
 
-  cli::cli_inform(
+  cli::cli_alert_info(
     "# stuff to paste below the line labeled 'CohortGrowDev'
 1 #_custom mortality/growth environmental setup
 {paste(utils::capture.output(Mlinks), sep = '', collapse = \"\\n\")}"
@@ -175,7 +175,7 @@ SSmakeMmatrix <- function(
     Menv <- rbind(Menv, temp) # paste into data.frame
   }
 
-  cli::cli_inform(
+  cli::cli_alert_info(
     "Environmental variables to paste into the bottom of the data file:
 {maxage + 1} # N environmental variables
 {nrow(Menv)} # N environmental observations
@@ -188,5 +188,5 @@ SSmakeMmatrix <- function(
     sink()
     close(zz)
   }
-  if (!is.null(outfile)) cli::cli_inform("file written to {outfile}")
+  if (!is.null(outfile)) cli::cli_alert_info("file written to {outfile}")
 }

--- a/R/SSmakeMmatrix.R
+++ b/R/SSmakeMmatrix.R
@@ -40,7 +40,9 @@ SSmakeMmatrix <- function(
   # check for existing file
   if (!is.null(outfile) && file.exists(outfile)) {
     if (!overwrite) {
-      cli::cli_alert_warning("File exists and input 'overwrite'=FALSE: {outfile}")
+      cli::cli_alert_warning(
+        "File exists and input 'overwrite'=FALSE: {outfile}"
+      )
       return()
     } else {
       file.remove(outfile)

--- a/R/SSmohnsrho.R
+++ b/R/SSmohnsrho.R
@@ -52,7 +52,7 @@
 #' @export
 SSmohnsrho <- function(summaryoutput, endyrvec, startyr, verbose = TRUE) {
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "The expected order of models in the summary output are the reference model followed by retro -1, retro -2, and so forth."
     )
   }

--- a/R/SSplotAgeMatrix.R
+++ b/R/SSplotAgeMatrix.R
@@ -86,7 +86,7 @@ SSplotAgeMatrix <- function(
       return()
     }
     if (length(replist[["lbinspop"]]) == 1 && is.na(replist[["lbinspop"]])) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "No distribution of length at age plots produced because replist[['ALK']] is NULL, likely because 'detailed age-structured reports' are not requested in the starter file."
       )
       return()

--- a/R/SSplotBiology.R
+++ b/R/SSplotBiology.R
@@ -141,12 +141,12 @@ SSplotBiology <-
     # test for presence of wtatage_switch
     wtatage_switch <- replist[["wtatage_switch"]]
     if (wtatage_switch) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Note: this model uses the empirical weight-at-age input. Plots of many quantities related to growth are skipped."
       )
     } else {
       if (is.null(replist[["endgrowth"]])) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Skipping biology plots because model output doesn't include biology-at-age information (endgrowth), likely because brief output was specified in starter.ss."
         )
         return()
@@ -408,7 +408,7 @@ SSplotBiology <-
       ## quick function to check for valid wtatage matrix and remove first
       ## redundant row if it's there. Used in weight_plot and maturity_plot.
       if (nrow(x) < 2) {
-        cli::cli_inform("Not enough rows in weight-at-age matrix to plot")
+        cli::cli_alert_info("Not enough rows in weight-at-age matrix to plot")
         return(NULL)
       }
       if (all(x[1, ] == x[2, ])) {
@@ -1251,7 +1251,7 @@ SSplotBiology <-
         plotinfo.tmp <- plotinfo.tmp[, c("file", "caption", "alt_text")]
         plotinfo <- rbind(plotinfo, plotinfo.tmp)
       } else {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Skipped some plots because AGE_LENGTH_KEY unavailable in report file because starter file set to produce limited report detail."
         )
       }
@@ -1261,7 +1261,7 @@ SSplotBiology <-
     growth_curve_labeled_fn <- function(option = 1) {
       # growth
       if (is.null(Growth_Parameters)) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Need updated SS_output function to get Growth_Parameters output"
         )
         return()
@@ -1434,7 +1434,7 @@ SSplotBiology <-
     CV_values_labeled_fn <- function(option = 1) {
       # growth
       if (is.null(Growth_Parameters)) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Need updated SS_output function to get Growth_Parameters output"
         )
         return()
@@ -2011,7 +2011,7 @@ SSplotBiology <-
     # Time-varying growth
     if (is.null(growthvaries)) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "No check for time-varying growth because starter file set to produce limited report detail."
         )
       }
@@ -2234,7 +2234,7 @@ SSplotBiology <-
           }
         }
       } else {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Skipping timevarying quantity plots (subplot 24), most likely because the MGparm_By_Year_after_adjustments table (report:7) is not reported in the Report.sso file."
         )
       }

--- a/R/SSplotComparisons.R
+++ b/R/SSplotComparisons.R
@@ -324,7 +324,7 @@ SSplotComparisons <-
       )
       pdf(file = pdffile, width = pwidth, height = pheight)
       if (verbose) {
-        cli::cli_inform("PDF file with plots will be: {pdffile}")
+        cli::cli_alert_info("PDF file with plots will be: {pdffile}")
       }
       par(par)
     }
@@ -468,19 +468,19 @@ SSplotComparisons <-
     }
     # some feedback about uncertainty settings
     if (all(uncertainty)) {
-      cli::cli_inform("showing uncertainty for all models")
+      cli::cli_alert_info("showing uncertainty for all models")
     }
     if (!any(uncertainty)) {
-      cli::cli_inform("not showing uncertainty for any models")
+      cli::cli_alert_info("not showing uncertainty for any models")
     }
     if (any(uncertainty) & !all(uncertainty)) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "showing uncertainty for model{ifelse(sum(uncertainty) > 1, 's: ', ' ')}{paste(which(uncertainty), collapse = ',')}"
       )
     }
     for (i in 1:n) {
       if (all(is.na(quantsSD[, i]) | quantsSD[, i] == 0)) {
-        cli::cli_inform("No uncertainty available for model {i}")
+        cli::cli_alert_warning("No uncertainty available for model {i}")
         uncertainty[i] <- FALSE
       }
     }
@@ -727,7 +727,7 @@ SSplotComparisons <-
         mean <- apply(mcmc.tmp, 2, mean, na.rm = TRUE)
         upper <- apply(mcmc.tmp, 2, quantile, prob = upperCI, na.rm = TRUE)
         if (!meanRecWarning) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "note: using mean recruitment from MCMC instead of median, because it is more comparable to MLE"
           )
           meanRecWarning <- TRUE
@@ -1426,7 +1426,7 @@ SSplotComparisons <-
               cex = par()[["cex.lab"]]
             )
           } else {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "No line added to SPR ratio plot, as the settings used in this model have not yet been configured in SSplotComparisons."
             )
             mtext(
@@ -2378,7 +2378,7 @@ SSplotComparisons <-
           mcmcColumn <- grep(parname, colnames(mcmc[[imodel]]), fixed = TRUE)
           # warn if it can't find the columns
           if (length(mcmcColumn) == 0) {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "No columns selected from MCMC for '{parname}' in model {imodel}"
             )
             good[iline] <- FALSE
@@ -2468,7 +2468,7 @@ SSplotComparisons <-
       }
       # make empty plot
       if (is.null(ymax)) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "  skipping plot of {parname} because it seems to not be estimated in any model"
         )
       } else {
@@ -2728,7 +2728,7 @@ SSplotComparisons <-
           box()
         }
         if (xunits != 1) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "x-axis for {parname} in density plot has been divided by {xunits} (so may be in units of {xlab2})"
           )
         }
@@ -2756,14 +2756,14 @@ SSplotComparisons <-
     uncertaintyplots <- intersect(c(2, 4, 6, 8, 10, 12), subplots)
     if (!any(uncertainty) & length(uncertaintyplots) > 0) {
       # warn if uncertainty is off but uncertainty plots are requested
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "skipping plots with uncertainty: {paste(uncertaintyplots, collapse = ',')}"
       )
     }
     # subplot 1: spawning biomass
     if (1 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("subplot 1: spawning biomass")
+        cli::cli_alert_info("subplot 1: spawning biomass")
       }
       if (plot) {
         ymax_vec[1] <- plotBio(option = 1, show_uncertainty = FALSE)
@@ -2779,7 +2779,7 @@ SSplotComparisons <-
     if (2 %in% subplots) {
       if (any(uncertainty)) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "subplot 2: spawning biomass with uncertainty intervals"
           )
         }
@@ -2798,7 +2798,7 @@ SSplotComparisons <-
     # (hopefully equal to fraction of unfished spawning output)
     if (3 %in% subplots) {
       if (verbose) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "subplot 3: biomass ratio (hopefully equal to fraction of unfished)"
         )
       }
@@ -2816,7 +2816,7 @@ SSplotComparisons <-
     if (4 %in% subplots) {
       if (any(uncertainty)) {
         if (verbose) {
-          cli::cli_inform("subplot 4: biomass ratio with uncertainty")
+          cli::cli_alert_info("subplot 4: biomass ratio with uncertainty")
         }
         if (plot) {
           ymax_vec[4] <- plotBratio(show_uncertainty = TRUE)
@@ -2832,7 +2832,7 @@ SSplotComparisons <-
     # subplot 18: summary biomass
     if (18 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("subplot 18: summary biomass")
+        cli::cli_alert_info("subplot 18: summary biomass")
       }
       if (plot) {
         ymax_vec[18] <- plotBio(option = 2, show_uncertainty = FALSE)
@@ -2849,13 +2849,13 @@ SSplotComparisons <-
       if (any(uncertainty)) {
         if (all(is.na(summaryoutput[["SmryBioSD"]][["Label"]]))) {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "skipping subplot 19 summary biomass with uncertainty because no models include summary biomass as a derived quantity"
             )
           }
         } else {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_info(
               "subplot 19: summary biomass with uncertainty intervals"
             )
           }
@@ -2874,7 +2874,7 @@ SSplotComparisons <-
     # subplot 5: SPR ratio
     if (5 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("subplot 5: SPR ratio")
+        cli::cli_alert_info("subplot 5: SPR ratio")
       }
       if (plot) {
         ymax_vec[5] <- plotSPRratio(show_uncertainty = FALSE)
@@ -2890,7 +2890,7 @@ SSplotComparisons <-
     if (6 %in% subplots) {
       if (any(uncertainty)) {
         if (verbose) {
-          cli::cli_inform("subplot 6: SPR ratio with uncertainty")
+          cli::cli_alert_info("subplot 6: SPR ratio with uncertainty")
         }
         if (plot) {
           ymax_vec[6] <- plotSPRratio(show_uncertainty = TRUE)
@@ -2906,7 +2906,7 @@ SSplotComparisons <-
     # subplot 7: F (harvest rate or fishing mortality, however defined)
     if (7 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("subplot 7: F value")
+        cli::cli_alert_info("subplot 7: F value")
       }
       if (plot) {
         ymax_vec[7] <- plotF(show_uncertainty = FALSE)
@@ -2923,7 +2923,7 @@ SSplotComparisons <-
     if (8 %in% subplots) {
       if (any(uncertainty)) {
         if (verbose) {
-          cli::cli_inform("subplot 8: F value with uncertainty")
+          cli::cli_alert_info("subplot 8: F value with uncertainty")
         }
         if (plot) {
           ymax_vec[8] <- plotF(show_uncertainty = TRUE)
@@ -2939,7 +2939,7 @@ SSplotComparisons <-
     # subplot 9: recruits
     if (9 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("subplot 9: recruits")
+        cli::cli_alert_info("subplot 9: recruits")
       }
       if (plot) {
         ymax_vec[9] <- plotRecruits(show_uncertainty = FALSE)
@@ -2955,7 +2955,7 @@ SSplotComparisons <-
     if (10 %in% subplots) {
       if (any(uncertainty)) {
         if (verbose) {
-          cli::cli_inform("subplot 10: recruits with uncertainty")
+          cli::cli_alert_info("subplot 10: recruits with uncertainty")
         }
         if (plot) {
           ymax_vec[10] <- plotRecruits()
@@ -2971,10 +2971,10 @@ SSplotComparisons <-
     # subplot 11: recruit devs
     if (11 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("subplot 11: recruit devs")
+        cli::cli_alert_info("subplot 11: recruit devs")
       }
       if (is.null(recdevs)) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "No recdevs present in the model summary, skipping plot."
         )
       } else {
@@ -2993,7 +2993,7 @@ SSplotComparisons <-
     if (12 %in% subplots) {
       if (any(uncertainty)) {
         if (verbose) {
-          cli::cli_inform("subplot 12: recruit devs with uncertainty")
+          cli::cli_alert_info("subplot 12: recruit devs with uncertainty")
         }
         if (plot) {
           ymax_vec[12] <- plotRecDevs()
@@ -3009,7 +3009,7 @@ SSplotComparisons <-
     # subplot 13: index fits
     if (13 %in% subplots & !is.null(indices) && nrow(indices) > 0) {
       if (verbose) {
-        cli::cli_inform("subplot 13: index fits")
+        cli::cli_alert_info("subplot 13: index fits")
       }
       for (iindex in seq_along(indexfleets[[1]])) {
         if (plot) {
@@ -3030,7 +3030,7 @@ SSplotComparisons <-
     # subplot 14: index fits on a log scale
     if (14 %in% subplots & !is.null(indices) && nrow(indices) > 0) {
       if (verbose) {
-        cli::cli_inform("subplot 14: index fits on a log scale")
+        cli::cli_alert_info("subplot 14: index fits on a log scale")
       }
       for (iindex in seq_along(indexfleets[[1]])) {
         if (plot) {
@@ -3052,7 +3052,7 @@ SSplotComparisons <-
     ## # subplot 15: phase plot
     if (15 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("subplot 15: phase plot")
+        cli::cli_alert_info("subplot 15: phase plot")
       }
       if (plot) {
         ymax_vec[15] <- plotPhase()
@@ -3068,7 +3068,7 @@ SSplotComparisons <-
     if (16 %in% subplots | 17 %in% subplots) {
       if (any(uncertainty)) {
         if (verbose) {
-          cli::cli_inform("subplots 16 and 17: densities")
+          cli::cli_alert_info("subplots 16 and 17: densities")
         }
         # look for all parameters or derived quantities matching
         # the input list of names
@@ -3089,7 +3089,7 @@ SSplotComparisons <-
             "No parameter/quantity names matching 'densitynames' input."
           )
         } else {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Parameter/quantity names matching 'densitynames' input: {paste(expandednames, sep = '', collapse = ', ')}"
           )
           ndensities <- length(expandednames)
@@ -3101,7 +3101,7 @@ SSplotComparisons <-
           )
           if (!is.null(densityxlabs) && length(densityxlabs) == ndensities) {
             densitytable[["label"]] <- densityxlabs
-            cli::cli_inform(
+            cli::cli_alert_info(
               "  table of parameter/quantity labels with associated x-axis label:"
             )
             print(densitytable)

--- a/R/SSplotComps.R
+++ b/R/SSplotComps.R
@@ -485,7 +485,7 @@ SSplotComps <-
     if (
       any(dbase_kind[["SuprPer"]] == "Sup" & dbase_kind[["Used"]] == "skip")
     ) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Removing super-period composition values labeled 'skip' and designating super-period values with a '*'"
       )
       dbase_kind <- dbase_kind[
@@ -921,7 +921,7 @@ SSplotComps <-
               )
               agg <- agg[agg[["f"]] %in% fleets, ]
               if (any(agg[["s"]] <= 0)) {
-                cli::cli_inform(
+                cli::cli_alert_info(
                   "super-periods may not work correctly in plots of aggregated comps"
                 )
                 agg <- agg[agg[["s"]] > 0, ]
@@ -1456,7 +1456,7 @@ SSplotComps <-
 
             if (max_n_ageerr > 1) {
               if (ageerr_warning) {
-                cli::cli_inform(
+                cli::cli_alert_info(
                   "Multiple samples with different ageing error types within fleet/year. Plots label '2005a3' indicates ageing error type 3 for 2005 sample. Bubble plots may be misleading with overlapping bubbles."
                 )
                 ageerr_warning <- FALSE
@@ -1556,7 +1556,7 @@ SSplotComps <-
             # add lines for growth of individual cohorts if requested
             if (length(cohortlines) > 0) {
               for (icohort in seq_along(cohortlines)) {
-                cli::cli_inform(
+                cli::cli_alert_info(
                   " Adding line for {cohortlines[icohort]} cohort"
                 )
                 if (kind == "LEN") {
@@ -1734,7 +1734,7 @@ SSplotComps <-
 
           if (max_n_ageerr > 1) {
             if (ageerr_warning) {
-              cli::cli_inform(
+              cli::cli_alert_info(
                 "Note: multiple samples with different ageing error types within fleet/year. Plots label '2005a3' indicates ageing error type 3 for 2005 sample. Bubble plots may be misleading with overlapping bubbles."
               )
               ageerr_warning <- FALSE
@@ -2224,7 +2224,7 @@ SSplotComps <-
               # add lines for growth of individual cohorts if requested
               if (length(cohortlines) > 0) {
                 for (icohort in seq_along(cohortlines)) {
-                  cli::cli_inform(
+                  cli::cli_alert_info(
                     " Adding line for {cohortlines[icohort]} cohort"
                   )
                   if (kind == "LEN") {
@@ -2338,11 +2338,11 @@ SSplotComps <-
                 # scaling when displaying both input and effective
                 sampsizeline <- effNline <- max(dbase[["Bin"]]) /
                   max(dbase[["Nsamp_adj"]], dbase[["effN"]], na.rm = TRUE)
-                cli::cli_inform(
+                cli::cli_alert_info(
                   "  Fleet {f} {titlesex} adj. input & effective N in red & green scaled by {effNline}"
                 )
               } else {
-                cli::cli_inform(
+                cli::cli_alert_info(
                   "  Fleet {f} {titlesex} adj. input N in red scaled by {sampsizeline}"
                 )
               }
@@ -2676,7 +2676,7 @@ SSplotComps <-
             goodbins <- intersect(aalbin, dbase[["Lbin_hi"]])
             if (length(goodbins) > 0) {
               if (length(badbins) > 0) {
-                cli::cli_inform(
+                cli::cli_alert_info(
                   "Error! the following inputs for 'aalbin' do not match the Lbin_hi values for the conditional age-at-length data: {badbins} the following inputs for 'aalbin' are fine: {goodbins}"
                 )
               }

--- a/R/SSplotDynamicB0.R
+++ b/R/SSplotDynamicB0.R
@@ -347,7 +347,7 @@ SSplotDynamicB0 <- function(
     }
   }
   if (verbose) {
-    cli::cli_inform("Plotting Dynamic B0")
+    cli::cli_alert_info("Plotting Dynamic B0")
   }
   return(invisible(plotinfo))
 }

--- a/R/SSplotIndices.R
+++ b/R/SSplotIndices.R
@@ -125,7 +125,9 @@ SSplotIndices <-
 
     # confirm that some CPUE values are present
     if (is.null(dim(cpue))) {
-      cli::cli_alert_warning("skipping index plots: no index data in this model")
+      cli::cli_alert_warning(
+        "skipping index plots: no index data in this model"
+      )
       return()
     }
 

--- a/R/SSplotIndices.R
+++ b/R/SSplotIndices.R
@@ -125,7 +125,7 @@ SSplotIndices <-
 
     # confirm that some CPUE values are present
     if (is.null(dim(cpue))) {
-      cli::cli_inform("skipping index plots: no index data in this model")
+      cli::cli_alert_warning("skipping index plots: no index data in this model")
       return()
     }
 
@@ -791,7 +791,7 @@ SSplotIndices <-
             allcpue <- rbind(allcpue, tempcpue)
           } else {
             if (verbose & 9 %in% subplots & datplot) {
-              cli::cli_inform(
+              cli::cli_alert_info(
                 "Excluding fleet {ifleet} from index comparison figure because it has negative values"
               )
             }

--- a/R/SSplotMovementRates.R
+++ b/R/SSplotMovementRates.R
@@ -69,7 +69,7 @@ SSplotMovementRates <-
     # subplot 1: movement in end year
     if (1 %in% subplots) {
       if (verbose) {
-        cli::cli_inform("Running subplot 1: movement rates in final year")
+        cli::cli_alert_info("Running subplot 1: movement rates in final year")
       }
 
       if (moveseas[1] == "all") {
@@ -83,7 +83,7 @@ SSplotMovementRates <-
 
         if (nrow(move2) == 0) {
           if (verbose) {
-            cli::cli_inform(
+            cli::cli_alert_warning(
               "Skipping movement rate plot: no movement in season {moveseas[iseas]}"
             )
           }
@@ -176,7 +176,7 @@ SSplotMovementRates <-
           )
           if (FALSE) {
             if (verbose) {
-              cli::cli_inform("Running subplot 2: time-varying movement rates")
+              cli::cli_alert_info("Running subplot 2: time-varying movement rates")
             }
             moveinfo <- move[, 1:6]
             moveinfo[["LabelBase2"]] <- paste(
@@ -195,7 +195,7 @@ SSplotMovementRates <-
             ]
             nmoves <- nrow(moveinfo)
             if (verbose) {
-              cli::cli_inform("N movement rates: {nmoves}")
+              cli::cli_alert_info("N movement rates: {nmoves}")
             }
             if (nareas > 2) {
               cli::cli_warn(
@@ -380,7 +380,7 @@ SSplotMovementRates <-
           } # end if(FALSE) turning off section that isn't working
         } # end check for time-varying movement
       } else {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Skipping time varying movement plots (subplot 2), most likely because MGparm_By_Year_after_adjustments table (report:7) is not reported in the Report.sso file."
         )
       }

--- a/R/SSplotMovementRates.R
+++ b/R/SSplotMovementRates.R
@@ -176,7 +176,9 @@ SSplotMovementRates <-
           )
           if (FALSE) {
             if (verbose) {
-              cli::cli_alert_info("Running subplot 2: time-varying movement rates")
+              cli::cli_alert_info(
+                "Running subplot 2: time-varying movement rates"
+              )
             }
             moveinfo <- move[, 1:6]
             moveinfo[["LabelBase2"]] <- paste(

--- a/R/SSplotNumbers.R
+++ b/R/SSplotNumbers.R
@@ -93,7 +93,7 @@ SSplotNumbers <-
 
     natage <- replist[["natage"]]
     if (is.null(natage)) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Skipped some plots because NUMBERS_AT_AGE unavailable in the report file. The starter file may be set to produce limited report detail."
       )
     } else {
@@ -156,7 +156,7 @@ SSplotNumbers <-
       if ("Settlement" %in% names(natage)) {
         settlement <- unique(natage[["Settlement"]])
         if (length(settlement) > 1) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Numbers at age plots only show first settlement event"
           )
         }
@@ -164,17 +164,17 @@ SSplotNumbers <-
       birth_seas_name <- grep("^BirthSeas", colnames(natage), value = TRUE)
       bseas <- unique(natage[[birth_seas_name]])
       if (length(bseas) > 1) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Numbers at age plots are for only the first birth season"
         )
       }
       if (ngpatterns > 1) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Numbers at age plots may not deal correctly with growth patterns: no guarantees!"
         )
       }
       if (nseasons > 1) {
-        cli::cli_inform("Numbers at age plots are for season 1 only")
+        cli::cli_alert_info("Numbers at age plots are for season 1 only")
         # change plot labels for seasonal models
         labels[16] <- gsub(
           pattern = "of year",
@@ -532,7 +532,7 @@ SSplotNumbers <-
             }
           } else {
             if (verbose) {
-              cli::cli_inform(
+              cli::cli_alert_info(
                 "skipped sex ratio contour plot because females=males for all ages and years"
               )
             }
@@ -891,7 +891,7 @@ SSplotNumbers <-
               }
             } else {
               if (verbose) {
-                cli::cli_inform(
+                cli::cli_alert_info(
                   "skipped sex ratio contour plot because females=males for all lengths and years"
                 )
               }
@@ -913,7 +913,7 @@ SSplotNumbers <-
           BirthSeas <- min(bseas)
         }
         if (length(bseas) > 1) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "showing equilibrium age for first birth season {BirthSeas}"
           )
         }
@@ -977,7 +977,7 @@ SSplotNumbers <-
                 col = areacols[iarea],
                 add = TRUE
               )
-              cli::cli_inform(
+              cli::cli_alert_info(
                 "Multiple matching lines in equilibrium plot indicate multiple morphs or platoons within each area/sex combination."
               )
             }

--- a/R/SSplotPars.R
+++ b/R/SSplotPars.R
@@ -226,7 +226,7 @@ SSplotPars <-
       }
       goodnames <- unique(goodnames)
       if (verbose) {
-        cli::cli_inform("Active parameters matching input vector 'strings':")
+        cli::cli_alert_info("Active parameters matching input vector 'strings':")
         print(goodnames)
       }
       if (length(goodnames) == 0) {
@@ -245,7 +245,7 @@ SSplotPars <-
     skip <- grep("Impl_err_", goodnames)
     if (length(skip) > 0) {
       goodnames <- goodnames[-skip]
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Skipping 'Impl_err_' parameters which don't have bounds reported"
       )
     }
@@ -253,7 +253,7 @@ SSplotPars <-
     skip <- grep("F_fleet_", goodnames)
     if (length(skip) > 0) {
       goodnames <- goodnames[-skip]
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Skipping 'F_fleet_' parameters which aren't yet supported by this function"
       )
     }
@@ -286,12 +286,12 @@ SSplotPars <-
       if (length(devrows) > 0) {
         goodnames <- goodnames[-devrows]
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "Excluding {length(devrows)} deviation parameters because input 'showdev' = FALSE"
           )
         }
         if (length(goodnames) == 0) {
-          cli::cli_inform("no parameters to plot")
+          cli::cli_alert_warning("no parameters to plot")
           return()
         }
       }
@@ -312,7 +312,7 @@ SSplotPars <-
     # get vector of standard deviations and test for NA or 0 values
     stds <- parameters[["Parm_StDev"]][parameters[["Label"]] %in% goodnames]
     if (showmle & (all(is.na(stds)) || min(stds, na.rm = TRUE) <= 0)) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Some parameters have std. dev. values in Report.sso equal to 0. Asymptotic uncertainty estimates will not be shown. Try re-running the model with the Hessian but no MCMC."
       )
     }
@@ -333,7 +333,7 @@ SSplotPars <-
           fixed = TRUE
         )
       }
-      cli::cli_inform(messagetext)
+      cli::cli_alert_info(messagetext)
     }
     # number of pages, each with nrows x ncols parameters
     npages <- ceiling(npars / (nrows * ncols))
@@ -428,7 +428,7 @@ SSplotPars <-
     } # end function wrapping up plotting
 
     if (debug) {
-      cli::cli_inform("Making plots of parameters:")
+      cli::cli_alert_info("Making plots of parameters:")
     }
 
     if (plot & !add) {
@@ -443,7 +443,7 @@ SSplotPars <-
       parname <- goodnames[ipar]
 
       if (debug) {
-        cli::cli_inform("    {parname}")
+        cli::cli_alert_info("    {parname}")
       }
       parline <- parameters[parameters[["Label"]] == parname, ]
 
@@ -547,13 +547,13 @@ SSplotPars <-
       # get mcmc results from replist created by SS_output
       mcmc <- replist[["mcmc"]]
       if (showpost && is.null(mcmc)) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "$mcmc not found in input 'replist', changing input to 'showpost=FALSE'"
         )
         showpost <- FALSE
       }
       if (showpost && length(mcmc) < 20) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "mcmc output has fewer than 20 rows, changing input to 'showpost=FALSE'"
         )
         showpost <- FALSE

--- a/R/SSplotPars.R
+++ b/R/SSplotPars.R
@@ -226,7 +226,9 @@ SSplotPars <-
       }
       goodnames <- unique(goodnames)
       if (verbose) {
-        cli::cli_alert_info("Active parameters matching input vector 'strings':")
+        cli::cli_alert_info(
+          "Active parameters matching input vector 'strings':"
+        )
         print(goodnames)
       }
       if (length(goodnames) == 0) {

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -167,7 +167,7 @@ SSplotProfile <-
       # create directory if it's missing
       if (!file.exists(plotdir)) {
         if (verbose) {
-          cli::cli_inform("creating directory: {plotdir}")
+          cli::cli_alert_info("creating directory: {plotdir}")
         }
         dir.create(plotdir, recursive = TRUE)
       }
@@ -220,10 +220,10 @@ SSplotProfile <-
     # get vector of parameter values
     parvec <- as.numeric(pars[pars[["Label"]] == parlabel, models])
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Parameter matching profile.string={profile.string}: {parlabel}"
       )
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Parameter values (after subsetting based on input 'models'): {paste(parvec, sep = '', collapse = ', ')}"
       )
     }
@@ -244,7 +244,7 @@ SSplotProfile <-
     }
 
     if (verbose & add_no_prior_line) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Parameter prior likelihoods: {paste(par_prior_like_vec, sep = '', collapse = ', ')}"
       )
     }
@@ -294,7 +294,7 @@ SSplotProfile <-
 
     nlines <- sum(include)
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Likelihood components showing max change as fraction of total change. To change which components are included, change input 'minfraction'."
       )
       print(data.frame(
@@ -396,7 +396,7 @@ SSplotProfile <-
       if (is.null(profile.label)) {
         # use parameter label for x-axis label
         profile.label <- parlabel
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "The input profile.label = NULL and the parameter label doesn't correspond to an automatically generated label. Setting profile.label equal to the parameter label."
         )
       }

--- a/R/SSplotRecdevs.R
+++ b/R/SSplotRecdevs.R
@@ -84,7 +84,7 @@ SSplotRecdevs <-
 
     if (nrow(recdev) == 0 || max(recdev[["Value"]]) == 0) {
       if (verbose) {
-        cli::cli_inform("Skipped SSplotrecdevs - no rec devs estimated")
+        cli::cli_alert_warning("Skipped SSplotrecdevs - no rec devs estimated")
       }
     } else {
       if (nrow(recdev) > 0) {

--- a/R/SSplotRecdist.R
+++ b/R/SSplotRecdist.R
@@ -172,7 +172,7 @@ SSplotRecdist <-
       if (nsexes == 1) {
         message1 <- "recruitment distribution by area and season:\n"
       }
-      cli::cli_inform(
+      cli::cli_alert_info(
         "{message1} {paste(utils::capture.output(recmat[, , sex]), sep = '', collapse = '\n')}"
       )
       if (plot) {

--- a/R/SSplotSPR.R
+++ b/R/SSplotSPR.R
@@ -80,7 +80,7 @@ SSplotSPR <-
 
     # message about skipping plots
     if (is.null(sprseries)) {
-      cli::cli_inform("Skipping SPR plots: no output available")
+      cli::cli_alert_warning("Skipping SPR plots: no output available")
       return()
     }
     # at least one non-converged model had NaN values for all years
@@ -182,7 +182,7 @@ SSplotSPR <-
     # temporary disable multi-season models until code cleanup
     if (2 %in% subplots) {
       if (nseasons > 1) {
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Skipped 1-SPR plot because it's not yet configured for multi-season models"
         )
       }
@@ -399,7 +399,7 @@ SSplotSPR <-
       Bratio_vals <- Bratio[["Value"]][Bratio[["Yr"]] %in% shared_yrs]
       SPRratio_vals <- SPRratio[["Value"]][SPRratio[["Yr"]] %in% shared_yrs]
       if (length(Bratio_vals) != length(SPRratio_vals)) {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Bratio and SPRratio vectors are different in length, skipping phase plot."
         )
         return()

--- a/R/SSplotSelex.R
+++ b/R/SSplotSelex.R
@@ -159,12 +159,12 @@ SSplotSelex <-
 
     # message about skipping plots
     if (is.null(ageselex)) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Skipping age-based selectivity plots: no output available"
       )
     }
     if (is.null(sizeselex)) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Skipping length-based selectivity plots: no output available"
       )
     }
@@ -275,7 +275,7 @@ SSplotSelex <-
       }
       if (any(time)) {
         if (length(years) > 1 & length(fleets) > 1) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "plot not yet configured to work well with multiple years and multiple fleets"
           )
         }
@@ -562,7 +562,7 @@ SSplotSelex <-
           )
       ) {
         agefactors <- setdiff(agefactors, "Asel")
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Skipping plot of age-based selectivity as all values = 1.0"
         )
       }

--- a/R/SSplotSexRatio.R
+++ b/R/SSplotSexRatio.R
@@ -151,7 +151,7 @@ SSplotSexRatio <-
     if (
       any(dbase_kind[["SuprPer"]] == "Sup" & dbase_kind[["Used"]] == "skip")
     ) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Removing super-period composition values labeled 'skip' and designating super-period values with a '*'"
       )
       dbase_kind <- dbase_kind[

--- a/R/SSplotSpawnrecruit.R
+++ b/R/SSplotSpawnrecruit.R
@@ -100,7 +100,7 @@ SSplotSpawnrecruit <-
 
     recruit <- replist[["recruit"]]
     if (is.null(recruit)) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Skipping stock-recruit plots: no recruitment information available"
       )
       return()

--- a/R/SSplotTags.R
+++ b/R/SSplotTags.R
@@ -76,13 +76,13 @@ SSplotTags <-
     tagdbase2 <- replist[["tagdbase2"]]
     if (is.null(tagdbase2) || nrow(tagdbase2) == 0) {
       if (verbose) {
-        cli::cli_inform("skipping tag plots because there's no tagging data")
+        cli::cli_alert_warning("skipping tag plots because there's no tagging data")
       }
     } else {
       # filter tag groups if requested
       if (!is.null(taggroups)) {
         tagdbase2 <- tagdbase2[tagdbase2[["Repl."]] %in% taggroups, ]
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Filtered tag groups for plotting based on input vector taggroups. Plots will show {length(unique(tagdbase2[['Repl.']]))} out of {length(unique(replist[['tagdbase2']][['Repl.']]))} total included in the model."
         )
       }

--- a/R/SSplotTags.R
+++ b/R/SSplotTags.R
@@ -76,7 +76,9 @@ SSplotTags <-
     tagdbase2 <- replist[["tagdbase2"]]
     if (is.null(tagdbase2) || nrow(tagdbase2) == 0) {
       if (verbose) {
-        cli::cli_alert_warning("skipping tag plots because there's no tagging data")
+        cli::cli_alert_warning(
+          "skipping tag plots because there's no tagging data"
+        )
       }
     } else {
       # filter tag groups if requested

--- a/R/SSplotYield.R
+++ b/R/SSplotYield.R
@@ -236,12 +236,12 @@ SSplotYield <-
             }
           }
         } else {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipped equilibrium yield plots: equil_yield has all NA values"
           )
         }
       } else {
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "Skipped equilibrium yield plots: no equil_yield results in this model"
         )
       }
@@ -415,7 +415,7 @@ SSplotYield <-
       sprseries <- replist[["sprseries"]]
       if (is.null(sprseries)) {
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Skipping yield per recruit plot because SPR_SERIES not in output"
           )
         }

--- a/R/SSsummarize.R
+++ b/R/SSsummarize.R
@@ -150,7 +150,7 @@ SSsummarize <- function(
   warn <- FALSE # flag for whether filter warning has been printed or not
 
   if (verbose) {
-    cli::cli_inform("Summarizing {n} models:")
+    cli::cli_alert_info("Summarizing {n} models:")
   }
 
   # loop over models within biglist
@@ -158,7 +158,7 @@ SSsummarize <- function(
     stats <- biglist[[imodel]]
     listname <- names(biglist)[imodel]
     if (verbose) {
-      cli::cli_inform("imodel={imodel}/{n}")
+      cli::cli_alert_info("imodel={imodel}/{n}")
     }
 
     # gradient
@@ -176,7 +176,7 @@ SSsummarize <- function(
     # check for non-NULL selectivity table
     if (is.null(sizeseltemp)) {
       if (verbose) {
-        cli::cli_inform("  no selectivity-at-length output")
+        cli::cli_alert_warning("no selectivity-at-length output")
       }
     } else {
       # if factor(s) not input, get all unique values from table
@@ -212,7 +212,7 @@ SSsummarize <- function(
     # check for NULL selectivity table
     if (is.null(ageseltemp)) {
       if (verbose) {
-        cli::cli_inform("  no selectivity-at-age output")
+        cli::cli_alert_warning("no selectivity-at-age output")
       }
     } else {
       # if factor(s) not input, get all unique values from table
@@ -328,8 +328,8 @@ SSsummarize <- function(
       ] <- parstemp[["Pr_Like"]][ipar]
     }
     if (verbose) {
-      cli::cli_inform(
-        "  N active pars = {sum(!is.na(parstemp[['Active_Cnt']]))}"
+      cli::cli_alert_info(
+        "N active pars = {sum(!is.na(parstemp[['Active_Cnt']]))}"
       )
     }
 
@@ -357,7 +357,7 @@ SSsummarize <- function(
     indextemp <- stats[["cpue"]]
     if (is.null(indextemp) || is.na(indextemp[[1]][1])) {
       if (verbose) {
-        cli::cli_inform("  no index data")
+        cli::cli_alert_warning("no index data")
       }
     } else {
       # temporarily remove columns added in SS version 3.30.13 (March 2019)
@@ -806,7 +806,7 @@ SSsummarize <- function(
       get("verbose", envir = parent.frame()) &
         deparse(substitute(data)) == "pars"
     ) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "For model(s) {paste(fix, collapse = ', ')}, values in 'pars', 'parsSD', 'parphases', and 'par_prior_likes' for {paste(
           data[oldrows, \"Label\"],
           data[newrows, \"Label\"],
@@ -896,7 +896,7 @@ SSsummarize <- function(
   # mylist[["lbinspop"]]   <- as.numeric(names(stats[["sizeselex"]])[-(1:5)])
 
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_success(
       "Summary finished. To avoid printing details above, use 'verbose = FALSE'."
     )
   }

--- a/R/SStableComparisons.R
+++ b/R/SStableComparisons.R
@@ -57,7 +57,7 @@ SStableComparisons <- function(
   mcmc = FALSE
 ) {
   if (verbose) {
-    cli::cli_inform("running SStableComparisons")
+    cli::cli_alert_info("running SStableComparisons")
   }
 
   # get stuff from summary output
@@ -98,11 +98,11 @@ SStableComparisons <- function(
         digit <- digits[iname]
       }
       if (verbose) {
-        cli::cli_inform("name={name};")
+        cli::cli_alert_info("name={name};")
       }
       if (name == "BLANK") {
         if (verbose) {
-          cli::cli_inform("added a blank row to the table")
+          cli::cli_alert_info("added a blank row to the table")
         }
         # add to table
         tab <- rbind(tab, " ")
@@ -152,13 +152,13 @@ SStableComparisons <- function(
           }
         }
         if (verbose) {
-          cli::cli_inform(
+          cli::cli_alert_info(
             "added {nrow(vals)} row{ifelse(nrow(vals) != 1, 's', '')}"
           )
         }
         if (!is.null(digits)) {
           if (verbose) {
-            cli::cli_inform("rounded to {digit} digits")
+            cli::cli_alert_info("rounded to {digit} digits")
           }
           vals[, -1] <- round(vals[, -1], digit)
         }
@@ -177,11 +177,11 @@ SStableComparisons <- function(
         digit <- digits[iname]
       }
       if (verbose) {
-        cli::cli_inform("name={name}; ")
+        cli::cli_alert_info("name={name}; ")
       }
       if (name == "BLANK") {
         if (verbose) {
-          cli::cli_inform("added a blank row to the table")
+          cli::cli_alert_info("added a blank row to the table")
         }
         # add to table
         tab <- rbind(tab, " ")
@@ -235,13 +235,13 @@ SStableComparisons <- function(
         }
         if (!is.null(digits)) {
           if (verbose) {
-            cli::cli_inform("rounded to {digit} digits")
+            cli::cli_alert_info("rounded to {digit} digits")
           }
           vals[, -1] <- round(vals[, -1], digit)
         }
 
         if (verbose) {
-          cli::cli_inform("added an mcmc row")
+          cli::cli_alert_info("added an mcmc row")
         }
         # add to table
         tab <- rbind(tab, vals)
@@ -265,7 +265,7 @@ SStableComparisons <- function(
       csvdir <- getwd()
     }
     fullpath <- paste(csvdir, csvfile, sep = "/")
-    cli::cli_inform("writing table to: {fullpath}")
+    cli::cli_alert_info("writing table to: {fullpath}")
     write.csv(tab, fullpath, row.names = FALSE)
   }
   # return table

--- a/R/TSCplot.R
+++ b/R/TSCplot.R
@@ -218,11 +218,11 @@ TSCplot <- function(
 
   if (!is.null(makePDF)) {
     dev.off()
-    cli::cli_inform("The plot is in pdf file {makePDF}")
+    cli::cli_alert_info("The plot is in pdf file {makePDF}")
   }
   if (!is.null(makePNG)) {
     dev.off()
-    cli::cli_inform("The plot is in png file {makePNG}")
+    cli::cli_alert_info("The plot is in png file {makePNG}")
   }
 
   invisible(SP)

--- a/R/check_exe.R
+++ b/R/check_exe.R
@@ -80,7 +80,7 @@ check_exe <- function(exe = "ss3", dir = getwd(), verbose = FALSE) {
   if (file.exists(file.path(dir, exename))) {
     path_to_exe <- path.expand(dir)
     if (verbose) {
-      cli::cli_inform("Executable found in directory {path_to_exe}")
+      cli::cli_alert_success("Executable found in directory {path_to_exe}")
     }
     # add ./ to exename so it knows to run in the current directory
     # but only if the exename doesn't include additional directory
@@ -106,14 +106,14 @@ check_exe <- function(exe = "ss3", dir = getwd(), verbose = FALSE) {
       if (file.info(normalizePath(path_to_exe))[["size"]] < 1e6) {
         if (verbose) {
           exe_size <- file.info(normalizePath(path_to_exe))[["size"]]
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "Executable found that isn't Stock Synthesis: {path_to_exe}; File size is too small: {exe_size}"
           )
         }
         path_to_exe <- ""
       } else {
         if (verbose) {
-          cli::cli_inform("Executable found at {path_to_exe}")
+          cli::cli_alert_success("Executable found at {path_to_exe}")
         }
         # remove filename to just get path
         path_to_exe <- dirname(path_to_exe)

--- a/R/copy_SS_inputs.R
+++ b/R/copy_SS_inputs.R
@@ -90,7 +90,7 @@ copy_SS_inputs <- function(
   }
 
   if (verbose) {
-    cli::cli_inform("copying files from {dir.old} to {dir.new}")
+    cli::cli_alert_info("copying files from {dir.old} to {dir.new}")
   }
 
   results <- rep(NA, 6)
@@ -177,7 +177,7 @@ copy_SS_inputs <- function(
       ]
       exefiles <- grep(pattern = "^[^.]+$", x = exefiles, value = TRUE)
       if (verbose) {
-        cli::cli_inform("Unix binaries are: {paste(exefiles, collapse = ', ')}")
+        cli::cli_alert_info("Unix binaries are: {paste(exefiles, collapse = ', ')}")
       }
     }
     if (length(exefiles) == 0) {
@@ -212,7 +212,7 @@ copy_SS_inputs <- function(
   # check for successful copying
   if (all(results, na.rm = TRUE)) {
     if (verbose) {
-      cli::cli_inform("copying complete")
+      cli::cli_alert_success("copying complete")
     }
     return(invisible(TRUE))
   } else {

--- a/R/copy_SS_inputs.R
+++ b/R/copy_SS_inputs.R
@@ -177,7 +177,9 @@ copy_SS_inputs <- function(
       ]
       exefiles <- grep(pattern = "^[^.]+$", x = exefiles, value = TRUE)
       if (verbose) {
-        cli::cli_alert_info("Unix binaries are: {paste(exefiles, collapse = ', ')}")
+        cli::cli_alert_info(
+          "Unix binaries are: {paste(exefiles, collapse = ', ')}"
+        )
       }
     }
     if (length(exefiles) == 0) {

--- a/R/file_increment.R
+++ b/R/file_increment.R
@@ -24,7 +24,9 @@ file_increment <- function(
   pattern = "^[CcPRw][a-zA-Z]+\\.sso|summary\\.sso|\\.par$"
 ) {
   if (verbose) {
-    cli::cli_alert_info("Renaming output files to have names like Report{i}.sso")
+    cli::cli_alert_info(
+      "Renaming output files to have names like Report{i}.sso"
+    )
   }
 
   ignore <- file.copy(

--- a/R/file_increment.R
+++ b/R/file_increment.R
@@ -24,7 +24,7 @@ file_increment <- function(
   pattern = "^[CcPRw][a-zA-Z]+\\.sso|summary\\.sso|\\.par$"
 ) {
   if (verbose) {
-    cli::cli_inform("Renaming output files to have names like Report{i}.sso")
+    cli::cli_alert_info("Renaming output files to have names like Report{i}.sso")
   }
 
   ignore <- file.copy(

--- a/R/get_SIS_info.R
+++ b/R/get_SIS_info.R
@@ -85,7 +85,7 @@ get_SIS_info <- function(
     sep = "_"
   )
 
-  cli::cli_inform(
+  cli::cli_alert_info(
     "writing SIS info to CSV files: {file.path(dir, filename_values)} and {file.path(dir, filename_timeseries)}"
   )
 
@@ -322,7 +322,7 @@ get_SIS_info <- function(
 
   # check for redundancy between F_values and Tot_Exploit columns
   if (model[["F_std_basis"]] == "_abs_F;_with_F=Exploit(bio)") {
-    cli::cli_inform(
+    cli::cli_alert_warning(
       "F_YYYY values are redundant with Tot_Exploit column in SPR series, excluding from output for SIS."
     )
     # remove redundant F_values column

--- a/R/helper_fxns.R
+++ b/R/helper_fxns.R
@@ -63,7 +63,7 @@ get_par_name <- function(dir, verbose = TRUE) {
     )
 
     if (verbose) {
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "Multiple files in directory match pattern *.par, choosing based on the preferences described in the help for get_par_name(): {parfile}"
       )
     }

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -232,7 +232,9 @@ jitter <- function(
     }
   )
   if (verbose) {
-    cli::cli_alert_success("Finished running jitters, running last few clean-up steps")
+    cli::cli_alert_success(
+      "Finished running jitters, running last few clean-up steps"
+    )
   }
 
   # delete jitter model directory

--- a/R/jitter.R
+++ b/R/jitter.R
@@ -147,13 +147,13 @@ jitter <- function(
   # setwd(dir)
 
   if (verbose) {
-    cli::cli_inform("Temporarily changing working directory to: {dir}")
+    cli::cli_alert_info("Temporarily changing working directory to: {dir}")
     if (!file.exists("Report.sso")) {
-      cli::cli_inform(
+      cli::cli_alert_info(
         "Copy output files from a converged run into {dir} prior to running jitter to enable easier comparisons."
       )
     }
-    cli::cli_inform("Checking starter file")
+    cli::cli_alert_info("Checking starter file")
   }
   # read starter file to test for non-zero jitter value
   starter <- SS_readstarter(
@@ -232,7 +232,7 @@ jitter <- function(
     }
   )
   if (verbose) {
-    cli::cli_inform("Finished running jitters, running last few clean-up steps")
+    cli::cli_alert_success("Finished running jitters, running last few clean-up steps")
   }
 
   # delete jitter model directory
@@ -250,7 +250,7 @@ jitter <- function(
   )
 
   if (printlikes) {
-    cli::cli_inform("Table of likelihood values:")
+    cli::cli_alert_info("Table of likelihood values:")
     print(table(likesaved))
   }
   return(invisible(likesaved))
@@ -293,7 +293,7 @@ iterate_jitter <- function(
   )
 
   if (verbose) {
-    cli::cli_inform("Starting run of jitter{i}")
+    cli::cli_alert_info("Starting run of jitter{i}")
   }
 
   # pause briefly when running in parallel to ensure seeds differ
@@ -334,7 +334,7 @@ iterate_jitter <- function(
       ]
     }
     if (printlikes) {
-      cli::cli_inform("Likelihood for jitter {i} = {like}")
+      cli::cli_alert_info("Likelihood for jitter {i} = {like}")
     }
     return(like)
   } else {

--- a/R/make_multifig.R
+++ b/R/make_multifig.R
@@ -866,7 +866,9 @@ make_multifig <-
     # par(mfcol=c(rows,cols), mar=c(5,4,4,2)+.1, oma=rep(0,4))
 
     if (anyscaled) {
-      cli::cli_alert_info("Compositions have been rescaled by dividing by binwidth")
+      cli::cli_alert_info(
+        "Compositions have been rescaled by dividing by binwidth"
+      )
     }
     # return information on what was plotted
     return(list(npages = npages, npanels = npanels, ipage = ipage))

--- a/R/make_multifig.R
+++ b/R/make_multifig.R
@@ -866,7 +866,7 @@ make_multifig <-
     # par(mfcol=c(rows,cols), mar=c(5,4,4,2)+.1, oma=rep(0,4))
 
     if (anyscaled) {
-      cli::cli_inform("Compositions have been rescaled by dividing by binwidth")
+      cli::cli_alert_info("Compositions have been rescaled by dividing by binwidth")
     }
     # return information on what was plotted
     return(list(npages = npages, npanels = npanels, ipage = ipage))

--- a/R/mcmc.nuisance.R
+++ b/R/mcmc.nuisance.R
@@ -90,7 +90,7 @@ mcmc.nuisance <- function(
         names(mcmcdata)[grep(labelstrings[istring], names(mcmcdata))]
       )
     }
-    cli::cli_inform(
+    cli::cli_alert_info(
       "All labels matching the input 'labelstrings': {paste(labels, collapse = ', ')}"
     )
     mcmcdata <- mcmcdata[, names(mcmcdata) %in% labels]

--- a/R/populate_multiple_folders.R
+++ b/R/populate_multiple_folders.R
@@ -67,7 +67,7 @@ populate_multiple_folders <- function(
 
   # note source and destination directories
   if (verbose) {
-    cli::cli_inform("copying files from {outerdir.old} to {outerdir.new}")
+    cli::cli_alert_info("copying files from {outerdir.old} to {outerdir.new}")
   }
 
   # empty data frame to attach things to
@@ -82,13 +82,13 @@ populate_multiple_folders <- function(
     # check to make sure it's a directory
     if (dir.exists(file.path(outerdir.old, dir))) {
       if (verbose) {
-        cli::cli_inform("copying {dir}")
+        cli::cli_alert_info("copying {dir}")
       }
       # check for presence of starter file
       if (!"starter.ss" %in% tolower(dir(file.path(outerdir.old, dir)))) {
         if (verbose) {
           # note that starter file is missing in a subfolder
-          cli::cli_inform(
+          cli::cli_alert_warning(
             "skipping {dir} which doesn't contain a starter.ss file"
           )
         }

--- a/R/profile.R
+++ b/R/profile.R
@@ -354,7 +354,7 @@ profile <- function(
       if (!is.null(string)) {
         profilevec_df <- data.frame(profilevec)
         names(profilevec_df) <- string
-        cli::cli_inform(
+        cli::cli_alert_info(
           "Profiling over {npars} parameters:\n{paste(profilevec_df, collapse = '\n')}"
         )
       }
@@ -370,7 +370,7 @@ profile <- function(
     }
   }
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Doing runs: {paste(whichruns, collapse = ', ')}, out of n = {n}"
     )
   }
@@ -412,7 +412,7 @@ profile <- function(
   }
   # check for consistency of par settings and future settings
   if (usepar & !globalpar & !is(future::plan(), "sequential")) {
-    cli::cli_inform(
+    cli::cli_warn(
       "usepar = TRUE and globalpar = FALSE, but you are attempting to run the profile in parallel. Changing future strategy to sequential. It will return to your original strategy upon exit."
     )
     # save current strategy as oplan, and change it to sequential, all in one step!
@@ -446,11 +446,11 @@ profile <- function(
     if (!overwrite & any(file.exists(newrepfiles))) {
       # Cannot think of scenario where both temp directory and ReportN.sso exist
       # Even if they do, this still works, it just prints out a little weird.
-      cli::cli_inform(
+      cli::cli_alert_warning(
         "skipping profile i={i}/{n} because overwrite=FALSE and file exists: {newrepfiles[file.exists(newrepfiles)]}"
       )
     } else {
-      cli::cli_inform("running profile i={i}/{n}")
+      cli::cli_alert_info("running profile i={i}/{n}")
 
       # change initial values in the control file
       # this also sets phase negative which is needed even when par file is used
@@ -489,7 +489,7 @@ profile <- function(
       if (!any(ctltable_new[["PHASE"]] == 1)) {
         phase2pars <- ctltable_new[which(ctltable_new[["PHASE"]] == 2), "Label"]
         par_to_change <- sort(phase2pars)[1]
-        cli::cli_inform(
+        cli::cli_alert_warning(
           "No estimated parameter in phase 1. Switching {par_to_change} from phase 2 to phase 1."
         )
         SS_changepars(
@@ -542,7 +542,7 @@ profile <- function(
           paste("# changed from", parval, "to", profilevec[i])
         )
         par <- c(par, "#", note)
-        cli::cli_inform("{paste(note, collapse = '\n')}")
+        cli::cli_alert_info("{paste(note, collapse = '\n')}")
         # write new par file
         writeLines(par, file.path(dir, paste0("ss_input_par", i, ".ss")))
         writeLines(par, file.path(profile_dir, parfile))

--- a/R/retro.R
+++ b/R/retro.R
@@ -133,7 +133,7 @@ retro <- function(
   furrr::future_walk(seq_along(years), function(iyr) {
     newdir_iyr <- file.path(newdir, subdirnames[iyr])
     if (verbose) {
-      cli::cli_inform("Running retrospective in {newdir_iyr}")
+      cli::cli_alert_info("Running retrospective in {newdir_iyr}")
     }
 
     # copy original input files to retro folder

--- a/R/run.R
+++ b/R/run.R
@@ -85,7 +85,7 @@ run <- function(
 
   # Skip directory that have report results files (if enabled), and then exit function
   if (file.exists(file.path(dir, "Report.sso")) && skipfinished) {
-    cli::cli_inform(
+    cli::cli_alert_warning(
       "Skipping {dir} because it contains a Report.sso file and skipfinished = TRUE"
     )
     results <- "contained Report.sso"
@@ -97,12 +97,12 @@ run <- function(
   setwd(dir) # change working directory
   # provide some messages
   if (verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Changing working directory to {dir} and running model using the command: {command} {extras}"
     )
   }
   if (!show_in_console && verbose) {
-    cli::cli_inform(
+    cli::cli_alert_info(
       "Input 'show_in_console' = FALSE, so writing console output to {console_output_file}"
     )
   }
@@ -140,7 +140,7 @@ run <- function(
       con = console_output_file
     )
     if (verbose) {
-      cli::cli_inform("console output written to {console_output_file}")
+      cli::cli_alert_info("console output written to {console_output_file}")
     }
   }
   # determine if run finished

--- a/R/table_exec_summary.R
+++ b/R/table_exec_summary.R
@@ -789,7 +789,7 @@ table_exec_summary <- function(
   # ES Table g  Predicted forecast values
   # ======================================================================
   if (verbose & is.null(fore)) {
-    cli::cli_alert_info(
+    cli::cli_alert_warning(
       "Skipping table of forecast values: no forecast available."
     )
   } else {

--- a/R/tune_comps.R
+++ b/R/tune_comps.R
@@ -510,7 +510,9 @@ tune_comps <- function(
 
     # remove weights specified through variance adjustment for comps, if any
     if (!is.null(ctl[["Variance_adjustment_list"]])) {
-      cli::cli_alert_info("removing composition variance adjustments from model")
+      cli::cli_alert_info(
+        "removing composition variance adjustments from model"
+      )
       # filter out just data types 4, 5, and 7 for length, age, and size comps
       if (nrow(ctl[["Variance_adjustment_list"]] > 0)) {
         ctl[["Variance_adjustment_list"]] <-

--- a/R/tune_comps.R
+++ b/R/tune_comps.R
@@ -514,7 +514,7 @@ tune_comps <- function(
         "removing composition variance adjustments from model"
       )
       # filter out just data types 4, 5, and 7 for length, age, and size comps
-      if (nrow(ctl[["Variance_adjustment_list"]] > 0)) {
+      if (nrow(ctl[["Variance_adjustment_list"]]) > 0) {
         ctl[["Variance_adjustment_list"]] <-
           ctl[["Variance_adjustment_list"]][
             !ctl[["Variance_adjustment_list"]][["factor"]] %in%

--- a/R/tune_comps.R
+++ b/R/tune_comps.R
@@ -299,7 +299,7 @@ tune_comps <- function(
   if (option %in% c("none", "Francis", "MI")) {
     if (!is.null(ctl[["dirichlet_parms"]])) {
       if (verbose) {
-        cli::cli_inform("Removing DM parameters from model")
+        cli::cli_alert_info("Removing DM parameters from model")
       }
       # take DM specifications out of data file
       if (!is.null(dat[["len_info"]])) {
@@ -510,7 +510,7 @@ tune_comps <- function(
 
     # remove weights specified through variance adjustment for comps, if any
     if (!is.null(ctl[["Variance_adjustment_list"]])) {
-      cli::cli_inform("removing composition variance adjustments from model")
+      cli::cli_alert_info("removing composition variance adjustments from model")
       # filter out just data types 4, 5, and 7 for length, age, and size comps
       if (nrow(ctl[["Variance_adjustment_list"]] > 0)) {
         ctl[["Variance_adjustment_list"]] <-
@@ -610,7 +610,7 @@ get_tuning_table <- function(
   for (type in c("len", "age", "size")) {
     for (fleet in fleets) {
       if (verbose) {
-        cli::cli_inform("calculating {type} tunings for fleet {fleet}")
+        cli::cli_alert_info("calculating {type} tunings for fleet {fleet}")
       }
       if (type == "len") {
         # table of info from SS3
@@ -776,7 +776,7 @@ get_tuning_table <- function(
   if (write) {
     file <- file.path(replist[["inputs"]][["dir"]], "suggested_tuning.ss")
     if (verbose) {
-      cli::cli_inform("writing to file {file}")
+      cli::cli_alert_info("writing to file {file}")
     }
     write.table(tuning_table, file = file, quote = FALSE, row.names = FALSE)
   }


### PR DESCRIPTION
I had incorrectly concluding that `cli::cli_inform()` was preferred (perhaps based on issues like https://github.com/r-lib/cli/issues/715), but I like the different symbols associated with `cli::cli_alert_info()`, `cli::cli_alert_success()` and `cli::cli_alert_warning()` so have changed everything over in this PR. The choice of what is a warning vs info vs success is subjective, so please suggest changes if anything looks wrong to you.