### PR TITLE
small improvements to FIMS converter

### DIFF
--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -126,7 +126,7 @@ SS_read <- function(
       )
       if (is.null(wtatage)) {
         cli::cli_alert_warning(
-          "Model does not require weight-at-age file and no wtatage.ss_new file found."
+          "Model does not require weight-at-age file and wtatage.ss_new is missing or empty. Skipping reading weight-at-age file."
         )
       }
       return_list[["wtatage"]] <- wtatage

--- a/R/SS_read.R
+++ b/R/SS_read.R
@@ -114,7 +114,23 @@ SS_read <- function(
     )
     return_list[["wtatage"]] <- wtatage
   } else if (read_wtatage) {
-    if (!file.exists(file.path(dir, "wtatage.ss_new"))) {
+    # request read of weight-at-age file even if not required by the model
+    # but need to check if the file exists first
+    # which is different for URL vs local file path
+    is_url <- grepl("^https?://", dir)
+    if (is_url) {
+      # read the URL, which will be NULL if not found
+      wtatage <- r4ss::SS_readwtatage(
+        file = file.path(dir, "wtatage.ss_new"),
+        verbose = verbose
+      )
+      if (is.null(wtatage)) {
+        cli::cli_alert_warning(
+          "Model does not require weight-at-age file and no wtatage.ss_new file found."
+        )
+      }
+      return_list[["wtatage"]] <- wtatage
+    } else if (!file.exists(file.path(dir, "wtatage.ss_new"))) {
       cli::cli_alert_warning(
         "Model does not require weight-at-age file and no wtatage.ss_new file found. Skipping reading weight-at-age file."
       )

--- a/R/ss3_data_to_fims.R
+++ b/R/ss3_data_to_fims.R
@@ -554,7 +554,7 @@ ss3_data_to_fims <- function(
     )
     print(res_filtered_out |> dplyr::count(type))
     res <- res |>
-      dplyr::filter(timing >= 0)
+      dplyr::filter(is.na(timing) | timing >= 0)
   }
 
   if (nrow(res) > 0) {

--- a/R/ss3_data_to_fims.R
+++ b/R/ss3_data_to_fims.R
@@ -67,7 +67,7 @@ ss3_data_to_fims <- function(
   }
   if (!"wtatage" %in% names(ss3_inputs)) {
     cli::cli_abort(
-      "'ss3_inputs' is missing element 'wtatage'. You may have to add it by running 'r4ss::SS_readwtatage()'. If the wtatage.ss_new file is empty, change the starter file setting `inputs$start$detailed_age_structure` to 1."
+      "'ss3_inputs' is missing element 'wtatage'. You may have to add it by running 'r4ss::SS_readwtatage()'. If the wtatage.ss_new file is empty, change the starter file setting `inputs[['start']][['detailed_age_structure']]` to 1."
     )
   }
   if (any(ss3_inputs[["wtatage"]][["year"]] < 0)) {
@@ -546,17 +546,21 @@ ss3_data_to_fims <- function(
     dplyr::filter_out(type != "weight_at_age" & timing > dat[["endyr"]])
 
   # remove negative year values
-  if (any(res$timing < 0, na.rm = TRUE)) {
+  if (any(res[["timing"]] < 0, na.rm = TRUE)) {
     res_filtered_out <- res |>
       dplyr::filter(timing < 0)
-    cli::cli_alert_warning("Negative year values found and removed (count by type):")
+    cli::cli_alert_warning(
+      "Negative year values found and removed (count by type):"
+    )
     print(res_filtered_out |> dplyr::count(type))
     res <- res |>
       dplyr::filter(timing >= 0)
   }
 
   if (nrow(res) > 0) {
-    cli::cli_alert_success("Data processing completed successfully. N rows by type (count by type):")
+    cli::cli_alert_success(
+      "Data processing completed successfully. N rows by type (count by type):"
+    )
     print(res |> dplyr::count(type))
   } else {
     cli::cli_alert_warning("No data rows found after processing.")

--- a/R/ss3_data_to_fims.R
+++ b/R/ss3_data_to_fims.R
@@ -67,7 +67,7 @@ ss3_data_to_fims <- function(
   }
   if (!"wtatage" %in% names(ss3_inputs)) {
     cli::cli_abort(
-      "'ss3_inputs' is missing element 'wtatage'. You may have to add it by running 'r4ss::SS_readwtatage()'"
+      "'ss3_inputs' is missing element 'wtatage'. You may have to add it by running 'r4ss::SS_readwtatage()'. If the wtatage.ss_new file is empty, change the starter file setting `inputs$start$detailed_age_structure` to 1."
     )
   }
   if (any(ss3_inputs[["wtatage"]][["year"]] < 0)) {
@@ -545,5 +545,22 @@ ss3_data_to_fims <- function(
     dplyr::filter_out(type == "weight_at_age" & timing > dat[["endyr"]] + 1) |>
     dplyr::filter_out(type != "weight_at_age" & timing > dat[["endyr"]])
 
-  return(res)
+  # remove negative year values
+  if (any(res$timing < 0, na.rm = TRUE)) {
+    res_filtered_out <- res |>
+      dplyr::filter(timing < 0)
+    cli::cli_alert_warning("Negative year values found and removed (count by type):")
+    print(res_filtered_out |> dplyr::count(type))
+    res <- res |>
+      dplyr::filter(timing >= 0)
+  }
+
+  if (nrow(res) > 0) {
+    cli::cli_alert_success("Data processing completed successfully. N rows by type (count by type):")
+    print(res |> dplyr::count(type))
+  } else {
+    cli::cli_alert_warning("No data rows found after processing.")
+  }
+
+  return(tibble::as_tibble(res))
 }

--- a/R/ss3_data_to_fims.R
+++ b/R/ss3_data_to_fims.R
@@ -65,7 +65,7 @@ ss3_data_to_fims <- function(
       "`ss3_inputs` should be a list containing both 'dat' and 'wtatage'"
     )
   }
-  if (!"wtatage" %in% names(ss3_inputs)) {
+  if (is.null(ss3_inputs[["wtatage"]]) || !"wtatage" %in% names(ss3_inputs)) {
     cli::cli_abort(
       "'ss3_inputs' is missing element 'wtatage'. You may have to add it by running 'r4ss::SS_readwtatage()'. If the wtatage.ss_new file is empty, change the starter file setting `inputs[['start']][['detailed_age_structure']]` to 1."
     )


### PR DESCRIPTION
Inspired by conversation with @JoelRice-NOAA and @kellijohnson-NOAA. Feedback is welcome from anyone.

- allow `SS_read()` to work better with files on github (check for missing wtatage file is different for URLs)
- more informative warning if wtatage doesn't get read
- filter negative year values with message
- summarize results in table printed to console
- return results as a tibble

If the wtatage file doesn't get read, you now get a message like
```
Error in `ss3_data_to_fims()`:
! 'ss3_inputs' is missing element 'wtatage'. You may have to add it by running 'r4ss::SS_readwtatage()'. If the wtatage.ss_new file
  is empty, change the starter file setting `inputs$start$detailed_age_structure` to 1.
```

Here's the full set of messages for a model which includes some 2 negative years in the index data:

```
ss3_data_to_fims("inst/extdata/simple_small_test")
i Reading in data from `inst/extdata/simple_small_test` using `r4ss::SS_read()`
i Reading in output from `inst/extdata/simple_small_test` using `r4ss::SS_output()`
i Using age bins: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
i Using length bins: 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 68, 72, 76, 80, 90
i Adding columns for missing age bins: a0
! Age-to-length conversion matrix from SS3 is based on population length
bins which have different minimum bin widths than the data length bins. 
The function will not aggregate all the proportions, and the results may not 
make sense. Consider modifying the SS3 model to have matching population 
and data bins.
i Aggregating low and high length bins in the `age_to_length_conversion` to match first and last data bins
! Negative year values found and removed (count by type):
   type n
1 index 2
v Data processing completed successfully. N rows by type (count by type):
           type   n
1      age_comp 256
2         catch  12
3         index  14
4   length_comp 400
5 weight_at_age 208
```