### PR TITLE
add option to exclude unconverged models from profile plots

### DIFF
--- a/R/PinerPlot.R
+++ b/R/PinerPlot.R
@@ -11,8 +11,10 @@
 #' @param component Which likelihood component to plot. Default is "Length_like".
 #' @param main Title for plot. Should match component.
 #' @param models Optional subset of the models described in
-#' `summaryoutput`.  Either "all" or a vector of numbers indicating
-#' columns in summary tables.
+#' `summaryoutput`. Can be "all", "converged", or a vector of numbers indicating
+#' columns in summary tables. The default "all" will include all models.
+#' The "converged" option will include only models with a maximum gradient less
+#' than or equal to the specified convergence criterion `conv_criteria`.
 #' @param profile.string Character string used to find parameter over which the
 #' profile was conducted. If `exact=FALSE`, this can be a substring of
 #' one of the SS parameter labels found in the Report.sso file.
@@ -158,7 +160,12 @@ PinerPlot <-
       models <- 1:n
     } else if (models[1] == "converged") {
       # relatively weak threshold for convergence based on max gradient
-      models <- which(summaryoutput[["maxgrad"]] < conv_criteria)
+      models <- which(summaryoutput[["maxgrad"]] <= conv_criteria)
+      if (length(models) == 0) {
+        cli::cli_abort(
+          "No models met the convergence criterion conv_criteria={conv_criteria}."
+        )
+      }
     } else {
       if (!all(models %in% 1:n)) {
         cli::cli_abort(

--- a/R/PinerPlot.R
+++ b/R/PinerPlot.R
@@ -56,6 +56,8 @@
 #' @param minfraction Minimum change in likelihood (over range considered) as a
 #' fraction of change in total likelihood for a component to be included in the
 #' figure.
+#' @param conv_criteria Maximum gradient for a model to be considered converged,
+#' used when `models = "converged"`.
 #' @references Kevin Piner says that he's not the originator of this idea so
 #' Athol Whitten is going to add a reference here.
 #' @author Ian G. Taylor, Kevin R. Piner, James T. Thorson
@@ -103,7 +105,8 @@ PinerPlot <-
     verbose = TRUE,
     fleetgroups = NULL,
     likelihood_type = "raw_times_lambda",
-    minfraction = 0.01
+    minfraction = 0.01,
+    conv_criteria = 0.01
   ) {
     # this function is very similar to SSplotProfile, but shows fleet-specific likelihoods
     # for a single components rather than multiple components aggregated across fleets
@@ -147,8 +150,15 @@ PinerPlot <-
     }
 
     # check number of models to be plotted
-    if (models[1] == "all") {
+    if (length(models) == 0) {
+      cli::cli_abort(
+        "Input 'models' should not be empty."
+      )
+    } else if (models[1] == "all") {
       models <- 1:n
+    } else if (models[1] == "converged") {
+      # relatively weak threshold for convergence based on max gradient
+      models <- which(summaryoutput[["maxgrad"]] < conv_criteria)
     } else {
       if (!all(models %in% 1:n)) {
         cli::cli_abort(

--- a/R/SS_output.R
+++ b/R/SS_output.R
@@ -4491,27 +4491,33 @@ consider increasing 'aalmaxbinrange' to designate some of these data as conditio
         ends <- grep("mean", rawALK[, 1]) - 1
         N_ALKs <- length(starts)
         # 3rd dimension should be either nmorphs or nmorphs*(number of Sub_Seas)
-        ALK <- array(NA, c(nlbinspop, accuage + 1, N_ALKs))
-        dimnames(ALK) <- list(
-          Length = rev(lbinspop),
-          TrueAge = 0:accuage,
-          Matrix = 1:N_ALKs
-        )
+        if (!is.null(nlbinspop) & length(nlbinspop) > 0) {
+          # if no comp data and model is purely age-based then nlbinspop is missing,
+          # but also probably not interested in constructing the ALK array anyway
+          ALK <- array(NA, c(nlbinspop, accuage + 1, N_ALKs))
+          dimnames(ALK) <- list(
+            Length = rev(lbinspop),
+            TrueAge = 0:accuage,
+            Matrix = 1:N_ALKs
+          )
 
-        # loop over subsections within age-length matrix
-        for (i in 1:N_ALKs) {
-          # get matrix of values
-          ALKtemp <- rawALK[starts[i]:ends[i], 2 + 0:accuage]
-          # loop over ages to convert values to numeric
-          ALKtemp <- type.convert(ALKtemp, as.is = TRUE)
-          # fill in appropriate slice of array
-          ALK[,, i] <- as.matrix(ALKtemp)
-          # get info on each matrix (such as "Seas: 1 Sub_Seas: 1 Morph: 1")
-          Matrix.Info <- rawALK[starts[i] - 2, ]
-          # filter out empty elements
-          Matrix.Info <- Matrix.Info[Matrix.Info != ""]
-          # combine elements to form a label in the dimnames
-          dimnames(ALK)[["Matrix"]][i] <- paste(Matrix.Info, collapse = " ")
+          # loop over subsections within age-length matrix
+          for (i in 1:N_ALKs) {
+            # get matrix of values
+            ALKtemp <- rawALK[starts[i]:ends[i], 2 + 0:accuage]
+            # loop over ages to convert values to numeric
+            ALKtemp <- type.convert(ALKtemp, as.is = TRUE)
+            # fill in appropriate slice of array
+            ALK[,, i] <- as.matrix(ALKtemp)
+            # get info on each matrix (such as "Seas: 1 Sub_Seas: 1 Morph: 1")
+            Matrix.Info <- rawALK[starts[i] - 2, ]
+            # filter out empty elements
+            Matrix.Info <- Matrix.Info[Matrix.Info != ""]
+            # combine elements to form a label in the dimnames
+            dimnames(ALK)[["Matrix"]][i] <- paste(Matrix.Info, collapse = " ")
+          }
+        } else {
+          ALK <- NULL
         }
         returndat[["ALK"]] <- ALK
       } # end check for keyword present

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -22,9 +22,9 @@
 #' filenaming convention based on iteration and date stamp.
 #' @inheritParams SS_output
 #' @inheritParams SStableComparisons
-#' @param modelnames Optional vector of model names which will can be passed to 
-#' downstream functions like `SSsummarize()`, `SSplotComparisons()` (where it is used 
-#' in the default legend), and `SStableComparisons()` (where it is used in the 
+#' @param modelnames Optional vector of model names which will can be passed to
+#' downstream functions like `SSsummarize()`, `SSplotComparisons()` (where it is used
+#' in the default legend), and `SStableComparisons()` (where it is used in the
 #' default column names).
 #' @author Ian Taylor
 #' @export

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -22,7 +22,7 @@
 #' filenaming convention based on iteration and date stamp.
 #' @inheritParams SS_output
 #' @inheritParams SStableComparisons
-#' @param modelnames Optional vector of model names which will can be passed to
+#' @param modelnames Optional vector of model names that can be passed to
 #' downstream functions like `SSsummarize()`, `SSplotComparisons()` (where it is used
 #' in the default legend), and `SStableComparisons()` (where it is used in the
 #' default column names).

--- a/R/SSgetoutput.R
+++ b/R/SSgetoutput.R
@@ -22,6 +22,10 @@
 #' filenaming convention based on iteration and date stamp.
 #' @inheritParams SS_output
 #' @inheritParams SStableComparisons
+#' @param modelnames Optional vector of model names which will can be passed to 
+#' downstream functions like `SSsummarize()`, `SSplotComparisons()` (where it is used 
+#' in the default legend), and `SStableComparisons()` (where it is used in the 
+#' default column names).
 #' @author Ian Taylor
 #' @export
 #' @seealso [SS_output()]

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -8,8 +8,11 @@
 #' @param summaryoutput List created by the function [SSsummarize()].
 #' @inheritParams r4ss_params
 #' @param models Optional subset of the models described in
-#' `summaryoutput`. Either "all" or a vector of numbers indicating
-#' columns in summary tables.
+#' `summaryoutput`. Can be "all", "converged", or a vector of numbers indicating
+#' columns in summary tables. The default "all" will include all models.
+#' The "converged" option will include only models that have converged 
+#' a maximum gradient less than the specified convergence criterion 
+#' `conv_criteria`.
 #' @param profile.string Character string used to find parameter over which the
 #' profile was conducted. If `exact=FALSE`, this can be a substring of
 #' one of the SS3 parameter labels found in the Report.sso file.
@@ -35,6 +38,8 @@
 #' @param sort.by.max.change Switch giving option to sort components in legend
 #' in order of maximum amount of change in likelihood (over range considered).
 #' Default=TRUE.
+#' @param conv_criteria Convergence criterion for determining which models are
+#' considered converged when `models="converged"`.
 #' @param col Optional vector of colors for each line.
 #' @param pch Optional vector of plot characters for the points.
 #' @param lty Line type for the likelihood components.
@@ -130,6 +135,7 @@ SSplotProfile <-
     ),
     minfraction = 0.01,
     sort.by.max.change = TRUE,
+    conv_criteria = 0.01,
     col = NULL,
     pch = NULL,
     lty = 1,
@@ -191,8 +197,15 @@ SSplotProfile <-
     par_prior_likes <- summaryoutput[["par_prior_likes"]]
 
     # check number of models to be plotted
-    if (models[1] == "all") {
+    if (length(models) == 0) {
+      cli::cli_abort(
+        "Input 'models' should not be empty."
+      )
+    } else if (models[1] == "all") {
       models <- 1:n
+    } else if (models[1] == "converged") {
+      # relatively weak threshold for convergence based on max gradient
+      models <- which(summaryoutput[["maxgrad"]] < conv_criteria)
     } else {
       if (!all(models %in% 1:n)) {
         cli::cli_abort(

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -10,8 +10,8 @@
 #' @param models Optional subset of the models described in
 #' `summaryoutput`. Can be "all", "converged", or a vector of numbers indicating
 #' columns in summary tables. The default "all" will include all models.
-#' The "converged" option will include only models that have converged 
-#' a maximum gradient less than the specified convergence criterion 
+#' The "converged" option will include only models that have converged
+#' a maximum gradient less than the specified convergence criterion
 #' `conv_criteria`.
 #' @param profile.string Character string used to find parameter over which the
 #' profile was conducted. If `exact=FALSE`, this can be a substring of

--- a/R/SSplotProfile.R
+++ b/R/SSplotProfile.R
@@ -10,9 +10,8 @@
 #' @param models Optional subset of the models described in
 #' `summaryoutput`. Can be "all", "converged", or a vector of numbers indicating
 #' columns in summary tables. The default "all" will include all models.
-#' The "converged" option will include only models that have converged
-#' a maximum gradient less than the specified convergence criterion
-#' `conv_criteria`.
+#' The "converged" option will include only models with a maximum gradient less
+#' than or equal to the specified convergence criterion `conv_criteria`.
 #' @param profile.string Character string used to find parameter over which the
 #' profile was conducted. If `exact=FALSE`, this can be a substring of
 #' one of the SS3 parameter labels found in the Report.sso file.
@@ -205,7 +204,12 @@ SSplotProfile <-
       models <- 1:n
     } else if (models[1] == "converged") {
       # relatively weak threshold for convergence based on max gradient
-      models <- which(summaryoutput[["maxgrad"]] < conv_criteria)
+      models <- which(summaryoutput[["maxgrad"]] <= conv_criteria)
+      if (length(models) == 0) {
+        cli::cli_abort(
+          "No models met the convergence criterion conv_criteria={conv_criteria}."
+        )
+      }
     } else {
       if (!all(models %in% 1:n)) {
         cli::cli_abort(

--- a/man/PinerPlot.Rd
+++ b/man/PinerPlot.Rd
@@ -44,7 +44,8 @@ PinerPlot(
   verbose = TRUE,
   fleetgroups = NULL,
   likelihood_type = "raw_times_lambda",
-  minfraction = 0.01
+  minfraction = 0.01,
+  conv_criteria = 0.01
 )
 }
 \arguments{
@@ -165,6 +166,9 @@ determines whether or not likelihoods plotted are adjusted by lambdas
 \item{minfraction}{Minimum change in likelihood (over range considered) as a
 fraction of change in total likelihood for a component to be included in the
 figure.}
+
+\item{conv_criteria}{Maximum gradient for a model to be considered converged,
+used when \code{models = "converged"}.}
 }
 \description{
 This style of plot was officially named a "Piner Plot" at the

--- a/man/PinerPlot.Rd
+++ b/man/PinerPlot.Rd
@@ -61,8 +61,10 @@ PinerPlot(
 \item{main}{Title for plot. Should match component.}
 
 \item{models}{Optional subset of the models described in
-\code{summaryoutput}.  Either "all" or a vector of numbers indicating
-columns in summary tables.}
+\code{summaryoutput}. Can be "all", "converged", or a vector of numbers indicating
+columns in summary tables. The default "all" will include all models.
+The "converged" option will include only models with a maximum gradient less
+than or equal to the specified convergence criterion \code{conv_criteria}.}
 
 \item{fleets}{Either the string "all", or a vector of numerical values, like
 c(1,3), listing fleets or surveys to be included in the plot.}

--- a/man/SSgetoutput.Rd
+++ b/man/SSgetoutput.Rd
@@ -52,8 +52,10 @@ relationship. This provides an option to provide the units, e.g.
 This needs to be a user input because the units depend on the choice of
 fecundity parameters which are calculated outside of the SS3 model.}
 
-\item{modelnames}{optional vector of labels to use as column names. Default
-is \code{summaryoutput[["modelnames"]]}.}
+\item{modelnames}{Optional vector of model names which will can be passed to
+downstream functions like \code{SSsummarize()}, \code{SSplotComparisons()} (where it is used
+in the default legend), and \code{SStableComparisons()} (where it is used in the
+default column names).}
 }
 \description{
 Apply the function \code{\link[=SS_output]{SS_output()}} multiple times and save output as

--- a/man/SSgetoutput.Rd
+++ b/man/SSgetoutput.Rd
@@ -52,7 +52,7 @@ relationship. This provides an option to provide the units, e.g.
 This needs to be a user input because the units depend on the choice of
 fecundity parameters which are calculated outside of the SS3 model.}
 
-\item{modelnames}{Optional vector of model names which will can be passed to
+\item{modelnames}{Optional vector of model names that can be passed to
 downstream functions like \code{SSsummarize()}, \code{SSplotComparisons()} (where it is used
 in the default legend), and \code{SStableComparisons()} (where it is used in the
 default column names).}

--- a/man/SSplotProfile.Rd
+++ b/man/SSplotProfile.Rd
@@ -65,9 +65,8 @@ SSplotProfile(
 \item{models}{Optional subset of the models described in
 \code{summaryoutput}. Can be "all", "converged", or a vector of numbers indicating
 columns in summary tables. The default "all" will include all models.
-The "converged" option will include only models that have converged
-a maximum gradient less than the specified convergence criterion
-\code{conv_criteria}.}
+The "converged" option will include only models with a maximum gradient less
+than or equal to the specified convergence criterion \code{conv_criteria}.}
 
 \item{profile.string}{Character string used to find parameter over which the
 profile was conducted. If \code{exact=FALSE}, this can be a substring of

--- a/man/SSplotProfile.Rd
+++ b/man/SSplotProfile.Rd
@@ -25,6 +25,7 @@ SSplotProfile(
     "F Ballpark", "Crash penalty"),
   minfraction = 0.01,
   sort.by.max.change = TRUE,
+  conv_criteria = 0.01,
   col = NULL,
   pch = NULL,
   lty = 1,
@@ -62,8 +63,11 @@ SSplotProfile(
 \item{print}{Print to PNG files?}
 
 \item{models}{Optional subset of the models described in
-\code{summaryoutput}. Either "all" or a vector of numbers indicating
-columns in summary tables.}
+\code{summaryoutput}. Can be "all", "converged", or a vector of numbers indicating
+columns in summary tables. The default "all" will include all models.
+The "converged" option will include only models that have converged
+a maximum gradient less than the specified convergence criterion
+\code{conv_criteria}.}
 
 \item{profile.string}{Character string used to find parameter over which the
 profile was conducted. If \code{exact=FALSE}, this can be a substring of
@@ -97,6 +101,9 @@ figure.}
 \item{sort.by.max.change}{Switch giving option to sort components in legend
 in order of maximum amount of change in likelihood (over range considered).
 Default=TRUE.}
+
+\item{conv_criteria}{Convergence criterion for determining which models are
+considered converged when \code{models="converged"}.}
 
 \item{col}{Optional vector of colors for each line.}
 

--- a/tests/testthat/test-basics.R
+++ b/tests/testthat/test-basics.R
@@ -72,8 +72,8 @@ test_that("get_ncol() finds the correct number of columns for SS_output()", {
   # 55 and 56 are values for simple_3.24 and simple_3.30.XX models
   # 62 is the value for simple_small
   expect(
-    all(results %in% c(55, 56, 62)),
-    "Optimum width of Report.sso wasn't 55, 56, or 62"
+    all(results %in% c(55, 56, 62, 100, 109)),
+    "Optimum width of Report.sso wasn't 55, 56, 62, 100, or 109"
   )
 })
 

--- a/tests/testthat/test-test-models.R
+++ b/tests/testthat/test-test-models.R
@@ -33,7 +33,7 @@ for (i in seq_along(mods)) {
         mod_path,
         exe = file.path(dir_exe, "ss3"),
         extras = "-stopph 0 -nohess",
-        skipfinished = TRUE
+        skipfinished = FALSE
       )
 
       if (!"Report.sso" %in% dir(mod_path)) {

--- a/tests/testthat/test-test-models.R
+++ b/tests/testthat/test-test-models.R
@@ -32,7 +32,8 @@ for (i in seq_along(mods)) {
       run(
         mod_path,
         exe = file.path(dir_exe, "ss3"),
-        extras = "-stopph 0 -nohess"
+        extras = "-stopph 0 -nohess",
+        skipfinished = TRUE
       )
 
       if (!"Report.sso" %in% dir(mod_path)) {


### PR DESCRIPTION
The profile plotting options could be improved in a variety of ways, but one easy change that just helped me out was to automatically exclude models with maximum gradients above some threshold as shown in this PR.
